### PR TITLE
Add default timezone

### DIFF
--- a/src/Smalot/PdfParser/Element/ElementDate.php
+++ b/src/Smalot/PdfParser/Element/ElementDate.php
@@ -130,13 +130,13 @@ class ElementDate extends ElementString
                 }
 
                 $format = self::$formats[strlen($name)];
-                $date   = \DateTime::createFromFormat($format, $name);
+                $date   = \DateTime::createFromFormat($format, $name,new \DateTimeZone('UTC'));
             } else {
                 // special cases
                 if (preg_match('/^\d{1,2}-\d{1,2}-\d{4},?\s+\d{2}:\d{2}:\d{2}[\+-]\d{4}$/', $name)) {
                     $name   = str_replace(',', '', $name);
                     $format = 'n-j-Y H:i:sO';
-                    $date   = \DateTime::createFromFormat($format, $name);
+                    $date   = \DateTime::createFromFormat($format, $name,new \DateTimeZone('UTC'));
                 }
             }
 

--- a/src/Smalot/PdfParser/Element/ElementDate.php
+++ b/src/Smalot/PdfParser/Element/ElementDate.php
@@ -130,13 +130,13 @@ class ElementDate extends ElementString
                 }
 
                 $format = self::$formats[strlen($name)];
-                $date   = \DateTime::createFromFormat($format, $name,new \DateTimeZone('UTC'));
+                $date   = \DateTime::createFromFormat($format, $name, new \DateTimeZone('UTC'));
             } else {
                 // special cases
                 if (preg_match('/^\d{1,2}-\d{1,2}-\d{4},?\s+\d{2}:\d{2}:\d{2}[\+-]\d{4}$/', $name)) {
                     $name   = str_replace(',', '', $name);
                     $format = 'n-j-Y H:i:sO';
-                    $date   = \DateTime::createFromFormat($format, $name,new \DateTimeZone('UTC'));
+                    $date   = \DateTime::createFromFormat($format, $name, new \DateTimeZone('UTC'));
                 }
             }
 


### PR DESCRIPTION
According to https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf page 87 section '7.9.4 Dates', date/timestamps should be, by default, in UTC/GMT. If no timezone is specified to \DateTime::createFromFormat it defaults to the system date/time which could pose problematic.