### PR TITLE
Fix illegal encoding for MacRomanEncoding

### DIFF
--- a/src/Smalot/PdfParser/Element.php
+++ b/src/Smalot/PdfParser/Element.php
@@ -51,9 +51,6 @@ class Element
      */
     protected $document = null;
 
-    /**
-     * @var mixed
-     */
     protected $value = null;
 
     /**

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -483,7 +483,7 @@ class Font extends PDFObject
                     $text = $result;
 
                     if ($encoding->get('BaseEncoding')->equals('MacRomanEncoding')) {
-                        $text = mb_convert_encoding($text, 'UTF-8', 'Mac');
+                        $text = mb_convert_encoding($text, 'UTF-8', 'ISO-8859-1');
 
                         return $text;
                     }
@@ -496,7 +496,7 @@ class Font extends PDFObject
             if ($this->get('Encoding') instanceof Element &&
                 $this->get('Encoding')->equals('MacRomanEncoding')
             ) {
-                $text = mb_convert_encoding($text, 'UTF-8', 'Mac');
+                $text = mb_convert_encoding($text, 'UTF-8', 'ISO-8859-1');
             } else {
                 $text = mb_convert_encoding($text, 'UTF-8', 'Windows-1252');
             }


### PR DESCRIPTION
With Mac in the from encoding, would get the following error: `mb_convert_encoding(): Illegal character encoding specified`.  Fixes https://github.com/smalot/pdfparser/issues/229