### PR TITLE
fix rare fatal error

### DIFF
--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -123,7 +123,7 @@ class Page extends Object
 
         $resources = $this->get('Resources');
 
-        if ($resources->has('XObject')) {
+        if (method_exists($resources, 'has') && $resources->has('XObject')) {
 
             if ($resources->get('XObject') instanceof Header) {
                 $xobjects = $resources->get('XObject')->getElements();


### PR DESCRIPTION
In one of the PDF I have parsed, the script exited with this message:
Fatal error: Call to undefined method Smalot\PdfParser\Element\ElementMissing::has() in ...
