### PR TITLE
Bug fix: FontType3 class added

### DIFF
--- a/src/Smalot/PdfParser/Font/FontType3.php
+++ b/src/Smalot/PdfParser/Font/FontType3.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ *          This file is part of the PdfParser library.
+ *
+ * @author  Sébastien MALOT <sebastien@malot.fr>
+ * @date    2017-01-03
+ * @license LGPLv3
+ * @url     <https://github.com/smalot/pdfparser>
+ *
+ *  PdfParser is a pdf library written in PHP, extraction oriented.
+ *  Copyright (C) 2017 - Sébastien MALOT <sebastien@malot.fr>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.
+ *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
+ *
+ */
+
+namespace Smalot\PdfParser\Font;
+
+use Smalot\PdfParser\Font;
+
+/**
+ * Class FontType3
+ *
+ * @package Smalot\PdfParser\Font
+ */
+class FontType3 extends Font
+{
+}


### PR DESCRIPTION
Some pdf-files require FontType3 class which is missing. Without it we have fatal error 
```
PHP Fatal error:  require(): Failed opening required '/vagrant/PDF-Parsers/Smalot\PdfParser\Font\FontType3.php' (include_path='.:/usr/share/php') in /vagrant/PDF-Parsers/_includes.php on line 101
PHP Stack trace:
PHP   1. {main}() /vagrant/PDF-Parsers/cli.php:0
PHP   2. Symfony\Component\Console\Application->run() /vagrant/PDF-Parsers/cli.php:24
PHP   3. Symfony\Component\Console\Application->doRun() /vagrant/PDF-Parsers/vendor/symfony/console/Symfony/Component/Console/Application.php:124
PHP   4. Symfony\Component\Console\Application->doRunCommand() /vagrant/PDF-Parsers/vendor/symfony/console/Symfony/Component/Console/Application.php:193
PHP   5. ContentParser\Console\Command\ProcessCommand->run() /vagrant/PDF-Parsers/vendor/symfony/console/Symfony/Component/Console/Application.php:889
PHP   6. ContentParser\Console\Command\ProcessCommand->execute() /vagrant/PDF-Parsers/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:252
PHP   7. ContentParser\Console\Command\ProcessCommand->testOneParser() /vagrant/PDF-Parsers/tools/cli/ProcessCommand.php:74
PHP   8. ReceiptFactory::forgeWithUrl() /vagrant/PDF-Parsers/tools/cli/ProcessCommand.php:141
PHP   9. PDFReceipt->__construct() /vagrant/PDF-Parsers/lib/ReceiptFactory.php:13
PHP  10. Smalot\PdfParser\Parser->parseContent() /vagrant/PDF-Parsers/class/PDFReceipt.php:35
PHP  11. Smalot\PdfParser\Parser->parseObject() /vagrant/PDF-Parsers/vendor/smalot/pdfparser/src/Smalot/PdfParser/Parser.php:106
PHP  12. Smalot\PdfParser\Object::factory() /vagrant/PDF-Parsers/vendor/smalot/pdfparser/src/Smalot/PdfParser/Parser.php:226
PHP  13. class_exists() /vagrant/PDF-Parsers/vendor/smalot/pdfparser/src/Smalot/PdfParser/Object.php:761
PHP  14. spl_autoload_call() /vagrant/PDF-Parsers/vendor/smalot/pdfparser/src/Smalot/PdfParser/Object.php:761
PHP  15. autoload_all() /vagrant/PDF-Parsers/vendor/smalot/pdfparser/src/Smalot/PdfParser/Object.php:761
```
After adding this file error is gone.
