### PR TITLE
Fixes : PHP7.4 Invalid characters passed for attempted conversion...

### DIFF
--- a/src/Smalot/PdfParser/Element/ElementHexa.php
+++ b/src/Smalot/PdfParser/Element/ElementHexa.php
@@ -74,7 +74,7 @@ class ElementHexa extends ElementString
         $text   = '';
         $length = strlen($value);
 
-        if (substr($value, 0, 2) == '00') {
+        if (substr($value, 0, 2) === '00') {
             for ($i = 0; $i < $length; $i += 4) {
                 $hex = substr($value, $i, 4);
                 $text .= '&#' . str_pad(hexdec($hex), 4, '0', STR_PAD_LEFT) . ';';


### PR DESCRIPTION
…these have been ignored

Disclamer : I have no idea about the internal of a PDF file. (my PDF file might even be invalid, it has been created with the last version of mpdf)

My `$value` contains : ` 0 0 2 b 6 6 3 8 4 2 2 4`

Since we use php we have : `" 0" == "00"` is `true` (line 77)

So I propose this fix, please explain to me if I can help you fix this.