### PR TITLE
Package tecnick.com/tcpdf is abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "homepage": "http://www.pdfparser.org",
     "require": {
         "php": ">=5.3.0",
-        "tecnick.com/tcpdf": ">=6.0.050"
+        "tecnickcom/tcpdf": ">=6.0.050"
     },
     "require-dev": {
         "atoum/atoum": "dev-master"


### PR DESCRIPTION
As `composer up` says:

> Package tecnick.com/tcpdf is abandoned, you should avoid using it. Use tecnickcom/tcpdf instead.