### PR TITLE
Using the first font from the document as default font

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -233,6 +233,14 @@ class Font extends Object
     }
 
     /**
+     * @param array $table
+     */
+    public function setTable($table)
+    {
+        $this->table = $table;
+    }
+
+    /**
      * @param string $hexa
      * @param bool   $add_braces
      *

--- a/src/Smalot/PdfParser/Object.php
+++ b/src/Smalot/PdfParser/Object.php
@@ -248,7 +248,19 @@ class Object
     {
         $text                = '';
         $sections            = $this->getSectionsText($this->content);
-        $current_font        = new Font($this->document);
+        $current_font = null;
+
+        foreach ($this->document->getObjects() as $obj) {
+            if ($obj instanceof Font) {
+                $current_font = $obj;
+                break;
+            }
+        }
+
+        if ($current_font === null) {
+            $current_font = new Font($this->document);
+        }
+
         $current_position_td = array('x' => false, 'y' => false);
         $current_position_tm = array('x' => false, 'y' => false);
 


### PR DESCRIPTION
I have PDF from FastReport that can't be parsed with `new Font($this->document)`
But parser works fine with first font object included in PDF

I know that is not best solution, but it's better than current blank font.

P.S. If you need my pdf file for testing, I can send it privately as it contains personal information.

