### PR TITLE
Switch from iconv() to mb_convert_encoding()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "homepage": "http://www.pdfparser.org",
     "require": {
         "php": ">=5.3.0",
-        "ext-iconv": "*",
+        "ext-mbstring": "*",
+        "ext-zlib": "*",
         "tecnickcom/tcpdf": "~6.0"
     },
     "require-dev": {

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -435,7 +435,7 @@ class Font extends PDFObject
                         foreach ($fonts as $font) {
                             if ($font instanceof Font) {
                                 if (($decoded = $font->translateChar($char, false)) !== false) {
-                                    $decoded = @iconv('Windows-1252', 'UTF-8//TRANSLIT//IGNORE', $decoded);
+                                    $decoded = mb_convert_encoding($decoded, 'UTF-8', 'Windows-1252');
                                     break;
                                 }
                             }
@@ -444,7 +444,7 @@ class Font extends PDFObject
                         if ($decoded !== false) {
                             $char = $decoded;
                         } else {
-                            $char = @iconv('Windows-1252', 'UTF-8//TRANSLIT//IGNORE', $char);
+                            $char = mb_convert_encoding($char, 'UTF-8', 'Windows-1252');
                         }
                     } else {
                         $char = self::MISSING;
@@ -492,7 +492,7 @@ class Font extends PDFObject
                     $text = $result;
 
                     if ($encoding->get('BaseEncoding')->equals('MacRomanEncoding')) {
-                        $text = @iconv('Mac', 'UTF-8//TRANSLIT//IGNORE', $text);
+                        $text = mb_convert_encoding($text, 'UTF-8', 'Mac');
 
                         return $text;
                     }
@@ -506,9 +506,9 @@ class Font extends PDFObject
             if ($this->get('Encoding') instanceof Element &&
                 $this->get('Encoding')->equals('MacRomanEncoding')
             ) {
-                $text = @iconv('Mac', 'UTF-8//TRANSLIT//IGNORE', $text);
+                $text = mb_convert_encoding($text, 'UTF-8', 'Mac');
             } else {
-                $text = @iconv('Windows-1252', 'UTF-8//TRANSLIT//IGNORE', $text);
+                $text = mb_convert_encoding($text, 'UTF-8', 'Windows-1252');
             }
         }
 


### PR DESCRIPTION
PHP's `iconv()` heavily relies on the underlying OS. `iconv()`'s advantage of transliteration is not supported by all implementations (i.e. `muslibc` which is used by Alpine Linux which is quite popular for docker containers) where pdfparser returns empty content.

There are some solutions to that problem (see #61) where I think the best one is switching from `iconv` to the `mbstring-ext`.

Fixes #61
