### PR TITLE
Fixed issue when encoding can not be casted to string.

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -86,7 +86,12 @@ class Font extends PDFObject
 
         $details['Name']     = $this->getName();
         $details['Type']     = $this->getType();
-        $details['Encoding'] = ($this->has('Encoding') ? (string)$this->get('Encoding') : 'Ansi');
+
+        try {
+            $details['Encoding'] = ($this->has('Encoding') ? (string) $this->get('Encoding') : 'Ansi');
+        } catch (\Exception $e) {
+            $details['Encoding'] = 'Ansi';
+        }
 
         $details += parent::getDetails($deep);
 


### PR DESCRIPTION
A lot of the pdf's I have tried to parse will fail when the encoding can not be converted to a string.