### PR TITLE
removing error control operator and updated PHPDoc

### DIFF
--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -61,25 +61,30 @@ class Parser
     }
 
     /**
-     * Parse PDF file
-     *
-     * @param string $filename
-     *
+     * @param $filename
      * @return Document
+     * @throws \Exception
      */
     public function parseFile($filename)
     {
         $content = file_get_contents($filename);
-
-        return @$this->parseContent($content);
+        /*
+         * 2018/06/20 @doganoo as multiple times a
+         * users have complained that the parseFile()
+         * method dies silently, it is an better option
+         * to remove the error control operator (@) and
+         * let the users know that the method throws an exception
+         * by adding @throws tag to PHPDoc.
+         *
+         * See here for an example: https://github.com/smalot/pdfparser/issues/204
+         */
+        return $this->parseContent($content);
     }
 
     /**
-     * Parse PDF content
-     *
-     * @param string $content
-     *
+     * @param $content
      * @return Document
+     * @throws \Exception
      */
     public function parseContent($content)
     {


### PR DESCRIPTION
as multiple users complained that the parseFile() method dies silently, I have removed the error control operator @ and added information about exceptions in PHPDoc.