### PR TITLE
adjust section splitting for empty section

### DIFF
--- a/src/Smalot/PdfParser/Object.php
+++ b/src/Smalot/PdfParser/Object.php
@@ -201,9 +201,12 @@ class Object
         $textCleaned = $this->cleanContent($content, '_');
 
         // Extract text blocks.
-        if (preg_match_all('/\s+BT[\s|\(|\[]+(.*?)\s+ET/s', $textCleaned, $matches, PREG_OFFSET_CAPTURE)) {
+        if (preg_match_all('/\s+BT[\s|\(|\[]+(.*?)\s*ET/s', $textCleaned, $matches, PREG_OFFSET_CAPTURE)) {
             foreach ($matches[1] as $part) {
                 $text    = $part[0];
+                if ($text === '') {
+                    continue;
+                }
                 $offset  = $part[1];
                 $section = substr($content, $offset, strlen($text));
 


### PR DESCRIPTION
I have incoming files where a large part did not show up in the parsed text. When debugging I found that the section splitting matches empty BT/ET blocks incorrectly, ignoring the ET and going on until the next ET. This results in a section starting with ET which will be ignored by getCommandsText.
This pull request might also fix #37 

> BT
> ET
> q
> 85.7 0 0 26.65 419.049 757.3 cm
> /Im1 Do
> Q
> BT
> /F1 8.0 Tf
> 0.0 Tc
> ...
