### PR TITLE
Parser fix

### DIFF
--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -170,7 +170,13 @@ class Parser
                         $match = array();
 
                         // Split xrefs and contents.
-                        preg_match('/^((\d+\s+\d+\s*)*)(.*)$/s', $content, $match);
+                        $p = strpos($content, "<<");
+                        $match = [
+                            "",
+                            trim(substr($content,0,$p)),
+                            "",
+                            trim(substr($content,$p)),
+                        ];
                         $content = $match[3];
 
                         // Extract xrefs.

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -169,7 +169,7 @@ class Parser
                     if ($header->get('Type')->equals('ObjStm')) {
                         $match = array();
 
-                        // Split xrefs and contents.
+                        // Split xrefs and contents. 
                         $p = strpos($content, "<<");
                         $match = [
                             "",


### PR DESCRIPTION
I had problems with some pdf-s on HPUX. This regex caused a core dump and the entire request died. If I change the regex with a simple parser it works.