### PR TITLE
fix(PDFObject): Fix PHP fatal error when getting text

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -384,7 +384,9 @@ class PDFObject
                             $id      = trim(array_pop($args), '/ ');
                             $xobject = $page->getXObject($id);
 
-                            if ( is_object($xobject) && !in_array($xobject->getUniqueId(), self::$recursionStack) ) {
+
+                             // @todo $xobject could be a ElementXRef object, which would then throw an error
+                             if ( is_object($xobject) && $xobject instanceof PDFObject && !in_array($xobject->getUniqueId(), self::$recursionStack) ) {
                                 // Not a circular reference.
                                 $text .= $xobject->getText($page);
                             }


### PR DESCRIPTION
Prevent a fatal error by checking if we really have a PDFObject before calling `getUniqueId()` on it.