### PR TITLE
page object not null verification

### DIFF
--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -257,6 +257,16 @@ class Document
         $pages = $this->getPages();
 
         foreach ($pages as $index => $page) {
+            /*
+             * @doganoo Dogan Ucar, dogan@dogan-ucar.de
+             *
+             * in some cases, the $page variable may be null.
+             * It is necessary to verify that the variable is not
+             * null before calling the getText() method.
+             */
+            if ($page == null) {
+                continue;
+            }
             if ($text = trim($page->getText())) {
                 $texts[] = $text;
             }


### PR DESCRIPTION
I have a weird case where the pdf document is valid but the page not. The page instance in the pages array is null. Therefore, i propose to verify the instance before calling the "getText()" method.