### PR TITLE
Define lowest deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,18 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - hhvm
+  - nightly
 
 jobs:
   fast_finish: true
   allow_failures:
-    - php: hhvm
+    - php: nightly
   include:
     - php: 7.2
       env: COMPOSER_FLAGS="--prefer-lowest"
 
 install:
   - composer self-update
-  - composer update --prefer-source -o $COMPOSER_FLAGS
+  - composer update --prefer-dist --no-progress --no-suggest --optimize-autoloader $COMPOSER_FLAGS
 
 script: ./vendor/bin/atoum -d src/Smalot/PdfParser/Tests/ -ncc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
+os: linux
+dist: xenial
 language: php
 
 php:
-#  - 5.3
-#  - 5.4
-#  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -11,14 +10,17 @@ php:
   - 7.3
   - 7.4
   - hhvm
-  
-matrix:
+
+jobs:
+  fast_finish: true
   allow_failures:
     - php: hhvm
-  
-before_script:
-  - composer self-update || true
-  - composer update
-  - composer --prefer-source --dev install
+  include:
+    - php: 7.2
+      env: COMPOSER_FLAGS="--prefer-lowest"
+
+install:
+  - composer self-update
+  - composer update --prefer-source -o $COMPOSER_FLAGS
 
 script: ./vendor/bin/atoum -d src/Smalot/PdfParser/Tests/ -ncc

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     },
     "homepage": "http://www.pdfparser.org",
     "require": {
-        "php": ">=5.3.0",
+        "php": "^5.6|^7.0",
         "ext-mbstring": "*",
         "ext-zlib": "*",
-        "tecnickcom/tcpdf": "~6.0"
+        "tecnickcom/tcpdf": "^6.2.22"
     },
     "require-dev": {
-        "atoum/atoum": "^2.8 | ^3.0"
+        "atoum/atoum": "^3.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Define the lowest deps possible for the lib to work:
- tecnickcom/tcpdf has a security advisory before 6.2.22 (see https://packagist.org/packages/tecnickcom/tcpdf/advisories?version=2463879)
- atoum/atoum doesn't work with version 3.0.0 (got few issues) and the version 2.8.0 doesn't work with PHP 7

Also:
- add a new build with `--prefer-lowest` for composer, so the lib is tested with the lowest deps possible
- rise minimum version of PHP to 5.6