### PR TITLE
Significant performance and memory improvement in cleanContent

### DIFF
--- a/src/Smalot/PdfParser/Object.php
+++ b/src/Smalot/PdfParser/Object.php
@@ -135,21 +135,19 @@ class Object
         $char    = $char[0];
         $content = str_replace(array('\\\\', '\\)', '\\('), $char . $char, $content);
 
-        // callback function to clean text
-        // callback is memoory efficient, and faster than a foreach loop.
-        $_clean = function($part) use ($char, &$_count) {
+        // this function is more memory efficient, and significantly faster than
+        $_clean = function($part) use($char) {
             return str_replace($part[1],str_repeat($char,strlen($part[1])), $part[0]);
         };
 
         // Remove image bloc with binary content
-        $content = preg_replace_callback('/\((.*?)\)/s', $_clean, $content);
+        $content = preg_replace_callback('/\s(BI\s.*?(\sID\s).*?(\sEI))\s/s',$_clean,$content);
 
         // Clean content in square brackets [.....]
-        $content = preg_replace_callback('/\((.*?)\)/s', $_clean, $content);
+        $content = preg_replace_callback('/\[((\(.*?\)|[0-9\.\-\s]*)*)\]/s',$_clean,$content);
 
         // Clean content in round brackets (.....)
-        $_count2 = 0;
-        $content = preg_replace_callback('/\((.*?)\)/s', $_clean, $content);
+        $content = preg_replace_callback('/\((.*?)\)/s',$_clean,$content);
 
         // Clean structure
         if ($parts = preg_split('/(<|>)/s', $content, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE)) {
@@ -169,11 +167,8 @@ class Object
         }
 
         // Clean BDC and EMC markup
-        $str = '/(\/[A-Za-z0-9\_]*\s*' . preg_quote($char) . '*BDC)/s';
-        $content = preg_replace_callback($str, $_clean, $content);
-
-        // preg_replace_callback('/\s(EMC)\s/s', $_clean, $content);
-        $content = preg_replace_callback('/\s(EMC)\s/s', $_clean, $content);
+        $content = preg_replace_callback('/(\/[A-Za-z0-9\_]*\s*' . preg_quote($char) . '*BDC)/s',$_clean,$content);
+        $content = preg_replace_callback('/\s(EMC)\s/s',$_clean,$content);
 
         return $content;
     }


### PR DESCRIPTION
I encountered a problem with parsing an arcGis generated PDF File that contained one page and numerous images, but no text (per say).  the cleanContent routine would take minutes to do it's task and timeout.

Numerous tests indicated that
a: preg_match_all with PREG_OFFSET_CAPTURE would not always return an array of 2 elements (so the offset was sometimes not returned)... which would result in the corruption of the beginning of $content instead of the cleaning of the regex.
b: the foreach loop and substr_replace were extremely slow and memory intensive.
c: using preg_replace_callback with a simple closure was extremely more optimal (down to ~2 seconds from ~166 seconds) and significantly less RAM.

Please check my code.
