### PR TITLE
Fix \f crush

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -385,11 +385,7 @@ class Font extends PDFObject
             }
 
             // replace escaped chars
-            $text = str_replace(
-                array('\\\\', '\(', '\)', '\n', '\r', '\t', '\ '),
-                array('\\', '(', ')', "\n", "\r", "\t", ' '),
-                $text
-            );
+            $text = stripcslashes($text);
 
             // add content to result string
             if (isset($words[$word_position])) {


### PR DESCRIPTION
Escaped f (\f) in text crushes parcing process;
The better way is using base php function *stripcslashes*
FIx for https://github.com/smalot/pdfparser/issues/260