### PR TITLE
Remove useless and incorrect statement

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,0 @@
-# Documentation #
-
-PDF References files has been downloaded from this url : http://www.adobe.com/devnet/pdf/pdf_reference_archive.html


### PR DESCRIPTION
The files document “PDF References files” origin, yet those files are
not shipped (they have been shipped in doc in the past (4eaba08), but
have then been removed (7f24a16).