### PR TITLE
Fix on Page->getText() and Page->getTextArray()

### DIFF
--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -33,6 +33,7 @@ namespace Smalot\PdfParser;
 use Smalot\PdfParser\Element\ElementArray;
 use Smalot\PdfParser\Element\ElementMissing;
 use Smalot\PdfParser\Element\ElementXRef;
+use Smalot\PdfParser\Element\ElementNull;
 
 /**
  * Class Page
@@ -185,6 +186,8 @@ class Page extends Object
 
             if ($contents instanceof ElementMissing) {
                 return '';
+			} elseif ($contents instanceof ElementNull) {
+				return '';
             } elseif ($contents instanceof Object) {
                 $elements = $contents->getHeader()->getElements();
 
@@ -230,6 +233,8 @@ class Page extends Object
 		if ($contents = $this->get('Contents')) {
 
 			if ($contents instanceof ElementMissing) {
+				return array();
+			} elseif ($contents instanceof ElementNull) {
 				return array();
 			} elseif ($contents instanceof Object) {
 				$elements = $contents->getHeader()->getElements();


### PR DESCRIPTION
In some PDFs, the content of the page is an instance of ElementNull, in those cases getText() and getTextArray() fails on getting the text: `Call to undefined method Smalot\PdfParser\Element\ElementNull::getText()`

Sample PDF with this kind of empty pages attached
[Sample-PDF-with-empty-pages.pdf](https://github.com/smalot/pdfparser/files/464316/Sample-PDF-with-empty-pages.pdf)
