### PR TITLE
Fixing infinite loop caused by wrong XREF reference, migration to newer bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.3.0",
         "tecnickcom/tcpdf": ">=6.0.050",
-	"tecnickcom/tc-lib-pdf-parser": "dev-master"
+        "tecnickcom/tc-lib-pdf-parser": "dev-master"
     },
     "require-dev": {
         "atoum/atoum": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "homepage": "http://www.pdfparser.org",
     "require": {
         "php": ">=5.3.0",
-        "tecnickcom/tcpdf": ">=6.0.050"
+        "tecnickcom/tcpdf": ">=6.0.050",
+	"tecnickcom/tc-lib-pdf-parser": "dev-master"
     },
     "require-dev": {
         "atoum/atoum": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.3.0",
         "tecnickcom/tcpdf": ">=6.0.050",
-        "tecnickcom/tc-lib-pdf-parser": "dev-master"
+        "tecnickcom/tc-lib-pdf-parser": "2.*"
     },
     "require-dev": {
         "atoum/atoum": "dev-master"

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -39,7 +39,7 @@ use Smalot\PdfParser\Element\ElementNull;
 use Smalot\PdfParser\Element\ElementNumeric;
 use Smalot\PdfParser\Element\ElementString;
 use Smalot\PdfParser\Element\ElementXRef;
-use Com\Tecnick\Pdf\Parser\Parser;
+use Com\Tecnick\Pdf\Parser\Parser as TCPDF_Parser;;
 
 /**
  * Class Parser
@@ -86,7 +86,7 @@ class Parser
     {
         // Create structure using TCPDF Parser.
         ob_start();
-        @$parser = new Parser();
+        @$parser = new TCPDF_Parser();
         list($xref, $data) = $parser->parse(ltrim($content));
         unset($parser);
         ob_end_clean();

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -39,6 +39,7 @@ use Smalot\PdfParser\Element\ElementNull;
 use Smalot\PdfParser\Element\ElementNumeric;
 use Smalot\PdfParser\Element\ElementString;
 use Smalot\PdfParser\Element\ElementXRef;
+use Com\Tecnick\Pdf\Parser\Parser;
 
 /**
  * Class Parser
@@ -85,8 +86,8 @@ class Parser
     {
         // Create structure using TCPDF Parser.
         ob_start();
-        @$parser = new \TCPDF_PARSER(ltrim($content));
-        list($xref, $data) = $parser->getParsedData();
+        @$parser = new Parser();
+        list($xref, $data) = $parser->parse(ltrim($content));
         unset($parser);
         ob_end_clean();
 


### PR DESCRIPTION
Migration to bundle that will overwrite old one - suggested by author there: https://sourceforge.net/p/tcpdf/discussion/435311/thread/996c7864/
Fix for parsing pdf files tht described in this ticket: https://github.com/smalot/pdfparser/issues/71
