### PR TITLE
add getTextArray methods to Page.php and Object.php -

### DIFF
--- a/src/Smalot/PdfParser/Object.php
+++ b/src/Smalot/PdfParser/Object.php
@@ -398,6 +398,140 @@ class Object
         return $text . ' ';
     }
 
+	/**
+	 * @param Page
+	 *
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getTextArray(Page $page = null)
+	{
+		$text                = array();
+		$sections            = $this->getSectionsText($this->content);
+		$current_font        = new Font($this->document);
+
+		foreach ($sections as $section) {
+
+			$commands = $this->getCommandsText($section);
+
+			foreach ($commands as $command) {
+
+				switch ($command[self::OPERATOR]) {
+					// set character spacing
+					case 'Tc':
+						break;
+
+					// move text current point
+					case 'Td':
+						break;
+
+					// move text current point and set leading
+					case 'TD':
+						break;
+
+					case 'Tf':
+						list($id,) = preg_split('/\s/s', $command[self::COMMAND]);
+						$id           = trim($id, '/');
+						$current_font = $page->getFont($id);
+						break;
+
+					case "'":
+					case 'Tj':
+						$command[self::COMMAND] = array($command);
+					case 'TJ':
+						// Skip if not previously defined, should never happened.
+						if (is_null($current_font)) {
+							// Fallback
+							// TODO : Improve
+							$text[] = $command[self::COMMAND][0][self::COMMAND];
+							continue;
+						}
+
+						$sub_text = $current_font->decodeText($command[self::COMMAND]);
+						$text[] = $sub_text;
+						break;
+
+					// set leading
+					case 'TL':
+						break;
+
+					case 'Tm':
+						break;
+
+					// set super/subscripting text rise
+					case 'Ts':
+						break;
+
+					// set word spacing
+					case 'Tw':
+						break;
+
+					// set horizontal scaling
+					case 'Tz':
+						//$text .= "\n";
+						break;
+
+					// move to start of next line
+					case 'T*':
+						//$text .= "\n";
+						break;
+
+					case 'Da':
+						break;
+
+					case 'Do':
+						if (!is_null($page)) {
+							$args = preg_split('/\s/s', $command[self::COMMAND]);
+							$id   = trim(array_pop($args), '/ ');
+							if ($xobject = $page->getXObject($id)) {
+								$text[] = $xobject->getText($page);
+							}
+						}
+						break;
+
+					case 'rg':
+					case 'RG':
+						break;
+
+					case 're':
+						break;
+
+					case 'co':
+						break;
+
+					case 'cs':
+						break;
+
+					case 'gs':
+						break;
+
+					case 'en':
+						break;
+
+					case 'sc':
+					case 'SC':
+						break;
+
+					case 'g':
+					case 'G':
+						break;
+
+					case 'V':
+						break;
+
+					case 'vo':
+					case 'Vo':
+						break;
+
+					default:
+				}
+			}
+		}
+
+		return $text;
+	}
+
+
     /**
      * @param string $text_part
      * @param int    $offset

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -219,4 +219,50 @@ class Page extends Object
 
         return '';
     }
+
+	/**
+	 * @param Page
+	 *
+	 * @return array
+	 */
+	public function getTextArray(Page $page = null)
+	{
+		if ($contents = $this->get('Contents')) {
+
+			if ($contents instanceof ElementMissing) {
+				return array();
+			} elseif ($contents instanceof Object) {
+				$elements = $contents->getHeader()->getElements();
+
+				if (is_numeric(key($elements))) {
+					$new_content = '';
+
+					foreach ($elements as $element) {
+						if ($element instanceof ElementXRef) {
+							$new_content .= $element->getObject()->getContent();
+						} else {
+							$new_content .= $element->getContent();
+						}
+					}
+
+					$header   = new Header(array(), $this->document);
+					$contents = new Object($this->document, $header, $new_content);
+				}
+			} elseif ($contents instanceof ElementArray) {
+				// Create a virtual global content.
+				$new_content = '';
+
+				foreach ($contents->getContent() as $content) {
+					$new_content .= $content->getContent() . "\n";
+				}
+
+				$header   = new Header(array(), $this->document);
+				$contents = new Object($this->document, $header, $new_content);
+			}
+
+			return $contents->getTextArray($this);
+		}
+
+		return array();
+	}
 }


### PR DESCRIPTION
to enable retrieving text in separate array elements rather than one long string. This will make it easier for people who are extracting data from PDFs to distinguish one text snippet from another.