### PR TITLE
Added Document getTextArrayByPageAndSection

### DIFF
--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -266,6 +266,25 @@ class Document
     }
 
     /**
+     * @param Page $page
+     *
+     * @return array
+     */
+    public function getTextArrayByPageAndSection(Page $page = null)
+    {
+        $textArrayByPageAndSection = array();
+        $pages = $this->getPages();
+
+        foreach ($pages as $index => $page) {
+            if ($textArrayBySection = $page->getTextArrayBySection()) {
+                $textArrayByPageAndSection[$index] = $textArrayBySection;
+            }
+        }
+
+        return $textArrayByPageAndSection;
+    }
+
+    /**
      * @param Header $trailer
      */
     public function setTrailer(Header $trailer)

--- a/src/Smalot/PdfParser/Object.php
+++ b/src/Smalot/PdfParser/Object.php
@@ -562,6 +562,143 @@ class Object
 		return $text;
 	}
 
+	/**
+	 * @param Page
+	 *
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getTextArrayBySection(Page $page = null)
+	{
+		$textArrayBySection  = array();
+		$sections            = $this->getSectionsText($this->content);
+		$current_font        = new Font($this->document);
+
+		foreach ($sections as $sectionIndex=>$section) {
+
+			$commands = $this->getCommandsText($section);
+
+			$text = [];
+			foreach ($commands as $command) {
+
+				switch ($command[self::OPERATOR]) {
+					// set character spacing
+					case 'Tc':
+						break;
+
+					// move text current point
+					case 'Td':
+						break;
+
+					// move text current point and set leading
+					case 'TD':
+						break;
+
+					case 'Tf':
+						list($id,) = preg_split('/\s/s', $command[self::COMMAND]);
+						$id           = trim($id, '/');
+						$current_font = $page->getFont($id);
+						break;
+
+					case "'":
+					case 'Tj':
+						$command[self::COMMAND] = array($command);
+					case 'TJ':
+						// Skip if not previously defined, should never happened.
+						if (is_null($current_font)) {
+							// Fallback
+							// TODO : Improve
+							$text[] = $command[self::COMMAND][0][self::COMMAND];
+							continue;
+						}
+
+						$sub_text = $current_font->decodeText($command[self::COMMAND]);
+						$text[] = $sub_text;
+						break;
+
+					// set leading
+					case 'TL':
+						break;
+
+					case 'Tm':
+						break;
+
+					// set super/subscripting text rise
+					case 'Ts':
+						break;
+
+					// set word spacing
+					case 'Tw':
+						break;
+
+					// set horizontal scaling
+					case 'Tz':
+						//$text .= "\n";
+						break;
+
+					// move to start of next line
+					case 'T*':
+						//$text .= "\n";
+						break;
+
+					case 'Da':
+						break;
+
+					case 'Do':
+						if (!is_null($page)) {
+							$args = preg_split('/\s/s', $command[self::COMMAND]);
+							$id   = trim(array_pop($args), '/ ');
+							if ($xobject = $page->getXObject($id)) {
+								$text[] = $xobject->getText($page);
+							}
+						}
+						break;
+
+					case 'rg':
+					case 'RG':
+						break;
+
+					case 're':
+						break;
+
+					case 'co':
+						break;
+
+					case 'cs':
+						break;
+
+					case 'gs':
+						break;
+
+					case 'en':
+						break;
+
+					case 'sc':
+					case 'SC':
+						break;
+
+					case 'g':
+					case 'G':
+						break;
+
+					case 'V':
+						break;
+
+					case 'vo':
+					case 'Vo':
+						break;
+
+					default:
+				}
+			}
+
+            $textArrayBySection[$sectionIndex] = $text;
+
+		}
+
+		return $textArrayBySection;
+	}
+
 
     /**
      * @param string $text_part

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -270,4 +270,53 @@ class Page extends Object
 
 		return array();
 	}
+
+	/**
+	 * @param Page
+	 *
+	 * @return array
+	 */
+	public function getTextArrayBySection(Page $page = null)
+	{
+		if ($contents = $this->get('Contents')) {
+
+			if ($contents instanceof ElementMissing) {
+				return array();
+			} elseif ($contents instanceof ElementNull) {
+				return array();
+			} elseif ($contents instanceof Object) {
+				$elements = $contents->getHeader()->getElements();
+
+				if (is_numeric(key($elements))) {
+					$new_content = '';
+
+					foreach ($elements as $element) {
+						if ($element instanceof ElementXRef) {
+							$new_content .= $element->getObject()->getContent();
+						} else {
+							$new_content .= $element->getContent();
+						}
+					}
+
+					$header   = new Header(array(), $this->document);
+					$contents = new Object($this->document, $header, $new_content);
+				}
+			} elseif ($contents instanceof ElementArray) {
+				// Create a virtual global content.
+				$new_content = '';
+
+				foreach ($contents->getContent() as $content) {
+					$new_content .= $content->getContent() . "\n";
+				}
+
+				$header   = new Header(array(), $this->document);
+				$contents = new Object($this->document, $header, $new_content);
+			}
+
+			return $contents->getTextArrayBySection($this);
+		}
+
+		return array();
+	}
+
 }


### PR DESCRIPTION
I was missing a way to remove parts of headers and footers as well as to detect natural separation of content. By including the section index in the returned array, natural separation of text content / sections are found, and by including the page index, it is easier to remove parts of headers and footers. 