### PR TITLE
Fix #91

### DIFF
--- a/src/Smalot/PdfParser/Object.php
+++ b/src/Smalot/PdfParser/Object.php
@@ -300,7 +300,9 @@ class Object
                     case 'Tf':
                         list($id,) = preg_split('/\s/s', $command[self::COMMAND]);
                         $id           = trim($id, '/');
-                        $current_font = $page->getFont($id);
+                        if (!is_null($page)) {
+                            $current_font = $page->getFont($id);
+                        }
                         break;
 
                     case "'":


### PR DESCRIPTION
As explained in issue #91, the 'Tf' case in the getText() switch statement does not check if `$page` is null, and thus can cause `$current_font` to become null.

Like in the 'Do' case, the `$current_font` should only be set if `$page` is not null.