### PR TITLE
define php-iconv requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "homepage": "http://www.pdfparser.org",
     "require": {
         "php": ">=5.3.0",
+        "ext-iconv": "*",
         "tecnickcom/tcpdf": "~6.0"
     },
     "require-dev": {


### PR DESCRIPTION
`Font.php` uses iconv (lines [438](https://github.com/smalot/pdfparser/blob/759718a16adeb70f88ecb8d28c162640efd4c2f8/src/Smalot/PdfParser/Font.php#L438) and [447](https://github.com/smalot/pdfparser/blob/759718a16adeb70f88ecb8d28c162640efd4c2f8/src/Smalot/PdfParser/Font.php#L447)) however the php iconv extension is not defined in composer.json as requirement