### PR TITLE
Fix for Issue #95

### DIFF
--- a/samples/bugs/Issue95_ANSI.pdf
+++ b/samples/bugs/Issue95_ANSI.pdf
@@ -1,0 +1,80 @@
+%PDF-1.3
+
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/Contents 4 0 R>>
+endobj
+
+4 0 obj
+<</Length 63>>
+stream
+2 J
+0.57 w
+BT /F1 16.00 Tf ET
+BT 31.19 794.57 Td <E6F6FC> Tj ET
+endstream
+endobj
+
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+/MediaBox [0 0 595.28 841.89]
+>>
+endobj
+
+5 0 obj
+<</Type /Font
+/BaseFont /Helvetica-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+
+6 0 obj
+<<
+/Producer (PyFPDF 1.7.2 http://pyfpdf.googlecode.com/)
+/CreationDate (D:20160305075701)
+>>
+endobj
+
+7 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+
+xref
+0 8
+0000000000 65535 f 
+0000000201 00000 n 
+0000000391 00000 n 
+0000000010 00000 n 
+0000000089 00000 n 
+0000000289 00000 n 
+0000000496 00000 n 
+0000000606 00000 n 
+trailer
+<<
+ /Size 8
+ /Root 7 0 R
+>>
+startxref
+710
+%%EOF

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -358,7 +358,11 @@ class Font extends Object
                 case '<':
                     // Decode hexadecimal.
                     $text = self::decodeHexadecimal('<' . $command[Object::COMMAND] . '>');
-                    $unicode = true;
+                    
+                    if (mb_check_encoding($text, "UTF-8")) {
+                        $unicode = true;
+                    }
+                    
                     break;
 
                 default:

--- a/src/Smalot/PdfParser/Tests/Units/Font.php
+++ b/src/Smalot/PdfParser/Tests/Units/Font.php
@@ -295,5 +295,30 @@ end';
             ),
         );
         $this->assert->string($font->decodeText($commands))->isEqualTo('Docu Docu');
+        
+        //Check if ANSI/Unicode detection and conversion is working properly
+        $filename = __DIR__ . '/../../../../../samples/bugs/Issue95_ANSI.pdf';
+        $parser   = new \Smalot\PdfParser\Parser();
+        $document = $parser->parseFile($filename);
+        $fonts    = $document->getFonts();
+        /** @var \Smalot\PdfParser\Font $font */
+        $font     = reset($fonts);
+        $commands = array(
+            array(
+                't' => '<',
+                'c' => "E6F6FC", //ANSI encoded string
+            ),
+        );
+        echo("----------------------------------------------------------------\n");
+        $this->assert->string($font->decodeText($commands))->isEqualTo('æöü');    
+        
+        $commands = array(
+            array(
+                't' => '<',
+                'c' => "C3A6C3B6C3BC", //Unicode encoded string
+            ),
+        );
+        echo("----------------------------------------------------------------\n");
+        $this->assert->string($font->decodeText($commands))->isEqualTo('æöü');
     }
 }

--- a/src/Smalot/PdfParser/Tests/Units/Font.php
+++ b/src/Smalot/PdfParser/Tests/Units/Font.php
@@ -296,7 +296,7 @@ end';
         );
         $this->assert->string($font->decodeText($commands))->isEqualTo('Docu Docu');
         
-        //Check if ANSI/Unicode detection and conversion is working properly
+        //Check if ANSI/Unicode detection is working properly
         $filename = __DIR__ . '/../../../../../samples/bugs/Issue95_ANSI.pdf';
         $parser   = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
@@ -309,7 +309,6 @@ end';
                 'c' => "E6F6FC", //ANSI encoded string
             ),
         );
-        echo("----------------------------------------------------------------\n");
         $this->assert->string($font->decodeText($commands))->isEqualTo('æöü');    
         
         $commands = array(
@@ -318,7 +317,6 @@ end';
                 'c' => "C3A6C3B6C3BC", //Unicode encoded string
             ),
         );
-        echo("----------------------------------------------------------------\n");
         $this->assert->string($font->decodeText($commands))->isEqualTo('æöü');
     }
 }


### PR DESCRIPTION
Check if `$text` is really Unicode before setting `$unicode = true`