### PR TITLE
PHP fatal error: Call to a member function getContent() on null in Smalot\PdfParser\Font->loadTranslateTable() (line 141 of src/Smalot/PdfParser/Font.php).

### DIFF
--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -120,7 +120,9 @@ class Document
         if ($this->trailer->has('Info')) {
             /** @var PDFObject $info */
             $info = $this->trailer->get('Info');
-            if ($info !== null) {
+            // This could be an ElementMissing object, so we need to check for
+            // the getHeader method first.
+            if ($info !== null && method_exists($info, 'getHeader')) {
                 $details = $info->getHeader()->getDetails();
             }
         }

--- a/src/Smalot/PdfParser/Header.php
+++ b/src/Smalot/PdfParser/Header.php
@@ -164,7 +164,7 @@ class Header
             $object = $this->document->getObjectById($obj->getId());
 
             if (is_null($object)) {
-                return null;
+                return new ElementMissing(null, null);
             }
 
             // Update elements list for future calls.

--- a/src/Smalot/PdfParser/Tests/Units/Header.php
+++ b/src/Smalot/PdfParser/Tests/Units/Header.php
@@ -118,9 +118,7 @@ class Header extends atoum\test
         $this->assert->object($header->get('SubType'))->isInstanceOf('\Smalot\PdfParser\Element\ElementName');
         $this->assert->object($header->get('Font'))->isInstanceOf('\Smalot\PdfParser\Page');
         $this->assert->object($header->get('Image'))->isInstanceOf('\Smalot\PdfParser\Element\ElementMissing');
-        $resources = $header->get('Resources');
-
-        $this->assert->variable($resources)->isNull();
+        $this->assert->object($header->get('Resources'))->isInstanceOf('\Smalot\PdfParser\Element\ElementMissing');
     }
 
     public function testResolveXRef()
@@ -134,12 +132,7 @@ class Header extends atoum\test
 
         $this->assert->object($header->get('Font'))->isInstanceOf('\Smalot\PdfParser\PDFObject');
 
-        $header=$header->get('Resources');
-        try {
-            $this->assert->variable($header)->isInstanceOf('\Smalot\PdfParser\Element\ElementMissing');
-            $this->assert->boolean(true)->isEqualTo(false);
-        } catch (\Exception $e) {
-            $this->assert->variable($header)->isNull();
-        }
+        $header = $header->get('Resources');
+        $this->assert->object($header)->isInstanceOf('\Smalot\PdfParser\Element\ElementMissing');
     }
 }


### PR DESCRIPTION
The problem is that Header::resolveXRef() sometimes can return null, but all callers expect that an Element comes out. We can return an ElementMissing to resolve that.