### PR TITLE
Fix decoding of hexadecimal digits

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -250,7 +250,7 @@ class Font extends PDFObject
     public static function decodeHexadecimal($hexa, $add_braces = false)
     {
         $text  = '';
-        $parts = preg_split('/(<[a-z0-9]+>)/si', $hexa, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('/(<[a-f0-9]+>)/si', $hexa, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 
         foreach ($parts as $part) {
             if (preg_match('/^<.*>$/', $part) && strpos($part, '<?xml') === false) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #18, #58
| License       | LGPL-3.0

PDF annotations (comments, shapes etc.) may contain HTML formatting.
Previously, any alphanumeric characters in angle brackets are captured by the regular expression.

This causes the hexadecimal packing and therefor the PDF parsing to fail. Example warning for HTML paragraph:
```
Warning:  pack(): Type H: illegal hex digit p in /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Font.php on line 264
```

The current PR is only a workaround for the warning, a improvement of the parsing to handle annotations correctly (or at least ignore them properly) would be better. For example, bold formatting is currently recognized as hex.

@smalot If you have any better solution, it is more than welcome 😊
Enclosed you find an (synthetic) example PDF with the edge case where the problem occurs.

Test script:
```php
<?php

error_reporting(E_ALL);

require_once('vendor/autoload.php');

$parser = new Smalot\PdfParser\Parser();

$pdf = file_get_contents('example.pdf');
$document = $parser->parseContent($pdf);
$pages = $document->getPages();

$expected = 'Example PDF';
$text = $pages[0]->getText();
if (substr($text, 0, strlen($expected)) === $expected) {
    echo 'Extracted text OK' . PHP_EOL;
} else {
    echo 'Extracted text not OK' . PHP_EOL;
}
```
[Test PDF file](https://github.com/smalot/pdfparser/files/2782769/example.pdf)

Result before fix:
```
// [...] more pack() warnings
PHP Warning:  pack(): Type H: illegal hex digit o in /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Font.php on line 262
PHP Stack trace:
PHP   1. {main}() /var/www/debug/pdfparse/test.php:0
PHP   2. Smalot\PdfParser\Parser->parseContent() /var/www/debug/pdfparse/test.php:10
PHP   3. Smalot\PdfParser\Parser->parseObject() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Parser.php:106
PHP   4. Smalot\PdfParser\Header::parse() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Parser.php:200
PHP   5. Smalot\PdfParser\Element\ElementStruct::parse() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Header.php:188
PHP   6. Smalot\PdfParser\Element::parse() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Element/ElementStruct.php:72
PHP   7. Smalot\PdfParser\Element\ElementString::parse() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Element.php:171
PHP   8. Smalot\PdfParser\Font::decodeHexadecimal() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Element/ElementString.php:98
PHP   9. pack() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Font.php:262
PHP Warning:  pack(): Type H: illegal hex digit y in /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Font.php on line 262
PHP Stack trace:
PHP   1. {main}() /var/www/debug/pdfparse/test.php:0
PHP   2. Smalot\PdfParser\Parser->parseContent() /var/www/debug/pdfparse/test.php:10
PHP   3. Smalot\PdfParser\Parser->parseObject() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Parser.php:106
PHP   4. Smalot\PdfParser\Header::parse() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Parser.php:200
PHP   5. Smalot\PdfParser\Element\ElementStruct::parse() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Header.php:188
PHP   6. Smalot\PdfParser\Element::parse() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Element/ElementStruct.php:72
PHP   7. Smalot\PdfParser\Element\ElementString::parse() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Element.php:171
PHP   8. Smalot\PdfParser\Font::decodeHexadecimal() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Element/ElementString.php:98
PHP   9. pack() /var/www/debug/pdfparse/vendor/smalot/pdfparser/src/Smalot/PdfParser/Font.php:262
Extracted text OK
```

Result after fix:
```
Extracted text OK
```