### PR TITLE
Add FriendsOfPHP/PHP-CS-Fixer to "require-dev" to enforce coding styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /composer
 debug*
 composer.lock
+/.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -9,7 +9,7 @@ return PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'no_superfluous_phpdoc_tags' => true,
         'ordered_imports' => true,
-        'phpdoc_annotation_without_dot' => true,
+        'phpdoc_summary' => false,
         'protected_to_private' => false,
      ])
     ->setRiskyAllowed(true)

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,23 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'no_empty_phpdoc' => true,
+        'ordered_imports' => true,
+        'protected_to_private' => false,
+        'php_unit_test_class_requires_covers' => false,
+        'no_superfluous_phpdoc_tags' => true,
+        // adds : void to each function with no return value
+        'void_return' => true,
+     ])
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+        ->files()
+        ->in(__DIR__ . '/samples')
+        ->in(__DIR__ . '/src')
+        ->name('*.php')
+    );

--- a/.php_cs
+++ b/.php_cs
@@ -10,8 +10,6 @@ return PhpCsFixer\Config::create()
         'protected_to_private' => false,
         'php_unit_test_class_requires_covers' => false,
         'no_superfluous_phpdoc_tags' => true,
-        // adds : void to each function with no return value
-        'void_return' => true,
      ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/.php_cs
+++ b/.php_cs
@@ -3,13 +3,14 @@
 return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
+        '@Symfony:risky' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'no_unused_imports' => true,
         'no_empty_phpdoc' => true,
-        'ordered_imports' => true,
-        'protected_to_private' => false,
-        'php_unit_test_class_requires_covers' => false,
+        'no_unused_imports' => true,
         'no_superfluous_phpdoc_tags' => true,
+        'ordered_imports' => true,
+        'phpdoc_annotation_without_dot' => true,
+        'protected_to_private' => false,
      ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "tecnickcom/tcpdf": "^6.2.22"
     },
     "require-dev": {
-        "atoum/atoum": "^3.1"
+        "atoum/atoum": "^3.1",
+        "friendsofphp/php-cs-fixer": "^2.16.3"
     },
     "autoload": {
         "psr-0": {

--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -69,7 +69,7 @@ class Document
         $this->trailer = new Header([], $this);
     }
 
-    public function init(): void
+    public function init()
     {
         $this->buildDictionary();
 
@@ -84,7 +84,7 @@ class Document
     /**
      * Build dictionary based on type header field.
      */
-    protected function buildDictionary(): void
+    protected function buildDictionary()
     {
         // Build dictionary.
         $this->dictionary = [];
@@ -101,7 +101,7 @@ class Document
     /**
      * Build details array.
      */
-    protected function buildDetails(): void
+    protected function buildDetails()
     {
         // Build details array.
         $details = [];
@@ -139,7 +139,7 @@ class Document
     /**
      * @param PDFObject[] $objects
      */
-    public function setObjects($objects = []): void
+    public function setObjects($objects = [])
     {
         $this->objects = (array) $objects;
 
@@ -273,7 +273,7 @@ class Document
         return $this->trailer;
     }
 
-    public function setTrailer(Header $trailer): void
+    public function setTrailer(Header $trailer)
     {
         $this->trailer = $trailer;
     }

--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,12 +26,9 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser;
-
-use Smalot\PdfParser\Element\ElementDate;
 
 /**
  * Technical references :
@@ -40,23 +38,21 @@ use Smalot\PdfParser\Element\ElementDate;
  * - http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/ISOLatin1Encoding.pm
  * - http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/ISOLatin9Encoding.pm
  * - http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/StandardEncoding.pm
- * - http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/WinAnsiEncoding.pm
+ * - http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/WinAnsiEncoding.pm.
  *
  * Class Document
- *
- * @package Smalot\PdfParser
  */
 class Document
 {
     /**
      * @var PDFObject[]
      */
-    protected $objects = array();
+    protected $objects = [];
 
     /**
      * @var array
      */
-    protected $dictionary = array();
+    protected $dictionary = [];
 
     /**
      * @var Header
@@ -68,18 +64,12 @@ class Document
      */
     protected $details = null;
 
-    /**
-     *
-     */
     public function __construct()
     {
-        $this->trailer = new Header(array(), $this);
+        $this->trailer = new Header([], $this);
     }
 
-    /**
-     *
-     */
-    public function init()
+    public function init(): void
     {
         $this->buildDictionary();
 
@@ -94,10 +84,10 @@ class Document
     /**
      * Build dictionary based on type header field.
      */
-    protected function buildDictionary()
+    protected function buildDictionary(): void
     {
         // Build dictionary.
-        $this->dictionary = array();
+        $this->dictionary = [];
 
         foreach ($this->objects as $id => $object) {
             $type = $object->getHeader()->get('Type')->getContent();
@@ -111,10 +101,10 @@ class Document
     /**
      * Build details array.
      */
-    protected function buildDetails()
+    protected function buildDetails(): void
     {
         // Build details array.
-        $details = array();
+        $details = [];
 
         // Extract document info
         if ($this->trailer->has('Info')) {
@@ -122,7 +112,7 @@ class Document
             $info = $this->trailer->get('Info');
             // This could be an ElementMissing object, so we need to check for
             // the getHeader method first.
-            if ($info !== null && method_exists($info, 'getHeader')) {
+            if (null !== $info && method_exists($info, 'getHeader')) {
                 $details = $info->getHeader()->getDetails();
             }
         }
@@ -149,9 +139,9 @@ class Document
     /**
      * @param PDFObject[] $objects
      */
-    public function setObjects($objects = array())
+    public function setObjects($objects = []): void
     {
-        $this->objects = (array)$objects;
+        $this->objects = (array) $objects;
 
         $this->init();
     }
@@ -186,7 +176,7 @@ class Document
      */
     public function getObjectsByType($type, $subtype = null)
     {
-        $objects = array();
+        $objects = [];
 
         foreach ($this->objects as $id => $object) {
             if ($object->getHeader()->get('Type') == $type &&
@@ -209,6 +199,7 @@ class Document
 
     /**
      * @return Page[]
+     *
      * @throws \Exception
      */
     public function getPages()
@@ -221,13 +212,14 @@ class Document
             $object = $this->objects[$id]->get('Pages');
             if (method_exists($object, 'getPages')) {
                 $pages = $object->getPages(true);
+
                 return $pages;
             }
         }
 
         if (isset($this->dictionary['Pages'])) {
             // Search for pages to list kids.
-            $pages = array();
+            $pages = [];
 
             /** @var Pages[] $objects */
             $objects = $this->getObjectsByType('Pages');
@@ -255,7 +247,7 @@ class Document
      */
     public function getText(Page $page = null)
     {
-        $texts = array();
+        $texts = [];
         $pages = $this->getPages();
 
         foreach ($pages as $index => $page) {
@@ -281,10 +273,7 @@ class Document
         return $this->trailer;
     }
 
-    /**
-     * @param Header $trailer
-     */
-    public function setTrailer(Header $trailer)
+    public function setTrailer(Header $trailer): void
     {
         $this->trailer = $trailer;
     }

--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -38,7 +38,7 @@ namespace Smalot\PdfParser;
  * - http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/ISOLatin1Encoding.pm
  * - http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/ISOLatin9Encoding.pm
  * - http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/StandardEncoding.pm
- * - http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/WinAnsiEncoding.pm.
+ * - http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/WinAnsiEncoding.pm
  *
  * Class Document
  */

--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -120,7 +120,7 @@ class Document
         // Retrieve the page count
         try {
             $pages = $this->getPages();
-            $details['Pages'] = count($pages);
+            $details['Pages'] = \count($pages);
         } catch (\Exception $e) {
             $details['Pages'] = 0;
         }
@@ -180,7 +180,7 @@ class Document
 
         foreach ($this->objects as $id => $object) {
             if ($object->getHeader()->get('Type') == $type &&
-                (is_null($subtype) || $object->getHeader()->get('Subtype') == $subtype)
+                (null === $subtype || $object->getHeader()->get('Subtype') == $subtype)
             ) {
                 $objects[$id] = $object;
             }
@@ -254,7 +254,7 @@ class Document
             /**
              * In some cases, the $page variable may be null.
              */
-            if (is_null($page)) {
+            if (null === $page) {
                 continue;
             }
             if ($text = trim($page->getText())) {

--- a/src/Smalot/PdfParser/Element.php
+++ b/src/Smalot/PdfParser/Element.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser;
@@ -42,9 +42,7 @@ use Smalot\PdfParser\Element\ElementStruct;
 use Smalot\PdfParser\Element\ElementXRef;
 
 /**
- * Class Element
- *
- * @package Smalot\PdfParser
+ * Class Element.
  */
 class Element
 {
@@ -53,42 +51,30 @@ class Element
      */
     protected $document = null;
 
-    /**
-     * @var mixed
-     */
     protected $value = null;
 
     /**
-     * @param mixed    $value
      * @param Document $document
      */
     public function __construct($value, Document $document = null)
     {
-        $this->value    = $value;
+        $this->value = $value;
         $this->document = $document;
     }
 
-    /**
-     *
-     */
-    public function init()
+    public function init(): void
     {
-
     }
 
     /**
-     * @param mixed $value
-     *
      * @return bool
      */
     public function equals($value)
     {
-        return ($value == $this->value);
+        return $value == $this->value;
     }
 
     /**
-     * @param mixed $value
-     *
      * @return bool
      */
     public function contains($value)
@@ -107,9 +93,6 @@ class Element
         }
     }
 
-    /**
-     * @return mixed
-     */
     public function getContent()
     {
         return $this->value;
@@ -120,7 +103,7 @@ class Element
      */
     public function __toString()
     {
-        return (string)($this->value);
+        return (string) ($this->value);
     }
 
     /**
@@ -129,14 +112,15 @@ class Element
      * @param int      $position
      *
      * @return array
+     *
      * @throws \Exception
      */
     public static function parse($content, Document $document = null, &$position = 0)
     {
-        $args        = func_get_args();
+        $args = func_get_args();
         $only_values = isset($args[3]) ? $args[3] : false;
-        $content     = trim($content);
-        $values      = array();
+        $content = trim($content);
+        $values = [];
 
         do {
             $old_position = $position;
@@ -145,12 +129,12 @@ class Element
                 if (!preg_match('/^\s*(?P<name>\/[A-Z0-9\._]+)(?P<value>.*)/si', substr($content, $position), $match)) {
                     break;
                 } else {
-                    $name     = ltrim($match['name'], '/');
-                    $value    = $match['value'];
+                    $name = ltrim($match['name'], '/');
+                    $value = $match['value'];
                     $position = strpos($content, $value, $position + strlen($match['name']));
                 }
             } else {
-                $name  = count($values);
+                $name = count($values);
                 $value = substr($content, $position);
             }
 

--- a/src/Smalot/PdfParser/Element.php
+++ b/src/Smalot/PdfParser/Element.php
@@ -42,7 +42,7 @@ use Smalot\PdfParser\Element\ElementStruct;
 use Smalot\PdfParser\Element\ElementXRef;
 
 /**
- * Class Element.
+ * Class Element
  */
 class Element
 {

--- a/src/Smalot/PdfParser/Element.php
+++ b/src/Smalot/PdfParser/Element.php
@@ -62,7 +62,7 @@ class Element
         $this->document = $document;
     }
 
-    public function init(): void
+    public function init()
     {
     }
 

--- a/src/Smalot/PdfParser/Element.php
+++ b/src/Smalot/PdfParser/Element.php
@@ -79,7 +79,7 @@ class Element
      */
     public function contains($value)
     {
-        if (is_array($this->value)) {
+        if (\is_array($this->value)) {
             /** @var Element $val */
             foreach ($this->value as $val) {
                 if ($val->equals($value)) {
@@ -117,7 +117,7 @@ class Element
      */
     public static function parse($content, Document $document = null, &$position = 0)
     {
-        $args = func_get_args();
+        $args = \func_get_args();
         $only_values = isset($args[3]) ? $args[3] : false;
         $content = trim($content);
         $values = [];
@@ -131,10 +131,10 @@ class Element
                 } else {
                     $name = ltrim($match['name'], '/');
                     $value = $match['value'];
-                    $position = strpos($content, $value, $position + strlen($match['name']));
+                    $position = strpos($content, $value, $position + \strlen($match['name']));
                 }
             } else {
-                $name = count($values);
+                $name = \count($values);
                 $value = substr($content, $position);
             }
 
@@ -162,7 +162,7 @@ class Element
                 $position = $old_position;
                 break;
             }
-        } while ($position < strlen($content));
+        } while ($position < \strlen($content));
 
         return $values;
     }

--- a/src/Smalot/PdfParser/Element/ElementArray.php
+++ b/src/Smalot/PdfParser/Element/ElementArray.php
@@ -36,7 +36,7 @@ use Smalot\PdfParser\Header;
 use Smalot\PdfParser\PDFObject;
 
 /**
- * Class ElementArray.
+ * Class ElementArray
  */
 class ElementArray extends Element
 {

--- a/src/Smalot/PdfParser/Element/ElementArray.php
+++ b/src/Smalot/PdfParser/Element/ElementArray.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,20 +26,17 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
 
-use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Header;
 use Smalot\PdfParser\PDFObject;
 
 /**
- * Class ElementArray
- *
- * @package Smalot\PdfParser\Element
+ * Class ElementArray.
  */
 class ElementArray extends Element
 {
@@ -51,9 +49,6 @@ class ElementArray extends Element
         parent::__construct($value, $document);
     }
 
-    /**
-     * @return mixed
-     */
     public function getContent()
     {
         foreach ($this->value as $name => $element) {
@@ -78,7 +73,7 @@ class ElementArray extends Element
      */
     public function getDetails($deep = true)
     {
-        $values   = array();
+        $values = [];
         $elements = $this->getContent();
 
         foreach ($elements as $key => $element) {
@@ -115,7 +110,7 @@ class ElementArray extends Element
     {
         if (($obj = $this->value[$name]) instanceof ElementXRef) {
             /** @var PDFObject $obj */
-            $obj                = $this->document->getObjectById($obj->getId());
+            $obj = $this->document->getObjectById($obj->getId());
             $this->value[$name] = $obj;
         }
 
@@ -135,19 +130,19 @@ class ElementArray extends Element
             preg_match_all('/(.*?)(\[|\])/s', trim($content), $matches);
 
             $level = 0;
-            $sub   = '';
+            $sub = '';
             foreach ($matches[0] as $part) {
                 $sub .= $part;
-                $level += (strpos($part, '[') !== false ? 1 : -1);
+                $level += (false !== strpos($part, '[') ? 1 : -1);
                 if ($level <= 0) {
                     break;
                 }
             }
 
             // Removes 1 level [ and ].
-            $sub        = substr(trim($sub), 1, -1);
+            $sub = substr(trim($sub), 1, -1);
             $sub_offset = 0;
-            $values     = Element::parse($sub, $document, $sub_offset, true);
+            $values = Element::parse($sub, $document, $sub_offset, true);
 
             $offset += strpos($content, '[') + 1;
             // Find next ']' position

--- a/src/Smalot/PdfParser/Element/ElementArray.php
+++ b/src/Smalot/PdfParser/Element/ElementArray.php
@@ -81,11 +81,11 @@ class ElementArray extends Element
                 $values[$key] = $element->getDetails($deep);
             } elseif ($element instanceof PDFObject && $deep) {
                 $values[$key] = $element->getDetails(false);
-            } elseif ($element instanceof ElementArray) {
+            } elseif ($element instanceof self) {
                 if ($deep) {
                     $values[$key] = $element->getDetails();
                 }
-            } elseif ($element instanceof Element && !($element instanceof ElementArray)) {
+            } elseif ($element instanceof Element && !($element instanceof self)) {
                 $values[$key] = $element->getContent();
             }
         }
@@ -146,7 +146,7 @@ class ElementArray extends Element
 
             $offset += strpos($content, '[') + 1;
             // Find next ']' position
-            $offset += strlen($sub) + 1;
+            $offset += \strlen($sub) + 1;
 
             return new self($values, $document);
         }

--- a/src/Smalot/PdfParser/Element/ElementBoolean.php
+++ b/src/Smalot/PdfParser/Element/ElementBoolean.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,18 +26,15 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
 
-use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
 
 /**
- * Class ElementBoolean
- *
- * @package Smalot\PdfParser\Element
+ * Class ElementBoolean.
  */
 class ElementBoolean extends Element
 {
@@ -46,7 +44,7 @@ class ElementBoolean extends Element
      */
     public function __construct($value, Document $document = null)
     {
-        parent::__construct((strtolower($value) == 'true' || $value === true), null);
+        parent::__construct(('true' == strtolower($value) || true === $value), null);
     }
 
     /**
@@ -58,13 +56,11 @@ class ElementBoolean extends Element
     }
 
     /**
-     * @param mixed $value
-     *
      * @return bool
      */
     public function equals($value)
     {
-        return ($this->getContent() === $value);
+        return $this->getContent() === $value;
     }
 
     /**
@@ -77,7 +73,7 @@ class ElementBoolean extends Element
     public static function parse($content, Document $document = null, &$offset = 0)
     {
         if (preg_match('/^\s*(?P<value>true|false)/is', $content, $match)) {
-            $value  = $match['value'];
+            $value = $match['value'];
             $offset += strpos($content, $value) + strlen($value);
 
             return new self($value, $document);

--- a/src/Smalot/PdfParser/Element/ElementBoolean.php
+++ b/src/Smalot/PdfParser/Element/ElementBoolean.php
@@ -34,7 +34,7 @@ use Smalot\PdfParser\Document;
 use Smalot\PdfParser\Element;
 
 /**
- * Class ElementBoolean.
+ * Class ElementBoolean
  */
 class ElementBoolean extends Element
 {

--- a/src/Smalot/PdfParser/Element/ElementBoolean.php
+++ b/src/Smalot/PdfParser/Element/ElementBoolean.php
@@ -74,7 +74,7 @@ class ElementBoolean extends Element
     {
         if (preg_match('/^\s*(?P<value>true|false)/is', $content, $match)) {
             $value = $match['value'];
-            $offset += strpos($content, $value) + strlen($value);
+            $offset += strpos($content, $value) + \strlen($value);
 
             return new self($value, $document);
         }

--- a/src/Smalot/PdfParser/Element/ElementDate.php
+++ b/src/Smalot/PdfParser/Element/ElementDate.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
 
 /**
- * Class ElementDate.
+ * Class ElementDate
  */
 class ElementDate extends ElementString
 {

--- a/src/Smalot/PdfParser/Element/ElementDate.php
+++ b/src/Smalot/PdfParser/Element/ElementDate.php
@@ -120,11 +120,11 @@ class ElementDate extends ElementString
             if (preg_match('/^\d{4}(\d{2}(\d{2}(\d{2}(\d{2}(\d{2}(Z(\d{2,4})?|[\+-]?\d{2}(\d{2})?)?)?)?)?)?)?$/', $name)) {
                 if ($pos = strpos($name, 'Z')) {
                     $name = substr($name, 0, $pos + 1);
-                } elseif (18 == strlen($name) && preg_match('/[^\+-]0000$/', $name)) {
+                } elseif (18 == \strlen($name) && preg_match('/[^\+-]0000$/', $name)) {
                     $name = substr($name, 0, -4).'+0000';
                 }
 
-                $format = self::$formats[strlen($name)];
+                $format = self::$formats[\strlen($name)];
                 $date = \DateTime::createFromFormat($format, $name, new \DateTimeZone('UTC'));
             } else {
                 // special cases
@@ -139,7 +139,7 @@ class ElementDate extends ElementString
                 return false;
             }
 
-            $offset += strpos($content, '(D:') + strlen($match['name']) + 4; // 1 for '(D:' and ')'
+            $offset += strpos($content, '(D:') + \strlen($match['name']) + 4; // 1 for '(D:' and ')'
             $element = new self($date, $document);
 
             return $element;

--- a/src/Smalot/PdfParser/Element/ElementDate.php
+++ b/src/Smalot/PdfParser/Element/ElementDate.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,28 +26,24 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
 
-use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
 
 /**
- * Class ElementDate
- *
- * @package Smalot\PdfParser\Element
+ * Class ElementDate.
  */
 class ElementDate extends ElementString
 {
     /**
      * @var array
      */
-    protected static $formats = array(
-        4  => 'Y',
-        6  => 'Ym',
-        8  => 'Ymd',
+    protected static $formats = [
+        4 => 'Y',
+        6 => 'Ym',
+        8 => 'Ymd',
         10 => 'YmdH',
         12 => 'YmdHi',
         14 => 'YmdHis',
@@ -54,7 +51,7 @@ class ElementDate extends ElementString
         17 => 'YmdHisO',
         18 => 'YmdHisO',
         19 => 'YmdHisO',
-    );
+    ];
 
     /**
      * @var string
@@ -77,14 +74,12 @@ class ElementDate extends ElementString
     /**
      * @param string $format
      */
-    public function setFormat($format)
+    public function setFormat($format): void
     {
         $this->format = $format;
     }
 
     /**
-     * @param mixed $value
-     *
      * @return bool
      */
     public function equals($value)
@@ -95,7 +90,7 @@ class ElementDate extends ElementString
             $timestamp = strtotime($value);
         }
 
-        return ($timestamp == $this->value->getTimeStamp());
+        return $timestamp == $this->value->getTimeStamp();
     }
 
     /**
@@ -103,7 +98,7 @@ class ElementDate extends ElementString
      */
     public function __toString()
     {
-        return (string)($this->value->format($this->format));
+        return (string) ($this->value->format($this->format));
     }
 
     /**
@@ -125,18 +120,18 @@ class ElementDate extends ElementString
             if (preg_match('/^\d{4}(\d{2}(\d{2}(\d{2}(\d{2}(\d{2}(Z(\d{2,4})?|[\+-]?\d{2}(\d{2})?)?)?)?)?)?)?$/', $name)) {
                 if ($pos = strpos($name, 'Z')) {
                     $name = substr($name, 0, $pos + 1);
-                } elseif (strlen($name) == 18 && preg_match('/[^\+-]0000$/', $name)) {
-                    $name = substr($name, 0, -4) . '+0000';
+                } elseif (18 == strlen($name) && preg_match('/[^\+-]0000$/', $name)) {
+                    $name = substr($name, 0, -4).'+0000';
                 }
 
                 $format = self::$formats[strlen($name)];
-                $date   = \DateTime::createFromFormat($format, $name, new \DateTimeZone('UTC'));
+                $date = \DateTime::createFromFormat($format, $name, new \DateTimeZone('UTC'));
             } else {
                 // special cases
                 if (preg_match('/^\d{1,2}-\d{1,2}-\d{4},?\s+\d{2}:\d{2}:\d{2}[\+-]\d{4}$/', $name)) {
-                    $name   = str_replace(',', '', $name);
+                    $name = str_replace(',', '', $name);
                     $format = 'n-j-Y H:i:sO';
-                    $date   = \DateTime::createFromFormat($format, $name, new \DateTimeZone('UTC'));
+                    $date = \DateTime::createFromFormat($format, $name, new \DateTimeZone('UTC'));
                 }
             }
 

--- a/src/Smalot/PdfParser/Element/ElementDate.php
+++ b/src/Smalot/PdfParser/Element/ElementDate.php
@@ -74,7 +74,7 @@ class ElementDate extends ElementString
     /**
      * @param string $format
      */
-    public function setFormat($format): void
+    public function setFormat($format)
     {
         $this->format = $format;
     }

--- a/src/Smalot/PdfParser/Element/ElementHexa.php
+++ b/src/Smalot/PdfParser/Element/ElementHexa.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
@@ -33,9 +33,7 @@ namespace Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
 
 /**
- * Class ElementHexa
- *
- * @package Smalot\PdfParser\Element
+ * Class ElementHexa.
  */
 class ElementHexa extends ElementString
 {
@@ -49,10 +47,10 @@ class ElementHexa extends ElementString
     public static function parse($content, Document $document = null, &$offset = 0)
     {
         if (preg_match('/^\s*\<(?P<name>[A-F0-9]+)\>/is', $content, $match)) {
-            $name    = $match['name'];
-            $offset += strpos($content, '<' . $name) + strlen($name) + 2; // 1 for '>'
+            $name = $match['name'];
+            $offset += strpos($content, '<'.$name) + strlen($name) + 2; // 1 for '>'
             // repackage string as standard
-            $name    = '(' . self::decode($name, $document) . ')';
+            $name = '('.self::decode($name, $document).')';
             $element = false;
 
             if (!($element = ElementDate::parse($name, $document))) {
@@ -71,13 +69,13 @@ class ElementHexa extends ElementString
      */
     public static function decode($value, Document $document = null)
     {
-        $text   = '';
+        $text = '';
         $length = strlen($value);
 
-        if (substr($value, 0, 2) === '00') {
+        if ('00' === substr($value, 0, 2)) {
             for ($i = 0; $i < $length; $i += 4) {
                 $hex = substr($value, $i, 4);
-                $text .= '&#' . str_pad(hexdec($hex), 4, '0', STR_PAD_LEFT) . ';';
+                $text .= '&#'.str_pad(hexdec($hex), 4, '0', STR_PAD_LEFT).';';
             }
         } else {
             for ($i = 0; $i < $length; $i += 2) {

--- a/src/Smalot/PdfParser/Element/ElementHexa.php
+++ b/src/Smalot/PdfParser/Element/ElementHexa.php
@@ -48,7 +48,7 @@ class ElementHexa extends ElementString
     {
         if (preg_match('/^\s*\<(?P<name>[A-F0-9]+)\>/is', $content, $match)) {
             $name = $match['name'];
-            $offset += strpos($content, '<'.$name) + strlen($name) + 2; // 1 for '>'
+            $offset += strpos($content, '<'.$name) + \strlen($name) + 2; // 1 for '>'
             // repackage string as standard
             $name = '('.self::decode($name, $document).')';
             $element = false;
@@ -70,7 +70,7 @@ class ElementHexa extends ElementString
     public static function decode($value, Document $document = null)
     {
         $text = '';
-        $length = strlen($value);
+        $length = \strlen($value);
 
         if ('00' === substr($value, 0, 2)) {
             for ($i = 0; $i < $length; $i += 4) {
@@ -80,7 +80,7 @@ class ElementHexa extends ElementString
         } else {
             for ($i = 0; $i < $length; $i += 2) {
                 $hex = substr($value, $i, 2);
-                $text .= chr(hexdec($hex));
+                $text .= \chr(hexdec($hex));
             }
         }
 

--- a/src/Smalot/PdfParser/Element/ElementHexa.php
+++ b/src/Smalot/PdfParser/Element/ElementHexa.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
 
 /**
- * Class ElementHexa.
+ * Class ElementHexa
  */
 class ElementHexa extends ElementString
 {

--- a/src/Smalot/PdfParser/Element/ElementMissing.php
+++ b/src/Smalot/PdfParser/Element/ElementMissing.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,16 +26,15 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
 
-use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
 
 /**
- * Class ElementMissing
+ * Class ElementMissing.
  */
 class ElementMissing extends Element
 {
@@ -48,8 +48,6 @@ class ElementMissing extends Element
     }
 
     /**
-     * @param mixed $value
-     *
      * @return bool
      */
     public function equals($value)
@@ -58,8 +56,6 @@ class ElementMissing extends Element
     }
 
     /**
-     * @param mixed $value
-     *
      * @return bool
      */
     public function contains($value)

--- a/src/Smalot/PdfParser/Element/ElementMissing.php
+++ b/src/Smalot/PdfParser/Element/ElementMissing.php
@@ -34,7 +34,7 @@ use Smalot\PdfParser\Document;
 use Smalot\PdfParser\Element;
 
 /**
- * Class ElementMissing.
+ * Class ElementMissing
  */
 class ElementMissing extends Element
 {

--- a/src/Smalot/PdfParser/Element/ElementName.php
+++ b/src/Smalot/PdfParser/Element/ElementName.php
@@ -67,7 +67,7 @@ class ElementName extends Element
     {
         if (preg_match('/^\s*\/(?P<name>[A-Z0-9\-\+,#\.]+)/is', $content, $match)) {
             $name = $match['name'];
-            $offset += strpos($content, $name) + strlen($name);
+            $offset += strpos($content, $name) + \strlen($name);
             $name = Font::decodeEntities($name);
 
             return new self($name, $document);

--- a/src/Smalot/PdfParser/Element/ElementName.php
+++ b/src/Smalot/PdfParser/Element/ElementName.php
@@ -35,7 +35,7 @@ use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Font;
 
 /**
- * Class ElementName.
+ * Class ElementName
  */
 class ElementName extends Element
 {

--- a/src/Smalot/PdfParser/Element/ElementName.php
+++ b/src/Smalot/PdfParser/Element/ElementName.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,19 +26,16 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
 
-use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Font;
 
 /**
- * Class ElementName
- *
- * @package Smalot\PdfParser\Element
+ * Class ElementName.
  */
 class ElementName extends Element
 {
@@ -51,8 +49,6 @@ class ElementName extends Element
     }
 
     /**
-     * @param mixed $value
-     *
      * @return bool
      */
     public function equals($value)
@@ -70,9 +66,9 @@ class ElementName extends Element
     public static function parse($content, Document $document = null, &$offset = 0)
     {
         if (preg_match('/^\s*\/(?P<name>[A-Z0-9\-\+,#\.]+)/is', $content, $match)) {
-            $name   = $match['name'];
+            $name = $match['name'];
             $offset += strpos($content, $name) + strlen($name);
-            $name   = Font::decodeEntities($name);
+            $name = Font::decodeEntities($name);
 
             return new self($name, $document);
         }

--- a/src/Smalot/PdfParser/Element/ElementNull.php
+++ b/src/Smalot/PdfParser/Element/ElementNull.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,18 +26,15 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
 
-use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
 
 /**
- * Class ElementNull
- *
- * @package Smalot\PdfParser\Element
+ * Class ElementNull.
  */
 class ElementNull extends Element
 {
@@ -58,13 +56,11 @@ class ElementNull extends Element
     }
 
     /**
-     * @param mixed $value
-     *
      * @return bool
      */
     public function equals($value)
     {
-        return ($this->getContent() === $value);
+        return $this->getContent() === $value;
     }
 
     /**

--- a/src/Smalot/PdfParser/Element/ElementNull.php
+++ b/src/Smalot/PdfParser/Element/ElementNull.php
@@ -34,7 +34,7 @@ use Smalot\PdfParser\Document;
 use Smalot\PdfParser\Element;
 
 /**
- * Class ElementNull.
+ * Class ElementNull
  */
 class ElementNull extends Element
 {

--- a/src/Smalot/PdfParser/Element/ElementNull.php
+++ b/src/Smalot/PdfParser/Element/ElementNull.php
@@ -73,7 +73,7 @@ class ElementNull extends Element
     public static function parse($content, Document $document = null, &$offset = 0)
     {
         if (preg_match('/^\s*(null)/s', $content, $match)) {
-            $offset += strpos($content, 'null') + strlen('null');
+            $offset += strpos($content, 'null') + \strlen('null');
 
             return new self(null, $document);
         }

--- a/src/Smalot/PdfParser/Element/ElementNumeric.php
+++ b/src/Smalot/PdfParser/Element/ElementNumeric.php
@@ -34,7 +34,7 @@ use Smalot\PdfParser\Document;
 use Smalot\PdfParser\Element;
 
 /**
- * Class ElementNumeric.
+ * Class ElementNumeric
  */
 class ElementNumeric extends Element
 {

--- a/src/Smalot/PdfParser/Element/ElementNumeric.php
+++ b/src/Smalot/PdfParser/Element/ElementNumeric.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,18 +26,15 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
 
-use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
 
 /**
- * Class ElementNumeric
- *
- * @package Smalot\PdfParser\Element
+ * Class ElementNumeric.
  */
 class ElementNumeric extends Element
 {
@@ -59,7 +57,7 @@ class ElementNumeric extends Element
     public static function parse($content, Document $document = null, &$offset = 0)
     {
         if (preg_match('/^\s*(?P<value>\-?[0-9\.]+)/s', $content, $match)) {
-            $value  = $match['value'];
+            $value = $match['value'];
             $offset += strpos($content, $value) + strlen($value);
 
             return new self($value, $document);

--- a/src/Smalot/PdfParser/Element/ElementNumeric.php
+++ b/src/Smalot/PdfParser/Element/ElementNumeric.php
@@ -44,7 +44,7 @@ class ElementNumeric extends Element
      */
     public function __construct($value, Document $document = null)
     {
-        parent::__construct(floatval($value), null);
+        parent::__construct((float) $value, null);
     }
 
     /**
@@ -58,7 +58,7 @@ class ElementNumeric extends Element
     {
         if (preg_match('/^\s*(?P<value>\-?[0-9\.]+)/s', $content, $match)) {
             $value = $match['value'];
-            $offset += strpos($content, $value) + strlen($value);
+            $offset += strpos($content, $value) + \strlen($value);
 
             return new self($value, $document);
         }

--- a/src/Smalot/PdfParser/Element/ElementString.php
+++ b/src/Smalot/PdfParser/Element/ElementString.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,19 +26,16 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
 
-use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Font;
 
 /**
- * Class ElementString
- *
- * @package Smalot\PdfParser\Element
+ * Class ElementString.
  */
 class ElementString extends Element
 {
@@ -51,8 +49,6 @@ class ElementString extends Element
     }
 
     /**
-     * @param mixed $value
-     *
      * @return bool
      */
     public function equals($value)
@@ -74,7 +70,7 @@ class ElementString extends Element
 
             // Find next ')' not escaped.
             $cur_start_text = $start_search_end = 0;
-            while (($cur_start_pos = strpos($name, ')', $start_search_end)) !== false) {
+            while (false !== ($cur_start_pos = strpos($name, ')', $start_search_end))) {
                 $cur_extract = substr($name, $cur_start_text, $cur_start_pos - $cur_start_text);
                 preg_match('/(?P<escape>[\\\]*)$/s', $cur_extract, $match);
                 if (!(strlen($match['escape']) % 2)) {
@@ -84,11 +80,11 @@ class ElementString extends Element
             }
 
             // Extract string.
-            $name   = substr($name, 0, $cur_start_pos);
+            $name = substr($name, 0, $cur_start_pos);
             $offset += strpos($content, '(') + $cur_start_pos + 2; // 2 for '(' and ')'
-            $name   = str_replace(
-                array('\\\\', '\\ ', '\\/', '\(', '\)', '\n', '\r', '\t'),
-                array('\\',   ' ',   '/',   '(',  ')',  "\n", "\r", "\t"),
+            $name = str_replace(
+                ['\\\\', '\\ ', '\\/', '\(', '\)', '\n', '\r', '\t'],
+                ['\\',   ' ',   '/',   '(',  ')',  "\n", "\r", "\t"],
                 $name
             );
 

--- a/src/Smalot/PdfParser/Element/ElementString.php
+++ b/src/Smalot/PdfParser/Element/ElementString.php
@@ -35,7 +35,7 @@ use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Font;
 
 /**
- * Class ElementString.
+ * Class ElementString
  */
 class ElementString extends Element
 {

--- a/src/Smalot/PdfParser/Element/ElementString.php
+++ b/src/Smalot/PdfParser/Element/ElementString.php
@@ -73,7 +73,7 @@ class ElementString extends Element
             while (false !== ($cur_start_pos = strpos($name, ')', $start_search_end))) {
                 $cur_extract = substr($name, $cur_start_text, $cur_start_pos - $cur_start_text);
                 preg_match('/(?P<escape>[\\\]*)$/s', $cur_extract, $match);
-                if (!(strlen($match['escape']) % 2)) {
+                if (!(\strlen($match['escape']) % 2)) {
                     break;
                 }
                 $start_search_end = $cur_start_pos + 1;

--- a/src/Smalot/PdfParser/Element/ElementStruct.php
+++ b/src/Smalot/PdfParser/Element/ElementStruct.php
@@ -61,7 +61,7 @@ class ElementStruct extends Element
                 }
             }
 
-            $offset += strpos($content, '<<') + strlen(rtrim($sub));
+            $offset += strpos($content, '<<') + \strlen(rtrim($sub));
 
             // Removes '<<' and '>>'.
             $sub = trim(preg_replace('/^\s*<<(.*)>>\s*$/s', '\\1', $sub));

--- a/src/Smalot/PdfParser/Element/ElementStruct.php
+++ b/src/Smalot/PdfParser/Element/ElementStruct.php
@@ -35,7 +35,7 @@ use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Header;
 
 /**
- * Class ElementStruct.
+ * Class ElementStruct
  */
 class ElementStruct extends Element
 {

--- a/src/Smalot/PdfParser/Element/ElementStruct.php
+++ b/src/Smalot/PdfParser/Element/ElementStruct.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,19 +26,16 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
 
-use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Header;
 
 /**
- * Class ElementStruct
- *
- * @package Smalot\PdfParser\Element
+ * Class ElementStruct.
  */
 class ElementStruct extends Element
 {
@@ -54,10 +52,10 @@ class ElementStruct extends Element
             preg_match_all('/(.*?)(<<|>>)/s', trim($content), $matches);
 
             $level = 0;
-            $sub   = '';
+            $sub = '';
             foreach ($matches[0] as $part) {
                 $sub .= $part;
-                $level += (strpos($part, '<<') !== false ? 1 : -1);
+                $level += (false !== strpos($part, '<<') ? 1 : -1);
                 if ($level <= 0) {
                     break;
                 }
@@ -70,7 +68,7 @@ class ElementStruct extends Element
 
             $position = 0;
             $elements = Element::parse($sub, $document, $position);
-            $header   = new Header($elements, $document);
+            $header = new Header($elements, $document);
 
             return $header;
         }

--- a/src/Smalot/PdfParser/Element/ElementXRef.php
+++ b/src/Smalot/PdfParser/Element/ElementXRef.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,18 +26,15 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Element;
 
-use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
 
 /**
- * Class ElementXRef
- *
- * @package Smalot\PdfParser\Element
+ * Class ElementXRef.
  */
 class ElementXRef extends Element
 {
@@ -48,17 +46,12 @@ class ElementXRef extends Element
         return $this->getContent();
     }
 
-    /**
-     * @return mixed
-     */
     public function getObject()
     {
         return $this->document->getObjectById($this->getId());
     }
 
     /**
-     * @param mixed $value
-     *
      * @return bool
      */
     public function equals($value)
@@ -73,7 +66,7 @@ class ElementXRef extends Element
      */
     public function __toString()
     {
-        return '#Obj#' . $this->getId();
+        return '#Obj#'.$this->getId();
     }
 
     /**

--- a/src/Smalot/PdfParser/Element/ElementXRef.php
+++ b/src/Smalot/PdfParser/Element/ElementXRef.php
@@ -34,7 +34,7 @@ use Smalot\PdfParser\Document;
 use Smalot\PdfParser\Element;
 
 /**
- * Class ElementXRef.
+ * Class ElementXRef
  */
 class ElementXRef extends Element
 {

--- a/src/Smalot/PdfParser/Element/ElementXRef.php
+++ b/src/Smalot/PdfParser/Element/ElementXRef.php
@@ -56,7 +56,7 @@ class ElementXRef extends Element
      */
     public function equals($value)
     {
-        $id = ($value instanceof ElementXRef) ? $value->getId() : $value;
+        $id = ($value instanceof self) ? $value->getId() : $value;
 
         return $this->getId() == $id;
     }
@@ -80,7 +80,7 @@ class ElementXRef extends Element
     {
         if (preg_match('/^\s*(?P<id>[0-9]+\s+[0-9]+\s+R)/s', $content, $match)) {
             $id = $match['id'];
-            $offset += strpos($content, $id) + strlen($id);
+            $offset += strpos($content, $id) + \strlen($id);
             $id = str_replace(' ', '_', rtrim($id, ' R'));
 
             return new self($id, $document);

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -52,7 +52,7 @@ class Encoding extends PDFObject
      */
     protected $mapping;
 
-    public function init(): void
+    public function init()
     {
         $this->mapping = [];
         $this->differences = [];

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser;
@@ -33,9 +33,7 @@ namespace Smalot\PdfParser;
 use Smalot\PdfParser\Element\ElementNumeric;
 
 /**
- * Class Encoding
- *
- * @package Smalot\PdfParser
+ * Class Encoding.
  */
 class Encoding extends PDFObject
 {
@@ -54,30 +52,27 @@ class Encoding extends PDFObject
      */
     protected $mapping;
 
-    /**
-     *
-     */
-    public function init()
+    public function init(): void
     {
-        $this->mapping     = array();
-        $this->differences = array();
-        $this->encoding    = null;
+        $this->mapping = [];
+        $this->differences = [];
+        $this->encoding = null;
 
         if ($this->has('BaseEncoding')) {
             // Load reference table charset.
             $baseEncoding = preg_replace('/[^A-Z0-9]/is', '', $this->get('BaseEncoding')->getContent());
-            $className    = '\\Smalot\\PdfParser\\Encoding\\' . $baseEncoding;
+            $className = '\\Smalot\\PdfParser\\Encoding\\'.$baseEncoding;
 
             if (class_exists($className)) {
                 $class = new $className();
                 $this->encoding = $class->getTranslations();
             } else {
-                throw new \Exception('Missing encoding data for: "' . $baseEncoding . '".');
+                throw new \Exception('Missing encoding data for: "'.$baseEncoding.'".');
             }
 
             // Build table including differences.
             $differences = $this->get('Differences')->getContent();
-            $code        = 0;
+            $code = 0;
 
             if (!is_array($differences)) {
                 return;
@@ -98,14 +93,14 @@ class Encoding extends PDFObject
                 }
 
                 // For the next char.
-                $code++;
+                ++$code;
             }
 
             // Build final mapping (custom => standard).
             $table = array_flip(array_reverse($this->encoding, true));
 
             foreach ($this->differences as $code => $difference) {
-                /** @var string $difference */
+                /* @var string $difference */
                 $this->mapping[$code] = (isset($table[$difference]) ? $table[$difference] : Font::MISSING);
             }
         }
@@ -116,10 +111,10 @@ class Encoding extends PDFObject
      */
     public function getDetails($deep = true)
     {
-        $details = array();
+        $details = [];
 
-        $details['BaseEncoding'] = ($this->has('BaseEncoding') ? (string)$this->get('BaseEncoding') : 'Ansi');
-        $details['Differences']  = ($this->has('Differences') ? (string)$this->get('Differences') : '');
+        $details['BaseEncoding'] = ($this->has('BaseEncoding') ? (string) $this->get('BaseEncoding') : 'Ansi');
+        $details['Differences'] = ($this->has('Differences') ? (string) $this->get('Differences') : '');
 
         $details += parent::getDetails($deep);
 
@@ -127,8 +122,6 @@ class Encoding extends PDFObject
     }
 
     /**
-     * @param int $char
-     *
      * @return int
      */
     public function translateChar($dec)

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -74,7 +74,7 @@ class Encoding extends PDFObject
             $differences = $this->get('Differences')->getContent();
             $code = 0;
 
-            if (!is_array($differences)) {
+            if (!\is_array($differences)) {
                 return;
             }
 
@@ -86,7 +86,7 @@ class Encoding extends PDFObject
                 }
 
                 // ElementName
-                if (is_object($difference)) {
+                if (\is_object($difference)) {
                     $this->differences[$code] = $difference->getContent();
                 } else {
                     $this->differences[$code] = $difference;

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser;
 use Smalot\PdfParser\Element\ElementNumeric;
 
 /**
- * Class Encoding.
+ * Class Encoding
  */
 class Encoding extends PDFObject
 {

--- a/src/Smalot/PdfParser/Encoding/ISOLatin1Encoding.php
+++ b/src/Smalot/PdfParser/Encoding/ISOLatin1Encoding.php
@@ -33,7 +33,7 @@
 namespace Smalot\PdfParser\Encoding;
 
 /**
- * Class ISOLatin1Encoding.
+ * Class ISOLatin1Encoding
  */
 class ISOLatin1Encoding
 {

--- a/src/Smalot/PdfParser/Encoding/ISOLatin1Encoding.php
+++ b/src/Smalot/PdfParser/Encoding/ISOLatin1Encoding.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 // Source : http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/ISOLatin1Encoding.pm
@@ -33,42 +33,40 @@
 namespace Smalot\PdfParser\Encoding;
 
 /**
- * Class ISOLatin1Encoding
- *
- * @package Smalot\PdfParser\Encoding
+ * Class ISOLatin1Encoding.
  */
 class ISOLatin1Encoding
 {
     public function getTranslations()
     {
         $encoding =
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          'space exclam quotedbl numbersign dollar percent ampersand quoteright ' .
-          'parenleft parenright asterisk plus comma minus period slash zero one ' .
-          'two three four five six seven eight nine colon semicolon less equal ' .
-          'greater question at A B C D E F G H I J K L M N O P Q R S T U V W X ' .
-          'Y Z bracketleft backslash bracketright asciicircum underscore ' .
-          'quoteleft a b c d e f g h i j k l m n o p q r s t u v w x y z ' .
-          'braceleft bar braceright asciitilde .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef dotlessi grave acute ' .
-          'circumflex tilde macron breve dotaccent dieresis .notdef ring ' .
-          'cedilla .notdef hungarumlaut ogonek caron space exclamdown cent ' .
-          'sterling currency yen brokenbar section dieresis copyright ' .
-          'ordfeminine guillemotleft logicalnot hyphen registered macron degree ' .
-          'plusminus twosuperior threesuperior acute mu paragraph ' .
-          'periodcentered cedilla onesuperior ordmasculine guillemotright ' .
-          'onequarter onehalf threequarters questiondown Agrave Aacute ' .
-          'Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute ' .
-          'Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde ' .
-          'Ograve Oacute Ocircumflex Otilde Odieresis multiply Oslash Ugrave ' .
-          'Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute ' .
-          'acircumflex atilde adieresis aring ae ccedilla egrave eacute ' .
-          'ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde ' .
-          'ograve oacute ocircumflex otilde odieresis divide oslash ugrave ' .
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          'space exclam quotedbl numbersign dollar percent ampersand quoteright '.
+          'parenleft parenright asterisk plus comma minus period slash zero one '.
+          'two three four five six seven eight nine colon semicolon less equal '.
+          'greater question at A B C D E F G H I J K L M N O P Q R S T U V W X '.
+          'Y Z bracketleft backslash bracketright asciicircum underscore '.
+          'quoteleft a b c d e f g h i j k l m n o p q r s t u v w x y z '.
+          'braceleft bar braceright asciitilde .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef dotlessi grave acute '.
+          'circumflex tilde macron breve dotaccent dieresis .notdef ring '.
+          'cedilla .notdef hungarumlaut ogonek caron space exclamdown cent '.
+          'sterling currency yen brokenbar section dieresis copyright '.
+          'ordfeminine guillemotleft logicalnot hyphen registered macron degree '.
+          'plusminus twosuperior threesuperior acute mu paragraph '.
+          'periodcentered cedilla onesuperior ordmasculine guillemotright '.
+          'onequarter onehalf threequarters questiondown Agrave Aacute '.
+          'Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute '.
+          'Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde '.
+          'Ograve Oacute Ocircumflex Otilde Odieresis multiply Oslash Ugrave '.
+          'Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute '.
+          'acircumflex atilde adieresis aring ae ccedilla egrave eacute '.
+          'ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde '.
+          'ograve oacute ocircumflex otilde odieresis divide oslash ugrave '.
           'uacute ucircumflex udieresis yacute thorn ydieresis';
 
         return explode(' ', $encoding);

--- a/src/Smalot/PdfParser/Encoding/ISOLatin9Encoding.php
+++ b/src/Smalot/PdfParser/Encoding/ISOLatin9Encoding.php
@@ -33,7 +33,7 @@
 namespace Smalot\PdfParser\Encoding;
 
 /**
- * Class ISOLatin9Encoding.
+ * Class ISOLatin9Encoding
  */
 class ISOLatin9Encoding
 {

--- a/src/Smalot/PdfParser/Encoding/ISOLatin9Encoding.php
+++ b/src/Smalot/PdfParser/Encoding/ISOLatin9Encoding.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 // Source : http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/ISOLatin9Encoding.pm
@@ -33,42 +33,40 @@
 namespace Smalot\PdfParser\Encoding;
 
 /**
- * Class ISOLatin9Encoding
- *
- * @package Smalot\PdfParser\Encoding
+ * Class ISOLatin9Encoding.
  */
 class ISOLatin9Encoding
 {
     public function getTranslations()
     {
         $encoding =
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          'space exclam quotedbl numbersign dollar percent ampersand quoteright ' .
-          'parenleft parenright asterisk plus comma minus period slash zero one ' .
-          'two three four five six seven eight nine colon semicolon less equal ' .
-          'greater question at A B C D E F G H I J K L M N O P Q R S T U V W X ' .
-          'Y Z bracketleft backslash bracketright asciicircum underscore ' .
-          'quoteleft a b c d e f g h i j k l m n o p q r s t u v w x y z ' .
-          'braceleft bar braceright asciitilde .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef dotlessi grave acute ' .
-          'circumflex tilde macron breve dotaccent dieresis .notdef ring ' .
-          'cedilla .notdef hungarumlaut ogonek caron space exclamdown cent ' .
-          'sterling Euro yen Scaron section scaron copyright ' .
-          'ordfeminine guillemotleft logicalnot hyphen registered macron degree ' .
-          'plusminus twosuperior threesuperior Zcaron mu paragraph ' .
-          'periodcentered zcaron onesuperior ordmasculine guillemotright ' .
-          'OE oe Ydieresis questiondown Agrave Aacute ' .
-          'Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute ' .
-          'Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde ' .
-          'Ograve Oacute Ocircumflex Otilde Odieresis multiply Oslash Ugrave ' .
-          'Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute ' .
-          'acircumflex atilde adieresis aring ae ccedilla egrave eacute ' .
-          'ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde ' .
-          'ograve oacute ocircumflex otilde odieresis divide oslash ugrave ' .
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          'space exclam quotedbl numbersign dollar percent ampersand quoteright '.
+          'parenleft parenright asterisk plus comma minus period slash zero one '.
+          'two three four five six seven eight nine colon semicolon less equal '.
+          'greater question at A B C D E F G H I J K L M N O P Q R S T U V W X '.
+          'Y Z bracketleft backslash bracketright asciicircum underscore '.
+          'quoteleft a b c d e f g h i j k l m n o p q r s t u v w x y z '.
+          'braceleft bar braceright asciitilde .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef dotlessi grave acute '.
+          'circumflex tilde macron breve dotaccent dieresis .notdef ring '.
+          'cedilla .notdef hungarumlaut ogonek caron space exclamdown cent '.
+          'sterling Euro yen Scaron section scaron copyright '.
+          'ordfeminine guillemotleft logicalnot hyphen registered macron degree '.
+          'plusminus twosuperior threesuperior Zcaron mu paragraph '.
+          'periodcentered zcaron onesuperior ordmasculine guillemotright '.
+          'OE oe Ydieresis questiondown Agrave Aacute '.
+          'Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute '.
+          'Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde '.
+          'Ograve Oacute Ocircumflex Otilde Odieresis multiply Oslash Ugrave '.
+          'Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute '.
+          'acircumflex atilde adieresis aring ae ccedilla egrave eacute '.
+          'ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde '.
+          'ograve oacute ocircumflex otilde odieresis divide oslash ugrave '.
           'uacute ucircumflex udieresis yacute thorn ydieresis';
 
         return explode(' ', $encoding);

--- a/src/Smalot/PdfParser/Encoding/MacRomanEncoding.php
+++ b/src/Smalot/PdfParser/Encoding/MacRomanEncoding.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 // Source : http://www.opensource.apple.com/source/vim/vim-34/vim/runtime/print/mac-roman.ps
@@ -33,46 +33,44 @@
 namespace Smalot\PdfParser\Encoding;
 
 /**
- * Class MacRomanEncoding
- *
- * @package Smalot\PdfParser\Encoding
+ * Class MacRomanEncoding.
  */
 class MacRomanEncoding
 {
     public function getTranslations()
     {
         $encoding =
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          'space exclam quotedbl numbersign dollar percent ampersand quotesingle ' .
-          'parenleft parenright asterisk plus comma minus period slash ' .
-          'zero one two three four five six seven ' .
-          'eight nine colon semicolon less equal greater question ' .
-          'at A B C D E F G ' .
-          'H I J K L M N O ' .
-          'P Q R S T U V W ' .
-          'X Y Z bracketleft backslash bracketright asciicircum underscore ' .
-          'grave a b c d e f g ' .
-          'h i j k l m n o ' .
-          'p q r s t u v w ' .
-          'x y z braceleft bar braceright asciitilde .notdef ' .
-          'Adieresis Aring Ccedilla Eacute Ntilde Odieresis Udieresis aacute ' .
-          'agrave acircumflex adieresis atilde aring ccedilla eacute egrave ' .
-          'ecircumflex edieresis iacute igrave icircumflex idieresis ntilde oacute ' .
-          'ograve ocircumflex odieresis otilde uacute ugrave ucircumflex udieresis ' .
-          'dagger degree cent sterling section bullet paragraph germandbls ' .
-          'registered copyright trademark acute dieresis notequal AE Oslash ' .
-          'infinity plusminus lessequal greaterequal yen mu partialdiff summation ' .
-          'Pi pi integral ordfeminine ordmasculine Omega ae oslash ' .
-          'questiondown exclamdown logicalnot radical florin approxequal delta guillemotleft ' .
-          'guillemotright ellipsis space Agrave Atilde Otilde OE oe ' .
-          'endash emdash quotedblleft quotedblright quoteleft quoteright divide lozenge ' .
-          'ydieresis Ydieresis fraction currency guilsinglleft guilsinglright fi fl ' .
-          'daggerdbl periodcentered quotesinglbase quotedblbase perthousand Acircumflex Ecircumflex Aacute ' .
-          'Edieresis Egrave Iacute Icircumflex Idieresis Igrave Oacute Ocircumflex ' .
-          'heart Ograve Uacute Ucircumflex Ugrave dotlessi circumflex tilde ' .
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          'space exclam quotedbl numbersign dollar percent ampersand quotesingle '.
+          'parenleft parenright asterisk plus comma minus period slash '.
+          'zero one two three four five six seven '.
+          'eight nine colon semicolon less equal greater question '.
+          'at A B C D E F G '.
+          'H I J K L M N O '.
+          'P Q R S T U V W '.
+          'X Y Z bracketleft backslash bracketright asciicircum underscore '.
+          'grave a b c d e f g '.
+          'h i j k l m n o '.
+          'p q r s t u v w '.
+          'x y z braceleft bar braceright asciitilde .notdef '.
+          'Adieresis Aring Ccedilla Eacute Ntilde Odieresis Udieresis aacute '.
+          'agrave acircumflex adieresis atilde aring ccedilla eacute egrave '.
+          'ecircumflex edieresis iacute igrave icircumflex idieresis ntilde oacute '.
+          'ograve ocircumflex odieresis otilde uacute ugrave ucircumflex udieresis '.
+          'dagger degree cent sterling section bullet paragraph germandbls '.
+          'registered copyright trademark acute dieresis notequal AE Oslash '.
+          'infinity plusminus lessequal greaterequal yen mu partialdiff summation '.
+          'Pi pi integral ordfeminine ordmasculine Omega ae oslash '.
+          'questiondown exclamdown logicalnot radical florin approxequal delta guillemotleft '.
+          'guillemotright ellipsis space Agrave Atilde Otilde OE oe '.
+          'endash emdash quotedblleft quotedblright quoteleft quoteright divide lozenge '.
+          'ydieresis Ydieresis fraction currency guilsinglleft guilsinglright fi fl '.
+          'daggerdbl periodcentered quotesinglbase quotedblbase perthousand Acircumflex Ecircumflex Aacute '.
+          'Edieresis Egrave Iacute Icircumflex Idieresis Igrave Oacute Ocircumflex '.
+          'heart Ograve Uacute Ucircumflex Ugrave dotlessi circumflex tilde '.
           'macron breve dotaccent ring cedilla hungarumlaut ogonek caron';
 
         return explode(' ', $encoding);

--- a/src/Smalot/PdfParser/Encoding/MacRomanEncoding.php
+++ b/src/Smalot/PdfParser/Encoding/MacRomanEncoding.php
@@ -33,7 +33,7 @@
 namespace Smalot\PdfParser\Encoding;
 
 /**
- * Class MacRomanEncoding.
+ * Class MacRomanEncoding
  */
 class MacRomanEncoding
 {

--- a/src/Smalot/PdfParser/Encoding/StandardEncoding.php
+++ b/src/Smalot/PdfParser/Encoding/StandardEncoding.php
@@ -33,7 +33,7 @@
 namespace Smalot\PdfParser\Encoding;
 
 /**
- * Class StandardEncoding.
+ * Class StandardEncoding
  */
 class StandardEncoding
 {

--- a/src/Smalot/PdfParser/Encoding/StandardEncoding.php
+++ b/src/Smalot/PdfParser/Encoding/StandardEncoding.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 // Source : http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/StandardEncoding.pm
@@ -33,42 +33,40 @@
 namespace Smalot\PdfParser\Encoding;
 
 /**
- * Class StandardEncoding
- *
- * @package Smalot\PdfParser\Encoding
+ * Class StandardEncoding.
  */
 class StandardEncoding
 {
     public function getTranslations()
     {
         $encoding =
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          'space exclam quotedbl numbersign dollar percent ampersand quoteright ' .
-          'parenleft parenright asterisk plus comma hyphen period slash zero ' .
-          'one two three four five six seven eight nine colon semicolon less ' .
-          'equal greater question at A B C D E F G H I J K L M N O P Q R S T U ' .
-          'V W X Y Z bracketleft backslash bracketright asciicircum underscore ' .
-          'quoteleft a b c d e f g h i j k l m n o p q r s t u v w x y z ' .
-          'braceleft bar braceright asciitilde .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef exclamdown cent ' .
-          'sterling fraction yen florin section currency quotesingle ' .
-          'quotedblleft guillemotleft guilsinglleft guilsinglright fi fl ' .
-          '.notdef endash dagger daggerdbl periodcentered .notdef paragraph ' .
-          'bullet quotesinglbase quotedblbase quotedblright guillemotright ' .
-          'ellipsis perthousand .notdef questiondown .notdef grave acute ' .
-          'circumflex tilde macron breve dotaccent dieresis .notdef ring ' .
-          'cedilla .notdef hungarumlaut ogonek caron emdash .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef AE .notdef ' .
-          'ordfeminine .notdef .notdef .notdef .notdef Lslash Oslash OE ' .
-          'ordmasculine .notdef .notdef .notdef .notdef .notdef ae .notdef ' .
-          '.notdef .notdef dotlessi .notdef .notdef lslash oslash oe germandbls ' .
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          'space exclam quotedbl numbersign dollar percent ampersand quoteright '.
+          'parenleft parenright asterisk plus comma hyphen period slash zero '.
+          'one two three four five six seven eight nine colon semicolon less '.
+          'equal greater question at A B C D E F G H I J K L M N O P Q R S T U '.
+          'V W X Y Z bracketleft backslash bracketright asciicircum underscore '.
+          'quoteleft a b c d e f g h i j k l m n o p q r s t u v w x y z '.
+          'braceleft bar braceright asciitilde .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef exclamdown cent '.
+          'sterling fraction yen florin section currency quotesingle '.
+          'quotedblleft guillemotleft guilsinglleft guilsinglright fi fl '.
+          '.notdef endash dagger daggerdbl periodcentered .notdef paragraph '.
+          'bullet quotesinglbase quotedblbase quotedblright guillemotright '.
+          'ellipsis perthousand .notdef questiondown .notdef grave acute '.
+          'circumflex tilde macron breve dotaccent dieresis .notdef ring '.
+          'cedilla .notdef hungarumlaut ogonek caron emdash .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef AE .notdef '.
+          'ordfeminine .notdef .notdef .notdef .notdef Lslash Oslash OE '.
+          'ordmasculine .notdef .notdef .notdef .notdef .notdef ae .notdef '.
+          '.notdef .notdef dotlessi .notdef .notdef lslash oslash oe germandbls '.
           '.notdef .notdef .notdef .notdef';
 
         return explode(' ', $encoding);

--- a/src/Smalot/PdfParser/Encoding/WinAnsiEncoding.php
+++ b/src/Smalot/PdfParser/Encoding/WinAnsiEncoding.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 // Source : http://cpansearch.perl.org/src/JV/PostScript-Font-1.10.02/lib/PostScript/WinANSIEncoding.pm
@@ -33,42 +33,40 @@
 namespace Smalot\PdfParser\Encoding;
 
 /**
- * Class WinAnsiEncoding
- *
- * @package Smalot\PdfParser\Encoding
+ * Class WinAnsiEncoding.
  */
 class WinAnsiEncoding
 {
     public function getTranslations()
     {
         $encoding =
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef ' .
-          'space exclam quotedbl numbersign dollar percent ampersand quotesingle ' .
-          'parenleft parenright asterisk plus comma hyphen period slash zero one ' .
-          'two three four five six seven eight nine colon semicolon less equal ' .
-          'greater question at A B C D E F G H I J K L M N O P Q R S T U V W X ' .
-          'Y Z bracketleft backslash bracketright asciicircum underscore ' .
-          'grave a b c d e f g h i j k l m n o p q r s t u v w x y z ' .
-          'braceleft bar braceright asciitilde bullet Euro bullet quotesinglbase ' .
-          'florin quotedblbase ellipsis dagger daggerdbl circumflex perthousand ' .
-          'Scaron guilsinglleft OE bullet Zcaron bullet bullet quoteleft quoteright ' .
-          'quotedblleft quotedblright bullet endash emdash tilde trademark scaron ' .
-          'guilsinglright oe bullet zcaron Ydieresis space exclamdown cent ' .
-          'sterling currency yen brokenbar section dieresis copyright ' .
-          'ordfeminine guillemotleft logicalnot hyphen registered macron degree ' .
-          'plusminus twosuperior threesuperior acute mu paragraph ' .
-          'periodcentered cedilla onesuperior ordmasculine guillemotright ' .
-          'onequarter onehalf threequarters questiondown Agrave Aacute ' .
-          'Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute ' .
-          'Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde ' .
-          'Ograve Oacute Ocircumflex Otilde Odieresis multiply Oslash Ugrave ' .
-          'Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute ' .
-          'acircumflex atilde adieresis aring ae ccedilla egrave eacute ' .
-          'ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde ' .
-          'ograve oacute ocircumflex otilde odieresis divide oslash ugrave ' .
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          '.notdef .notdef .notdef .notdef .notdef .notdef .notdef .notdef '.
+          'space exclam quotedbl numbersign dollar percent ampersand quotesingle '.
+          'parenleft parenright asterisk plus comma hyphen period slash zero one '.
+          'two three four five six seven eight nine colon semicolon less equal '.
+          'greater question at A B C D E F G H I J K L M N O P Q R S T U V W X '.
+          'Y Z bracketleft backslash bracketright asciicircum underscore '.
+          'grave a b c d e f g h i j k l m n o p q r s t u v w x y z '.
+          'braceleft bar braceright asciitilde bullet Euro bullet quotesinglbase '.
+          'florin quotedblbase ellipsis dagger daggerdbl circumflex perthousand '.
+          'Scaron guilsinglleft OE bullet Zcaron bullet bullet quoteleft quoteright '.
+          'quotedblleft quotedblright bullet endash emdash tilde trademark scaron '.
+          'guilsinglright oe bullet zcaron Ydieresis space exclamdown cent '.
+          'sterling currency yen brokenbar section dieresis copyright '.
+          'ordfeminine guillemotleft logicalnot hyphen registered macron degree '.
+          'plusminus twosuperior threesuperior acute mu paragraph '.
+          'periodcentered cedilla onesuperior ordmasculine guillemotright '.
+          'onequarter onehalf threequarters questiondown Agrave Aacute '.
+          'Acircumflex Atilde Adieresis Aring AE Ccedilla Egrave Eacute '.
+          'Ecircumflex Edieresis Igrave Iacute Icircumflex Idieresis Eth Ntilde '.
+          'Ograve Oacute Ocircumflex Otilde Odieresis multiply Oslash Ugrave '.
+          'Uacute Ucircumflex Udieresis Yacute Thorn germandbls agrave aacute '.
+          'acircumflex atilde adieresis aring ae ccedilla egrave eacute '.
+          'ecircumflex edieresis igrave iacute icircumflex idieresis eth ntilde '.
+          'ograve oacute ocircumflex otilde odieresis divide oslash ugrave '.
           'uacute ucircumflex udieresis yacute thorn ydieresis';
 
         return explode(' ', $encoding);

--- a/src/Smalot/PdfParser/Encoding/WinAnsiEncoding.php
+++ b/src/Smalot/PdfParser/Encoding/WinAnsiEncoding.php
@@ -33,7 +33,7 @@
 namespace Smalot\PdfParser\Encoding;
 
 /**
- * Class WinAnsiEncoding.
+ * Class WinAnsiEncoding
  */
 class WinAnsiEncoding
 {

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -31,7 +31,7 @@
 namespace Smalot\PdfParser;
 
 /**
- * Class Font.
+ * Class Font
  */
 class Font extends PDFObject
 {

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -95,7 +95,7 @@ class Font extends PDFObject
     {
         $dec = hexdec(bin2hex($char));
 
-        if (array_key_exists($dec, $this->table)) {
+        if (\array_key_exists($dec, $this->table)) {
             $char = $this->table[$dec];
         } else {
             $char = ($use_default ? self::MISSING : $char);
@@ -119,7 +119,7 @@ class Font extends PDFObject
      */
     public function loadTranslateTable()
     {
-        if (!is_null($this->table)) {
+        if (null !== $this->table) {
             return $this->table;
         }
 
@@ -141,8 +141,8 @@ class Font extends PDFObject
                     preg_match_all($regexp, $section, $matches);
 
                     $this->tableSizes = [
-                        'from' => max(1, strlen(current($matches['from'])) / 2),
-                        'to' => max(1, strlen(current($matches['to'])) / 2),
+                        'from' => max(1, \strlen(current($matches['from'])) / 2),
+                        'to' => max(1, \strlen(current($matches['to'])) / 2),
                     ];
 
                     break;
@@ -156,7 +156,7 @@ class Font extends PDFObject
 
                     preg_match_all($regexp, $section, $matches);
 
-                    $this->tableSizes['from'] = max(1, strlen(current($matches['from'])) / 2);
+                    $this->tableSizes['from'] = max(1, \strlen(current($matches['from'])) / 2);
 
                     foreach ($matches['from'] as $key => $from) {
                         $parts = preg_split(
@@ -282,7 +282,7 @@ class Font extends PDFObject
 
         foreach ($parts as $part) {
             if (preg_match('/^\\\\\d{3}$/', $part)) {
-                $text .= chr(octdec(trim($part, '\\')));
+                $text .= \chr(octdec(trim($part, '\\')));
             } else {
                 $text .= $part;
             }
@@ -303,7 +303,7 @@ class Font extends PDFObject
 
         foreach ($parts as $part) {
             if (preg_match('/^#\d{2}$/', $part)) {
-                $text .= chr(hexdec(trim($part, '#')));
+                $text .= \chr(hexdec(trim($part, '#')));
             } else {
                 $text .= $part;
             }
@@ -323,7 +323,7 @@ class Font extends PDFObject
             // Strip U+FEFF byte order marker.
             $decode = substr($text, 2);
             $text = '';
-            $length = strlen($decode);
+            $length = \strlen($decode);
 
             for ($i = 0; $i < $length; $i += 2) {
                 $text .= self::uchr(hexdec(bin2hex(substr($decode, $i, 2))));
@@ -356,8 +356,8 @@ class Font extends PDFObject
         foreach ($commands as $command) {
             switch ($command[PDFObject::TYPE]) {
                 case 'n':
-                    if (floatval(trim($command[PDFObject::COMMAND])) < $font_space) {
-                        $word_position = count($words);
+                    if ((float) (trim($command[PDFObject::COMMAND])) < $font_space) {
+                        $word_position = \count($words);
                     }
                     continue 2;
 
@@ -408,7 +408,7 @@ class Font extends PDFObject
 
             if ($bytes) {
                 $result = '';
-                $length = strlen($text);
+                $length = \strlen($text);
 
                 for ($i = 0; $i < $length; $i += $bytes) {
                     $char = substr($text, $i, $bytes);
@@ -424,7 +424,7 @@ class Font extends PDFObject
                         $decoded = false;
 
                         foreach ($fonts as $font) {
-                            if ($font instanceof Font) {
+                            if ($font instanceof self) {
                                 if (false !== ($decoded = $font->translateChar($char, false))) {
                                     $decoded = mb_convert_encoding($decoded, 'UTF-8', 'Windows-1252');
                                     break;
@@ -472,12 +472,12 @@ class Font extends PDFObject
                     $text = $result;
                 } else {
                     $result = '';
-                    $length = strlen($text);
+                    $length = \strlen($text);
 
                     for ($i = 0; $i < $length; ++$i) {
                         $dec_av = hexdec(bin2hex($text[$i]));
                         $dec_ap = $encoding->translateChar($dec_av);
-                        $result .= chr($dec_ap);
+                        $result .= \chr($dec_ap);
                     }
 
                     $text = $result;

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,21 +26,15 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser;
 
 /**
- * Class Font
- *
- * @package Smalot\PdfParser
+ * Class Font.
  */
 class Font extends PDFObject
 {
-    /**
-     *
-     */
     const MISSING = '?';
 
     /**
@@ -52,10 +47,7 @@ class Font extends PDFObject
      */
     protected $tableSizes = null;
 
-    /**
-     *
-     */
-    public function init()
+    public function init(): void
     {
         // Load translate table.
         $this->loadTranslateTable();
@@ -66,7 +58,7 @@ class Font extends PDFObject
      */
     public function getName()
     {
-        return $this->has('BaseFont') ? (string)$this->get('BaseFont') : '[Unknown]';
+        return $this->has('BaseFont') ? (string) $this->get('BaseFont') : '[Unknown]';
     }
 
     /**
@@ -74,7 +66,7 @@ class Font extends PDFObject
      */
     public function getType()
     {
-        return (string)$this->header->get('Subtype');
+        return (string) $this->header->get('Subtype');
     }
 
     /**
@@ -82,11 +74,11 @@ class Font extends PDFObject
      */
     public function getDetails($deep = true)
     {
-        $details = array();
+        $details = [];
 
-        $details['Name']     = $this->getName();
-        $details['Type']     = $this->getType();
-        $details['Encoding'] = ($this->has('Encoding') ? (string)$this->get('Encoding') : 'Ansi');
+        $details['Name'] = $this->getName();
+        $details['Type'] = $this->getType();
+        $details['Encoding'] = ($this->has('Encoding') ? (string) $this->get('Encoding') : 'Ansi');
 
         $details += parent::getDetails($deep);
 
@@ -119,7 +111,7 @@ class Font extends PDFObject
      */
     public static function uchr($code)
     {
-        return html_entity_decode('&#' . ((int)$code) . ';', ENT_NOQUOTES, 'UTF-8');
+        return html_entity_decode('&#'.((int) $code).';', ENT_NOQUOTES, 'UTF-8');
     }
 
     /**
@@ -131,15 +123,15 @@ class Font extends PDFObject
             return $this->table;
         }
 
-        $this->table      = array();
-        $this->tableSizes = array(
+        $this->table = [];
+        $this->tableSizes = [
             'from' => 1,
-            'to'   => 1,
-        );
+            'to' => 1,
+        ];
 
         if ($this->has('ToUnicode')) {
             $content = $this->get('ToUnicode')->getContent();
-            $matches = array();
+            $matches = [];
 
             // Support for multiple spacerange sections
             if (preg_match_all('/begincodespacerange(?P<sections>.*?)endcodespacerange/s', $content, $matches)) {
@@ -148,10 +140,10 @@ class Font extends PDFObject
 
                     preg_match_all($regexp, $section, $matches);
 
-                    $this->tableSizes = array(
+                    $this->tableSizes = [
                         'from' => max(1, strlen(current($matches['from'])) / 2),
-                        'to'   => max(1, strlen(current($matches['to'])) / 2),
-                    );
+                        'to' => max(1, strlen(current($matches['to'])) / 2),
+                    ];
 
                     break;
                 }
@@ -173,7 +165,7 @@ class Font extends PDFObject
                             0,
                             PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE
                         );
-                        $text  = '';
+                        $text = '';
                         foreach ($parts as $part) {
                             $text .= self::uchr(hexdec($part));
                         }
@@ -192,10 +184,10 @@ class Font extends PDFObject
 
                     foreach ($matches['from'] as $key => $from) {
                         $char_from = hexdec($from);
-                        $char_to   = hexdec($matches['to'][$key]);
-                        $offset    = hexdec($matches['offset'][$key]);
+                        $char_to = hexdec($matches['to'][$key]);
+                        $offset = hexdec($matches['offset'][$key]);
 
-                        for ($char = $char_from; $char <= $char_to; $char++) {
+                        for ($char = $char_from; $char <= $char_to; ++$char) {
                             $this->table[$char] = self::uchr($char - $char_from + $offset);
                         }
                     }
@@ -208,7 +200,7 @@ class Font extends PDFObject
 
                     foreach ($matches['from'] as $key => $from) {
                         $char_from = hexdec($from);
-                        $strings   = array();
+                        $strings = [];
 
                         preg_match_all('/<(?P<string>[0-9A-F]+)> */is', $matches['strings'][$key], $strings);
 
@@ -219,7 +211,7 @@ class Font extends PDFObject
                                 0,
                                 PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE
                             );
-                            $text  = '';
+                            $text = '';
                             foreach ($parts as $part) {
                                 $text .= self::uchr(hexdec($part));
                             }
@@ -236,7 +228,7 @@ class Font extends PDFObject
     /**
      * @param array $table
      */
-    public function setTable($table)
+    public function setTable($table): void
     {
         $this->table = $table;
     }
@@ -250,15 +242,15 @@ class Font extends PDFObject
     public static function decodeHexadecimal($hexa, $add_braces = false)
     {
         // Special shortcut for XML content.
-        if (stripos($hexa, '<?xml') !== false) {
+        if (false !== stripos($hexa, '<?xml')) {
             return $hexa;
         }
 
-        $text  = '';
+        $text = '';
         $parts = preg_split('/(<[a-f0-9]+>)/si', $hexa, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 
         foreach ($parts as $part) {
-            if (preg_match('/^<.*>$/', $part) && stripos($part, '<?xml') === false) {
+            if (preg_match('/^<.*>$/', $part) && false === stripos($part, '<?xml')) {
                 $part = trim($part, '<>');
                 if ($add_braces) {
                     $text .= '(';
@@ -286,7 +278,7 @@ class Font extends PDFObject
     public static function decodeOctal($text)
     {
         $parts = preg_split('/(\\\\\d{3})/s', $text, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
-        $text  = '';
+        $text = '';
 
         foreach ($parts as $part) {
             if (preg_match('/^\\\\\d{3}$/', $part)) {
@@ -307,7 +299,7 @@ class Font extends PDFObject
     public static function decodeEntities($text)
     {
         $parts = preg_split('/(#\d{2})/s', $text, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
-        $text  = '';
+        $text = '';
 
         foreach ($parts as $part) {
             if (preg_match('/^#\d{2}$/', $part)) {
@@ -330,7 +322,7 @@ class Font extends PDFObject
         if (preg_match('/^\xFE\xFF/i', $text)) {
             // Strip U+FEFF byte order marker.
             $decode = substr($text, 2);
-            $text   = '';
+            $text = '';
             $length = strlen($decode);
 
             for ($i = 0; $i < $length; $i += 2) {
@@ -357,9 +349,9 @@ class Font extends PDFObject
     public function decodeText($commands)
     {
         $word_position = 0;
-        $words         = array();
-        $unicode       = false;
-        $font_space    = $this->getFontSpaceLimit();
+        $words = [];
+        $unicode = false;
+        $font_space = $this->getFontSpaceLimit();
 
         foreach ($commands as $command) {
             switch ($command[PDFObject::TYPE]) {
@@ -367,13 +359,13 @@ class Font extends PDFObject
                     if (floatval(trim($command[PDFObject::COMMAND])) < $font_space) {
                         $word_position = count($words);
                     }
-                    continue(2);
+                    continue 2;
 
                 case '<':
                     // Decode hexadecimal.
-                    $text = self::decodeHexadecimal('<' . $command[PDFObject::COMMAND] . '>');
+                    $text = self::decodeHexadecimal('<'.$command[PDFObject::COMMAND].'>');
 
-                    if (mb_check_encoding($text, "UTF-8")) {
+                    if (mb_check_encoding($text, 'UTF-8')) {
                         $unicode = true;
                     }
 
@@ -397,7 +389,7 @@ class Font extends PDFObject
 
         foreach ($words as &$word) {
             $loop_unicode = $unicode;
-            $word         = $this->decodeContent($word, $loop_unicode);
+            $word = $this->decodeContent($word, $loop_unicode);
         }
 
         return implode(' ', $words);
@@ -412,7 +404,6 @@ class Font extends PDFObject
     protected function decodeContent($text, &$unicode)
     {
         if ($this->has('ToUnicode')) {
-
             $bytes = $this->tableSizes['from'];
 
             if ($bytes) {
@@ -422,27 +413,26 @@ class Font extends PDFObject
                 for ($i = 0; $i < $length; $i += $bytes) {
                     $char = substr($text, $i, $bytes);
 
-                    if (($decoded = $this->translateChar($char, false)) !== false) {
+                    if (false !== ($decoded = $this->translateChar($char, false))) {
                         $char = $decoded;
                     } elseif ($this->has('DescendantFonts')) {
-
                         if ($this->get('DescendantFonts') instanceof PDFObject) {
-                            $fonts   = $this->get('DescendantFonts')->getHeader()->getElements();
+                            $fonts = $this->get('DescendantFonts')->getHeader()->getElements();
                         } else {
-                            $fonts   = $this->get('DescendantFonts')->getContent();
+                            $fonts = $this->get('DescendantFonts')->getContent();
                         }
                         $decoded = false;
 
                         foreach ($fonts as $font) {
                             if ($font instanceof Font) {
-                                if (($decoded = $font->translateChar($char, false)) !== false) {
+                                if (false !== ($decoded = $font->translateChar($char, false))) {
                                     $decoded = mb_convert_encoding($decoded, 'UTF-8', 'Windows-1252');
                                     break;
                                 }
                             }
                         }
 
-                        if ($decoded !== false) {
+                        if (false !== $decoded) {
                             $char = $decoded;
                         } else {
                             $char = mb_convert_encoding($char, 'UTF-8', 'Windows-1252');
@@ -465,8 +455,8 @@ class Font extends PDFObject
 
             if ($encoding instanceof Encoding) {
                 if ($unicode) {
-                    $chars  = preg_split(
-                        '//s' . ($unicode ? 'u' : ''),
+                    $chars = preg_split(
+                        '//s'.($unicode ? 'u' : ''),
                         $text,
                         -1,
                         PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
@@ -484,7 +474,7 @@ class Font extends PDFObject
                     $result = '';
                     $length = strlen($text);
 
-                    for ($i = 0; $i < $length; $i++) {
+                    for ($i = 0; $i < $length; ++$i) {
                         $dec_av = hexdec(bin2hex($text[$i]));
                         $dec_ap = $encoding->translateChar($dec_av);
                         $result .= chr($dec_ap);
@@ -503,7 +493,6 @@ class Font extends PDFObject
 
         // Convert to unicode if not already done.
         if (!$unicode) {
-
             if ($this->get('Encoding') instanceof Element &&
                 $this->get('Encoding')->equals('MacRomanEncoding')
             ) {

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -47,7 +47,7 @@ class Font extends PDFObject
      */
     protected $tableSizes = null;
 
-    public function init(): void
+    public function init()
     {
         // Load translate table.
         $this->loadTranslateTable();
@@ -228,7 +228,7 @@ class Font extends PDFObject
     /**
      * @param array $table
      */
-    public function setTable($table): void
+    public function setTable($table)
     {
         $this->table = $table;
     }

--- a/src/Smalot/PdfParser/Font/FontCIDFontType0.php
+++ b/src/Smalot/PdfParser/Font/FontCIDFontType0.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Font;
@@ -33,9 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontCIDFontType0
- *
- * @package Smalot\PdfParser\Font
+ * Class FontCIDFontType0.
  */
 class FontCIDFontType0 extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontCIDFontType0.php
+++ b/src/Smalot/PdfParser/Font/FontCIDFontType0.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontCIDFontType0.
+ * Class FontCIDFontType0
  */
 class FontCIDFontType0 extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontCIDFontType2.php
+++ b/src/Smalot/PdfParser/Font/FontCIDFontType2.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontCIDFontType2.
+ * Class FontCIDFontType2
  */
 class FontCIDFontType2 extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontCIDFontType2.php
+++ b/src/Smalot/PdfParser/Font/FontCIDFontType2.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Font;
@@ -33,9 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontCIDFontType2
- *
- * @package Smalot\PdfParser\Font
+ * Class FontCIDFontType2.
  */
 class FontCIDFontType2 extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontTrueType.php
+++ b/src/Smalot/PdfParser/Font/FontTrueType.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontTrueType.
+ * Class FontTrueType
  */
 class FontTrueType extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontTrueType.php
+++ b/src/Smalot/PdfParser/Font/FontTrueType.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Font;
@@ -33,9 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontTrueType
- *
- * @package Smalot\PdfParser\Font
+ * Class FontTrueType.
  */
 class FontTrueType extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontType0.php
+++ b/src/Smalot/PdfParser/Font/FontType0.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Font;
@@ -33,9 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontType0
- *
- * @package Smalot\PdfParser\Font
+ * Class FontType0.
  */
 class FontType0 extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontType0.php
+++ b/src/Smalot/PdfParser/Font/FontType0.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontType0.
+ * Class FontType0
  */
 class FontType0 extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontType1.php
+++ b/src/Smalot/PdfParser/Font/FontType1.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontType1.
+ * Class FontType1
  */
 class FontType1 extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontType1.php
+++ b/src/Smalot/PdfParser/Font/FontType1.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Font;
@@ -33,9 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontType1
- *
- * @package Smalot\PdfParser\Font
+ * Class FontType1.
  */
 class FontType1 extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontType3.php
+++ b/src/Smalot/PdfParser/Font/FontType3.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontType3.
+ * Class FontType3
  */
 class FontType3 extends Font
 {

--- a/src/Smalot/PdfParser/Font/FontType3.php
+++ b/src/Smalot/PdfParser/Font/FontType3.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Font;
@@ -33,9 +33,7 @@ namespace Smalot\PdfParser\Font;
 use Smalot\PdfParser\Font;
 
 /**
- * Class FontType3
- *
- * @package Smalot\PdfParser\Font
+ * Class FontType3.
  */
 class FontType3 extends Font
 {

--- a/src/Smalot/PdfParser/Header.php
+++ b/src/Smalot/PdfParser/Header.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser;
@@ -36,9 +36,7 @@ use Smalot\PdfParser\Element\ElementStruct;
 use Smalot\PdfParser\Element\ElementXRef;
 
 /**
- * Class Header
- *
- * @package Smalot\PdfParser
+ * Class Header.
  */
 class Header
 {
@@ -53,10 +51,10 @@ class Header
     protected $elements = null;
 
     /**
-     * @param Element[] $elements   List of elements.
-     * @param Document  $document   Document.
+     * @param Element[] $elements list of elements
+     * @param Document  $document document
      */
-    public function __construct($elements = array(), Document $document = null)
+    public function __construct($elements = [], Document $document = null)
     {
         $this->elements = $elements;
         $this->document = $document;
@@ -64,8 +62,6 @@ class Header
 
     /**
      * Returns all elements.
-     *
-     * @return mixed
      */
     public function getElements()
     {
@@ -83,7 +79,7 @@ class Header
      */
     public function getElementTypes()
     {
-        $types = array();
+        $types = [];
 
         foreach ($this->elements as $key => $element) {
             $types[$key] = get_class($element);
@@ -99,7 +95,7 @@ class Header
      */
     public function getDetails($deep = true)
     {
-        $values   = array();
+        $values = [];
         $elements = $this->getElements();
 
         foreach ($elements as $key => $element) {
@@ -155,6 +151,7 @@ class Header
      * @param string $name
      *
      * @return Element|PDFObject
+     *
      * @throws \Exception
      */
     protected function resolveXRef($name)
@@ -183,15 +180,15 @@ class Header
      */
     public static function parse($content, Document $document, &$position = 0)
     {
-        /** @var Header $header */
-        if (substr(trim($content), 0, 2) == '<<') {
+        /* @var Header $header */
+        if ('<<' == substr(trim($content), 0, 2)) {
             $header = ElementStruct::parse($content, $document, $position);
         } else {
             $elements = ElementArray::parse($content, $document, $position);
             if ($elements) {
-                $header = new self($elements->getRawContent(), null);//$document);
+                $header = new self($elements->getRawContent(), null); //$document);
             } else {
-                $header = new self(array(), $document);
+                $header = new self([], $document);
             }
         }
 
@@ -199,7 +196,7 @@ class Header
             return $header;
         } else {
             // Build an empty header.
-            return new self(array(), $document);
+            return new self([], $document);
         }
     }
 }

--- a/src/Smalot/PdfParser/Header.php
+++ b/src/Smalot/PdfParser/Header.php
@@ -82,7 +82,7 @@ class Header
         $types = [];
 
         foreach ($this->elements as $key => $element) {
-            $types[$key] = get_class($element);
+            $types[$key] = \get_class($element);
         }
 
         return $types;
@@ -99,7 +99,7 @@ class Header
         $elements = $this->getElements();
 
         foreach ($elements as $key => $element) {
-            if ($element instanceof Header && $deep) {
+            if ($element instanceof self && $deep) {
                 $values[$key] = $element->getDetails($deep);
             } elseif ($element instanceof PDFObject && $deep) {
                 $values[$key] = $element->getDetails(false);
@@ -124,7 +124,7 @@ class Header
      */
     public function has($name)
     {
-        if (array_key_exists($name, $this->elements)) {
+        if (\array_key_exists($name, $this->elements)) {
             return true;
         } else {
             return false;
@@ -138,7 +138,7 @@ class Header
      */
     public function get($name)
     {
-        if (array_key_exists($name, $this->elements)) {
+        if (\array_key_exists($name, $this->elements)) {
             return $this->resolveXRef($name);
         }
 
@@ -156,11 +156,11 @@ class Header
      */
     protected function resolveXRef($name)
     {
-        if (($obj = $this->elements[$name]) instanceof ElementXRef && !is_null($this->document)) {
+        if (($obj = $this->elements[$name]) instanceof ElementXRef && null !== $this->document) {
             /** @var ElementXRef $obj */
             $object = $this->document->getObjectById($obj->getId());
 
-            if (is_null($object)) {
+            if (null === $object) {
                 return new ElementMissing(null, null);
             }
 

--- a/src/Smalot/PdfParser/Header.php
+++ b/src/Smalot/PdfParser/Header.php
@@ -36,7 +36,7 @@ use Smalot\PdfParser\Element\ElementStruct;
 use Smalot\PdfParser\Element\ElementXRef;
 
 /**
- * Class Header.
+ * Class Header
  */
 class Header
 {

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -73,7 +73,7 @@ class PDFObject
     public function __construct(Document $document, Header $header = null, $content = null)
     {
         $this->document = $document;
-        $this->header = !is_null($header) ? $header : new Header();
+        $this->header = null !== $header ? $header : new Header();
         $this->content = $content;
     }
 
@@ -138,19 +138,19 @@ class PDFObject
         // Remove image bloc with binary content
         preg_match_all('/\s(BI\s.*?(\sID\s).*?(\sEI))\s/s', $content, $matches, PREG_OFFSET_CAPTURE);
         foreach ($matches[0] as $part) {
-            $content = substr_replace($content, str_repeat($char, strlen($part[0])), $part[1], strlen($part[0]));
+            $content = substr_replace($content, str_repeat($char, \strlen($part[0])), $part[1], \strlen($part[0]));
         }
 
         // Clean content in square brackets [.....]
         preg_match_all('/\[((\(.*?\)|[0-9\.\-\s]*)*)\]/s', $content, $matches, PREG_OFFSET_CAPTURE);
         foreach ($matches[1] as $part) {
-            $content = substr_replace($content, str_repeat($char, strlen($part[0])), $part[1], strlen($part[0]));
+            $content = substr_replace($content, str_repeat($char, \strlen($part[0])), $part[1], \strlen($part[0]));
         }
 
         // Clean content in round brackets (.....)
         preg_match_all('/\((.*?)\)/s', $content, $matches, PREG_OFFSET_CAPTURE);
         foreach ($matches[1] as $part) {
-            $content = substr_replace($content, str_repeat($char, strlen($part[0])), $part[1], strlen($part[0]));
+            $content = substr_replace($content, str_repeat($char, \strlen($part[0])), $part[1], \strlen($part[0]));
         }
 
         // Clean structure
@@ -162,7 +162,7 @@ class PDFObject
                     ++$level;
                 }
 
-                $content .= (0 == $level ? $part : str_repeat($char, strlen($part)));
+                $content .= (0 == $level ? $part : str_repeat($char, \strlen($part)));
 
                 if ('>' == $part) {
                     --$level;
@@ -178,12 +178,12 @@ class PDFObject
             PREG_OFFSET_CAPTURE
         );
         foreach ($matches[1] as $part) {
-            $content = substr_replace($content, str_repeat($char, strlen($part[0])), $part[1], strlen($part[0]));
+            $content = substr_replace($content, str_repeat($char, \strlen($part[0])), $part[1], \strlen($part[0]));
         }
 
         preg_match_all('/\s(EMC)\s/s', $content, $matches, PREG_OFFSET_CAPTURE);
         foreach ($matches[1] as $part) {
-            $content = substr_replace($content, str_repeat($char, strlen($part[0])), $part[1], strlen($part[0]));
+            $content = substr_replace($content, str_repeat($char, \strlen($part[0])), $part[1], \strlen($part[0]));
         }
 
         return $content;
@@ -208,7 +208,7 @@ class PDFObject
                     continue;
                 }
                 $offset = $part[1];
-                $section = substr($content, $offset, strlen($text));
+                $section = substr($content, $offset, \strlen($text));
 
                 // Removes BDC and EMC markup.
                 $section = preg_replace('/(\/[A-Za-z0-9]+\s*<<.*?)(>>\s*BDC)(.*?)(EMC\s+)/s', '${3}', $section.' ');
@@ -222,7 +222,7 @@ class PDFObject
             foreach ($matches[1] as $part) {
                 $text = $part[0];
                 $offset = $part[1];
-                $section = substr($content, $offset, strlen($text));
+                $section = substr($content, $offset, \strlen($text));
 
                 $sections[] = $section;
             }
@@ -274,12 +274,12 @@ class PDFObject
                         $args = preg_split('/\s/s', $command[self::COMMAND]);
                         $y = array_pop($args);
                         $x = array_pop($args);
-                        if ((floatval($x) <= 0) ||
-                            (false !== $current_position_td['y'] && floatval($y) < floatval($current_position_td['y']))
+                        if (((float) $x <= 0) ||
+                            (false !== $current_position_td['y'] && (float) $y < (float) ($current_position_td['y']))
                         ) {
                             // vertical offset
                             $text .= "\n";
-                        } elseif (false !== $current_position_td['x'] && floatval($x) > floatval(
+                        } elseif (false !== $current_position_td['x'] && (float) $x > (float) (
                                 $current_position_td['x']
                             )
                         ) {
@@ -294,9 +294,9 @@ class PDFObject
                         $args = preg_split('/\s/s', $command[self::COMMAND]);
                         $y = array_pop($args);
                         $x = array_pop($args);
-                        if (floatval($y) < 0) {
+                        if ((float) $y < 0) {
                             $text .= "\n";
-                        } elseif (floatval($x) <= 0) {
+                        } elseif ((float) $x <= 0) {
                             $text .= ' ';
                         }
                         break;
@@ -304,7 +304,7 @@ class PDFObject
                     case 'Tf':
                         list($id) = preg_split('/\s/s', $command[self::COMMAND]);
                         $id = trim($id, '/');
-                        if (!is_null($page)) {
+                        if (null !== $page) {
                             $current_font = $page->getFont($id);
                         }
                         break;
@@ -315,7 +315,7 @@ class PDFObject
                         // no break
                     case 'TJ':
                         // Skip if not previously defined, should never happened.
-                        if (is_null($current_font)) {
+                        if (null === $current_font) {
                             // Fallback
                             // TODO : Improve
                             $text .= $command[self::COMMAND][0][self::COMMAND];
@@ -336,13 +336,13 @@ class PDFObject
                         $y = array_pop($args);
                         $x = array_pop($args);
                         if (false !== $current_position_tm['x']) {
-                            $delta = abs(floatval($x) - floatval($current_position_tm['x']));
+                            $delta = abs((float) $x - (float) ($current_position_tm['x']));
                             if ($delta > 10) {
                                 $text .= "\t";
                             }
                         }
                         if (false !== $current_position_tm['y']) {
-                            $delta = abs(floatval($y) - floatval($current_position_tm['y']));
+                            $delta = abs((float) $y - (float) ($current_position_tm['y']));
                             if ($delta > 10) {
                                 $text .= "\n";
                             }
@@ -372,13 +372,13 @@ class PDFObject
                         break;
 
                     case 'Do':
-                        if (!is_null($page)) {
+                        if (null !== $page) {
                             $args = preg_split('/\s/s', $command[self::COMMAND]);
                             $id = trim(array_pop($args), '/ ');
                             $xobject = $page->getXObject($id);
 
                             // @todo $xobject could be a ElementXRef object, which would then throw an error
-                            if (is_object($xobject) && $xobject instanceof PDFObject && !in_array($xobject->getUniqueId(), self::$recursionStack)) {
+                            if (\is_object($xobject) && $xobject instanceof self && !\in_array($xobject->getUniqueId(), self::$recursionStack)) {
                                 // Not a circular reference.
                                 $text .= $xobject->getText($page);
                             }
@@ -471,7 +471,7 @@ class PDFObject
                         // no break
                     case 'TJ':
                         // Skip if not previously defined, should never happened.
-                        if (is_null($current_font)) {
+                        if (null === $current_font) {
                             // Fallback
                             // TODO : Improve
                             $text[] = $command[self::COMMAND][0][self::COMMAND];
@@ -511,7 +511,7 @@ class PDFObject
                         break;
 
                     case 'Do':
-                        if (!is_null($page)) {
+                        if (null !== $page) {
                             $args = preg_split('/\s/s', $command[self::COMMAND]);
                             $id = trim(array_pop($args), '/ ');
                             if ($xobject = $page->getXObject($id)) {
@@ -572,7 +572,7 @@ class PDFObject
     {
         $commands = $matches = [];
 
-        while ($offset < strlen($text_part)) {
+        while ($offset < \strlen($text_part)) {
             $offset += strspn($text_part, "\x00\x09\x0a\x0c\x0d\x20", $offset);
             $char = $text_part[$offset];
 
@@ -591,7 +591,7 @@ class PDFObject
                     ) {
                         $operator = $matches[2];
                         $command = $matches[1];
-                        $offset += strlen($matches[0]);
+                        $offset += \strlen($matches[0]);
                     } elseif (preg_match(
                         '/^\/([A-Z0-9\._,\+]+)\s+([A-Z]+)\s*/si',
                         substr($text_part, $offset),
@@ -600,7 +600,7 @@ class PDFObject
                     ) {
                         $operator = $matches[2];
                         $command = $matches[1];
-                        $offset += strlen($matches[0]);
+                        $offset += \strlen($matches[0]);
                     }
                     break;
 
@@ -615,7 +615,7 @@ class PDFObject
 
                         if (preg_match('/^\s*[A-Z]{1,2}\s*/si', substr($text_part, $offset), $matches)) {
                             $operator = trim($matches[0]);
-                            $offset += strlen($matches[0]);
+                            $offset += \strlen($matches[0]);
                         }
                     } else {
                         ++$offset;
@@ -636,7 +636,7 @@ class PDFObject
 
                     if (preg_match('/^\s*[A-Z]{1,2}\s*/si', substr($text_part, $offset), $matches)) {
                         $operator = trim($matches[0]);
-                        $offset += strlen($matches[0]);
+                        $offset += \strlen($matches[0]);
                     }
                     break;
 
@@ -676,7 +676,7 @@ class PDFObject
 
                         if (preg_match('/^\s*([A-Z\']{1,2})\s*/si', substr($text_part, $offset), $matches)) {
                             $operator = $matches[1];
-                            $offset += strlen($matches[0]);
+                            $offset += \strlen($matches[0]);
                         }
                     }
                     break;
@@ -693,16 +693,16 @@ class PDFObject
                     ) {
                         $operator = trim($matches['id']);
                         $command = trim($matches['data']);
-                        $offset += strlen($matches[0]);
+                        $offset += \strlen($matches[0]);
                     } elseif (preg_match('/^\s*([0-9\.\-]+\s*?)+\s*/si', substr($text_part, $offset), $matches)) {
                         $type = 'n';
                         $command = trim($matches[0]);
-                        $offset += strlen($matches[0]);
+                        $offset += \strlen($matches[0]);
                     } elseif (preg_match('/^\s*([A-Z\*]+)\s*/si', substr($text_part, $offset), $matches)) {
                         $type = '';
                         $operator = $matches[1];
                         $command = '';
-                        $offset += strlen($matches[0]);
+                        $offset += \strlen($matches[0]);
                     }
             }
 
@@ -739,7 +739,7 @@ class PDFObject
                         return new Form($document, $header, $content);
 
                     default:
-                        return new PDFObject($document, $header, $content);
+                        return new self($document, $header, $content);
                 }
                 break;
 
@@ -764,7 +764,7 @@ class PDFObject
 
                 // no break
             default:
-                return new PDFObject($document, $header, $content);
+                return new self($document, $header, $content);
         }
     }
 

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -34,7 +34,7 @@ use Smalot\PdfParser\XObject\Form;
 use Smalot\PdfParser\XObject\Image;
 
 /**
- * Class PDFObject.
+ * Class PDFObject
  */
 class PDFObject
 {

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -77,7 +77,7 @@ class PDFObject
         $this->content = $content;
     }
 
-    public function init(): void
+    public function init()
     {
     }
 

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -55,7 +55,7 @@ class Page extends PDFObject
      */
     public function getFonts()
     {
-        if (!is_null($this->fonts)) {
+        if (null !== $this->fonts) {
             return $this->fonts;
         }
 
@@ -117,7 +117,7 @@ class Page extends PDFObject
      */
     public function getXObjects()
     {
-        if (!is_null($this->xobjects)) {
+        if (null !== $this->xobjects) {
             return $this->xobjects;
         }
 
@@ -176,7 +176,7 @@ class Page extends PDFObject
      *
      * @return string
      */
-    public function getText(Page $page = null)
+    public function getText(self $page = null)
     {
         if ($contents = $this->get('Contents')) {
             if ($contents instanceof ElementMissing) {
@@ -223,7 +223,7 @@ class Page extends PDFObject
      *
      * @return array
      */
-    public function getTextArray(Page $page = null)
+    public function getTextArray(self $page = null)
     {
         if ($contents = $this->get('Contents')) {
             if ($contents instanceof ElementMissing) {

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -36,7 +36,7 @@ use Smalot\PdfParser\Element\ElementNull;
 use Smalot\PdfParser\Element\ElementXRef;
 
 /**
- * Class Page.
+ * Class Page
  */
 class Page extends PDFObject
 {
@@ -111,7 +111,7 @@ class Page extends PDFObject
     }
 
     /**
-     * Support for XObject.
+     * Support for XObject
      *
      * @return PDFObject[]
      */

--- a/src/Smalot/PdfParser/Pages.php
+++ b/src/Smalot/PdfParser/Pages.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,15 +26,12 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser;
 
 /**
- * Class Pages
- *
- * @package Smalot\PdfParser
+ * Class Pages.
  */
 class Pages extends PDFObject
 {
@@ -45,15 +43,13 @@ class Pages extends PDFObject
     public function getPages($deep = false)
     {
         if ($this->has('Kids')) {
-
             if (!$deep) {
                 return $this->get('Kids')->getContent();
             } else {
-                $kids  = $this->get('Kids')->getContent();
-                $pages = array();
+                $kids = $this->get('Kids')->getContent();
+                $pages = [];
 
                 foreach ($kids as $kid) {
-
                     if ($kid instanceof Pages) {
                         $pages = array_merge($pages, $kid->getPages(true));
                     } else {
@@ -65,6 +61,6 @@ class Pages extends PDFObject
             }
         }
 
-        return array();
+        return [];
     }
 }

--- a/src/Smalot/PdfParser/Pages.php
+++ b/src/Smalot/PdfParser/Pages.php
@@ -31,7 +31,7 @@
 namespace Smalot\PdfParser;
 
 /**
- * Class Pages.
+ * Class Pages
  */
 class Pages extends PDFObject
 {

--- a/src/Smalot/PdfParser/Pages.php
+++ b/src/Smalot/PdfParser/Pages.php
@@ -50,7 +50,7 @@ class Pages extends PDFObject
                 $pages = [];
 
                 foreach ($kids as $kid) {
-                    if ($kid instanceof Pages) {
+                    if ($kid instanceof self) {
                         $pages = array_merge($pages, $kid->getPages(true));
                     } else {
                         $pages[] = $kid;

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -143,7 +143,7 @@ class Parser
      * @param array    $structure
      * @param Document $document
      */
-    protected function parseObject($id, $structure, $document): void
+    protected function parseObject($id, $structure, $document)
     {
         $header = new Header([], $document);
         $content = '';

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -41,7 +41,7 @@ use Smalot\PdfParser\Element\ElementString;
 use Smalot\PdfParser\Element\ElementXRef;
 
 /**
- * Class Parser.
+ * Class Parser
  */
 class Parser
 {

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -125,7 +125,7 @@ class Parser
 
             if (is_numeric($values)) {
                 $trailer[$name] = new ElementNumeric($values, $document);
-            } elseif (is_array($values)) {
+            } elseif (\is_array($values)) {
                 $value = $this->parseTrailer($values, null);
                 $trailer[$name] = new ElementArray($value, null);
             } elseif (false !== strpos($values, '_')) {
@@ -197,7 +197,7 @@ class Parser
 
                         foreach ($positions as $index => $position) {
                             $id = $ids[$index].'_0';
-                            $next_position = isset($positions[$index + 1]) ? $positions[$index + 1] : strlen($content);
+                            $next_position = isset($positions[$index + 1]) ? $positions[$index + 1] : \strlen($content);
                             $sub_content = substr($content, $position, $next_position - $position);
 
                             $sub_header = Header::parse($sub_content, $document);
@@ -240,7 +240,7 @@ class Parser
     protected function parseHeader($structure, $document)
     {
         $elements = [];
-        $count = count($structure);
+        $count = \count($structure);
 
         for ($position = 0; $position < $count; $position += 2) {
             $name = $structure[$position][1];

--- a/src/Smalot/PdfParser/Tests/Units/Document.php
+++ b/src/Smalot/PdfParser/Tests/Units/Document.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units;
 use mageekguy\atoum;
 
 /**
- * Class Document.
+ * Class Document
  */
 class Document extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Document.php
+++ b/src/Smalot/PdfParser/Tests/Units/Document.php
@@ -67,7 +67,7 @@ class Document extends atoum\test
         $object2 = new \Smalot\PdfParser\Page($document, $header);
         $document->setObjects([1 => $object1, 2 => $object2]);
 
-        $this->assert->integer(count($objects = $document->getObjects()))->isEqualTo(2);
+        $this->assert->integer(\count($objects = $document->getObjects()))->isEqualTo(2);
         $this->assert->object($objects[1])->isInstanceOf('\Smalot\PdfParser\PDFObject');
         $this->assert->object($objects[2])->isInstanceOf('\Smalot\PdfParser\PDFObject');
         $this->assert->object($objects[2])->isInstanceOf('\Smalot\PdfParser\Page');
@@ -76,14 +76,14 @@ class Document extends atoum\test
     public function testDictionary()
     {
         $document = new \Smalot\PdfParser\Document();
-        $this->assert->integer(count($objects = $document->getDictionary()))->isEqualTo(0);
+        $this->assert->integer(\count($objects = $document->getDictionary()))->isEqualTo(0);
         $object1 = new \Smalot\PdfParser\PDFObject($document);
         $content = '<</Type/Page>>';
         $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object2 = new \Smalot\PdfParser\Page($document, $header);
         $document->setObjects([1 => $object1, 2 => $object2]);
-        $this->assert->integer(count($objects = $document->getDictionary()))->isEqualTo(1);
-        $this->assert->integer(count($objects['Page']))->isEqualTo(1);
+        $this->assert->integer(\count($objects = $document->getDictionary()))->isEqualTo(1);
+        $this->assert->integer(\count($objects['Page']))->isEqualTo(1);
         $this->assert->integer($objects['Page'][2])->isEqualTo(2);
     }
 
@@ -95,7 +95,7 @@ class Document extends atoum\test
         $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object2 = new \Smalot\PdfParser\Page($document, $header);
         $document->setObjects([1 => $object1, 2 => $object2]);
-        $this->assert->integer(count($objects = $document->getObjectsByType('Page')))->isEqualTo(1);
+        $this->assert->integer(\count($objects = $document->getObjectsByType('Page')))->isEqualTo(1);
         $this->assert->object($objects[2])->isInstanceOf('\Smalot\PdfParser\PDFObject');
         $this->assert->object($objects[2])->isInstanceOf('\Smalot\PdfParser\Page');
     }
@@ -119,7 +119,7 @@ class Document extends atoum\test
         $object2 = new \Smalot\PdfParser\Page($document, $header);
         $document->setObjects([1 => $object1, 2 => $object2]);
         $pages = $document->getPages();
-        $this->assert->integer(count($pages))->isEqualTo(2);
+        $this->assert->integer(\count($pages))->isEqualTo(2);
         $this->assert->object($pages[0])->isInstanceOf('\Smalot\PdfParser\Page');
         $this->assert->object($pages[1])->isInstanceOf('\Smalot\PdfParser\Page');
 
@@ -141,7 +141,7 @@ class Document extends atoum\test
             ['1_0' => $object1, '2_0' => $object2, '3_0' => $object3, '4_0' => $object4, '5_0' => $object5]
         );
         $pages = $document->getPages();
-        $this->assert->integer(count($pages))->isEqualTo(3);
+        $this->assert->integer(\count($pages))->isEqualTo(3);
         $this->assert->object($pages[0])->isInstanceOf('\Smalot\PdfParser\Page');
         $this->assert->object($pages[1])->isInstanceOf('\Smalot\PdfParser\Page');
         $this->assert->object($pages[2])->isInstanceOf('\Smalot\PdfParser\Page');
@@ -174,7 +174,7 @@ class Document extends atoum\test
             ]
         );
         $pages = $document->getPages();
-        $this->assert->integer(count($pages))->isEqualTo(3);
+        $this->assert->integer(\count($pages))->isEqualTo(3);
         $this->assert->object($pages[0])->isInstanceOf('\Smalot\PdfParser\Page');
         $this->assert->object($pages[1])->isInstanceOf('\Smalot\PdfParser\Page');
         $this->assert->object($pages[2])->isInstanceOf('\Smalot\PdfParser\Page');

--- a/src/Smalot/PdfParser/Tests/Units/Document.php
+++ b/src/Smalot/PdfParser/Tests/Units/Document.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class Document extends atoum\test
 {
-    public function testSetObjects(): void
+    public function testSetObjects()
     {
         $document = new \Smalot\PdfParser\Document();
         $object = new \Smalot\PdfParser\PDFObject($document);
@@ -57,7 +57,7 @@ class Document extends atoum\test
         $this->assert->object($document->getObjectById(2))->isInstanceOf('\Smalot\PdfParser\PDFObject');
     }
 
-    public function testGetObjects(): void
+    public function testGetObjects()
     {
         $document = new \Smalot\PdfParser\Document();
         $object1 = new \Smalot\PdfParser\PDFObject($document);
@@ -73,7 +73,7 @@ class Document extends atoum\test
         $this->assert->object($objects[2])->isInstanceOf('\Smalot\PdfParser\Page');
     }
 
-    public function testDictionary(): void
+    public function testDictionary()
     {
         $document = new \Smalot\PdfParser\Document();
         $this->assert->integer(count($objects = $document->getDictionary()))->isEqualTo(0);
@@ -87,7 +87,7 @@ class Document extends atoum\test
         $this->assert->integer($objects['Page'][2])->isEqualTo(2);
     }
 
-    public function testGetObjectsByType(): void
+    public function testGetObjectsByType()
     {
         $document = new \Smalot\PdfParser\Document();
         $object1 = new \Smalot\PdfParser\PDFObject($document);
@@ -100,7 +100,7 @@ class Document extends atoum\test
         $this->assert->object($objects[2])->isInstanceOf('\Smalot\PdfParser\Page');
     }
 
-    public function testGetPages(): void
+    public function testGetPages()
     {
         // Missing catalog
         $document = new \Smalot\PdfParser\Document();

--- a/src/Smalot/PdfParser/Tests/Units/Document.php
+++ b/src/Smalot/PdfParser/Tests/Units/Document.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units;
@@ -33,41 +33,39 @@ namespace Smalot\PdfParser\Tests\Units;
 use mageekguy\atoum;
 
 /**
- * Class Document
- *
- * @package Smalot\PdfParser\Tests\Units
+ * Class Document.
  */
 class Document extends atoum\test
 {
-    public function testSetObjects()
+    public function testSetObjects(): void
     {
         $document = new \Smalot\PdfParser\Document();
-        $object   = new \Smalot\PdfParser\PDFObject($document);
+        $object = new \Smalot\PdfParser\PDFObject($document);
         // Obj #1 is missing
         $this->assert->variable($document->getObjectById(1))->isNull();
-        $document->setObjects(array(1 => $object));
+        $document->setObjects([1 => $object]);
         // Obj #1 exists
         $this->assert->object($document->getObjectById(1))->isInstanceOf('\Smalot\PdfParser\PDFObject');
 
         $content = '<</Type/Page>>';
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
-        $object  = new \Smalot\PdfParser\PDFObject($document, $header);
-        $document->setObjects(array(2 => $object));
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
+        $object = new \Smalot\PdfParser\PDFObject($document, $header);
+        $document->setObjects([2 => $object]);
         // Obj #1 is missing
         $this->assert->assert->variable($document->getObjectById(1))->isNull();
         // Obj #2 exists
         $this->assert->object($document->getObjectById(2))->isInstanceOf('\Smalot\PdfParser\PDFObject');
     }
 
-    public function testGetObjects()
+    public function testGetObjects(): void
     {
         $document = new \Smalot\PdfParser\Document();
-        $object1  = new \Smalot\PdfParser\PDFObject($document);
-        $content  = '<</Type/Page>>unparsed content';
-        $header   = \Smalot\PdfParser\Header::parse($content, $document);
+        $object1 = new \Smalot\PdfParser\PDFObject($document);
+        $content = '<</Type/Page>>unparsed content';
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
 
         $object2 = new \Smalot\PdfParser\Page($document, $header);
-        $document->setObjects(array(1 => $object1, 2 => $object2));
+        $document->setObjects([1 => $object1, 2 => $object2]);
 
         $this->assert->integer(count($objects = $document->getObjects()))->isEqualTo(2);
         $this->assert->object($objects[1])->isInstanceOf('\Smalot\PdfParser\PDFObject');
@@ -75,34 +73,34 @@ class Document extends atoum\test
         $this->assert->object($objects[2])->isInstanceOf('\Smalot\PdfParser\Page');
     }
 
-    public function testDictionary()
+    public function testDictionary(): void
     {
         $document = new \Smalot\PdfParser\Document();
         $this->assert->integer(count($objects = $document->getDictionary()))->isEqualTo(0);
         $object1 = new \Smalot\PdfParser\PDFObject($document);
         $content = '<</Type/Page>>';
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object2 = new \Smalot\PdfParser\Page($document, $header);
-        $document->setObjects(array(1 => $object1, 2 => $object2));
+        $document->setObjects([1 => $object1, 2 => $object2]);
         $this->assert->integer(count($objects = $document->getDictionary()))->isEqualTo(1);
         $this->assert->integer(count($objects['Page']))->isEqualTo(1);
         $this->assert->integer($objects['Page'][2])->isEqualTo(2);
     }
 
-    public function testGetObjectsByType()
+    public function testGetObjectsByType(): void
     {
         $document = new \Smalot\PdfParser\Document();
-        $object1  = new \Smalot\PdfParser\PDFObject($document);
-        $content  = '<</Type/Page>>';
-        $header   = \Smalot\PdfParser\Header::parse($content, $document);
-        $object2  = new \Smalot\PdfParser\Page($document, $header);
-        $document->setObjects(array(1 => $object1, 2 => $object2));
+        $object1 = new \Smalot\PdfParser\PDFObject($document);
+        $content = '<</Type/Page>>';
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
+        $object2 = new \Smalot\PdfParser\Page($document, $header);
+        $document->setObjects([1 => $object1, 2 => $object2]);
         $this->assert->integer(count($objects = $document->getObjectsByType('Page')))->isEqualTo(1);
         $this->assert->object($objects[2])->isInstanceOf('\Smalot\PdfParser\PDFObject');
         $this->assert->object($objects[2])->isInstanceOf('\Smalot\PdfParser\Page');
     }
 
-    public function testGetPages()
+    public function testGetPages(): void
     {
         // Missing catalog
         $document = new \Smalot\PdfParser\Document();
@@ -115,11 +113,11 @@ class Document extends atoum\test
 
         // Listing pages from type Page
         $content = '<</Type/Page>>';
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object1 = new \Smalot\PdfParser\Page($document, $header);
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object2 = new \Smalot\PdfParser\Page($document, $header);
-        $document->setObjects(array(1 => $object1, 2 => $object2));
+        $document->setObjects([1 => $object1, 2 => $object2]);
         $pages = $document->getPages();
         $this->assert->integer(count($pages))->isEqualTo(2);
         $this->assert->object($pages[0])->isInstanceOf('\Smalot\PdfParser\Page');
@@ -127,20 +125,20 @@ class Document extends atoum\test
 
         // Listing pages from type Pages (kids)
         $content = '<</Type/Page>>';
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object1 = new \Smalot\PdfParser\Page($document, $header);
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object2 = new \Smalot\PdfParser\Page($document, $header);
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object3 = new \Smalot\PdfParser\Page($document, $header);
         $content = '<</Type/Pages/Kids[1 0 R 2 0 R]>>';
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object4 = new \Smalot\PdfParser\Pages($document, $header);
         $content = '<</Type/Pages/Kids[3 0 R]>>';
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object5 = new \Smalot\PdfParser\Pages($document, $header);
         $document->setObjects(
-            array('1_0' => $object1, '2_0' => $object2, '3_0' => $object3, '4_0' => $object4, '5_0' => $object5)
+            ['1_0' => $object1, '2_0' => $object2, '3_0' => $object3, '4_0' => $object4, '5_0' => $object5]
         );
         $pages = $document->getPages();
         $this->assert->integer(count($pages))->isEqualTo(3);
@@ -150,30 +148,30 @@ class Document extends atoum\test
 
         // Listing pages from type Catalog
         $content = '<</Type/Page>>';
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object1 = new \Smalot\PdfParser\Page($document, $header);
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object2 = new \Smalot\PdfParser\Page($document, $header);
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object3 = new \Smalot\PdfParser\Page($document, $header);
         $content = '<</Type/Pages/Kids[1 0 R 2 0 R]>>';
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object4 = new \Smalot\PdfParser\Pages($document, $header);
         $content = '<</Type/Pages/Kids[4 0 R 3 0 R]>>';
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object5 = new \Smalot\PdfParser\Pages($document, $header);
         $content = '<</Type/Catalog/Pages 5 0 R >>';
-        $header  = \Smalot\PdfParser\Header::parse($content, $document);
+        $header = \Smalot\PdfParser\Header::parse($content, $document);
         $object6 = new \Smalot\PdfParser\Pages($document, $header);
         $document->setObjects(
-            array(
+            [
                 '1_0' => $object1,
                 '2_0' => $object2,
                 '3_0' => $object3,
                 '4_0' => $object4,
                 '5_0' => $object5,
-                '6_0' => $object6
-            )
+                '6_0' => $object6,
+            ]
         );
         $pages = $document->getPages();
         $this->assert->integer(count($pages))->isEqualTo(3);

--- a/src/Smalot/PdfParser/Tests/Units/Element.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element.php
@@ -53,38 +53,38 @@ class Element extends atoum\test
         $this->assert->object($elements['NameType'])->isInstanceOf('\Smalot\PdfParser\Element\ElementName');
         $this->assert->string($elements['NameType']->getContent())->isEqualTo('FlateDecode');
 
-        $this->assert->boolean(array_key_exists('Contents', $elements))->isEqualTo(true);
+        $this->assert->boolean(\array_key_exists('Contents', $elements))->isEqualTo(true);
         $this->assert->object($elements['Contents'])->isInstanceOf('\Smalot\PdfParser\Element\ElementArray');
         $this->assert->boolean($elements['Contents']->contains(42))->isEqualTo(true);
 
-        $this->assert->boolean(array_key_exists('Fonts', $elements))->isEqualTo(true);
+        $this->assert->boolean(\array_key_exists('Fonts', $elements))->isEqualTo(true);
         $this->assert->object($elements['Fonts'])->isInstanceOf('\Smalot\PdfParser\Header');
 
-        $this->assert->boolean(array_key_exists('NullType', $elements))->isEqualTo(true);
+        $this->assert->boolean(\array_key_exists('NullType', $elements))->isEqualTo(true);
         $this->assert->object($elements['NullType'])->isInstanceOf('\Smalot\PdfParser\Element\ElementNull');
         $this->assert->castToString($elements['NullType'])->isEqualTo('null');
 
-        $this->assert->boolean(array_key_exists('StringType', $elements))->isEqualTo(true);
+        $this->assert->boolean(\array_key_exists('StringType', $elements))->isEqualTo(true);
         $this->assert->object($elements['StringType'])->isInstanceOf('\Smalot\PdfParser\Element\ElementString');
         $this->assert->string($elements['StringType']->getContent())->isEqualTo('hello');
 
-        $this->assert->boolean(array_key_exists('DateType', $elements))->isEqualTo(true);
+        $this->assert->boolean(\array_key_exists('DateType', $elements))->isEqualTo(true);
         $this->assert->object($elements['DateType'])->isInstanceOf('\Smalot\PdfParser\Element\ElementDate');
 //        $this->assert->castToString($elements['DateType'])->isEqualTo('2013-09-01T23:55:55+02:00');
 
-        $this->assert->boolean(array_key_exists('XRefType', $elements))->isEqualTo(true);
+        $this->assert->boolean(\array_key_exists('XRefType', $elements))->isEqualTo(true);
         $this->assert->object($elements['XRefType'])->isInstanceOf('\Smalot\PdfParser\Element\ElementXRef');
         $this->assert->string($elements['XRefType']->getId())->isEqualTo('2_0');
 
-        $this->assert->boolean(array_key_exists('NumericType', $elements))->isEqualTo(true);
+        $this->assert->boolean(\array_key_exists('NumericType', $elements))->isEqualTo(true);
         $this->assert->object($elements['NumericType'])->isInstanceOf('\Smalot\PdfParser\Element\ElementNumeric');
         $this->assert->castToString($elements['NumericType'])->isEqualTo('8');
 
-        $this->assert->boolean(array_key_exists('HexaType', $elements))->isEqualTo(true);
+        $this->assert->boolean(\array_key_exists('HexaType', $elements))->isEqualTo(true);
         $this->assert->object($elements['HexaType'])->isInstanceOf('\Smalot\PdfParser\Element\ElementString');
         $this->assert->string($elements['HexaType']->getContent())->isEqualTo(' ');
 
-        $this->assert->boolean(array_key_exists('BooleanType', $elements))->isEqualTo(true);
+        $this->assert->boolean(\array_key_exists('BooleanType', $elements))->isEqualTo(true);
         $this->assert->object($elements['BooleanType'])->isInstanceOf('\Smalot\PdfParser\Element\ElementBoolean');
         $this->assert->boolean($elements['BooleanType']->getContent())->isEqualTo(false);
 

--- a/src/Smalot/PdfParser/Tests/Units/Element.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class Element extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         $document = new \Smalot\PdfParser\Document([]);
 
@@ -115,7 +115,7 @@ class Element extends atoum\test
         $this->assert->string($elements['NameType']->getContent())->isEqualTo('FlateDecode');*/
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $element = new \Smalot\PdfParser\Element(42);
         $content = $element->getContent();
@@ -126,7 +126,7 @@ class Element extends atoum\test
         $this->assert->array($content)->hasSize(2);
     }
 
-    public function testEquals(): void
+    public function testEquals()
     {
         $element = new \Smalot\PdfParser\Element(2);
 
@@ -134,7 +134,7 @@ class Element extends atoum\test
         $this->assert->boolean($element->equals(8))->isEqualTo(false);
     }
 
-    public function testContains(): void
+    public function testContains()
     {
         $val_4 = new \Smalot\PdfParser\Element(4);
         $val_2 = new \Smalot\PdfParser\Element(2);
@@ -144,7 +144,7 @@ class Element extends atoum\test
         $this->assert->boolean($element->contains(8))->isEqualTo(false);
     }
 
-    public function test__toString(): void
+    public function test__toString()
     {
         $element = new \Smalot\PdfParser\Element(2);
         $this->assert->castToString($element)->isEqualTo('2');

--- a/src/Smalot/PdfParser/Tests/Units/Element.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units;
 use mageekguy\atoum;
 
 /**
- * Class Element.
+ * Class Element
  */
 class Element extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units;
@@ -33,22 +33,20 @@ namespace Smalot\PdfParser\Tests\Units;
 use mageekguy\atoum;
 
 /**
- * Class Element
- *
- * @package Smalot\PdfParser\Tests\Units
+ * Class Element.
  */
 class Element extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
-        $document = new \Smalot\PdfParser\Document(array());
+        $document = new \Smalot\PdfParser\Document([]);
 
         // Only_values = false.
-        $content  = '/NameType /FlateDecode
+        $content = '/NameType /FlateDecode
         /Contents[4 0 R 42]/Fonts<</F1 41/F2 43>>/NullType
         null/StringType(hello)/DateType(D:20130901235555+02\'00\')/XRefType 2 0 R
         /NumericType 8/HexaType<0020>/BooleanType false';
-        $offset   = 0;
+        $offset = 0;
         $elements = \Smalot\PdfParser\Element::parse($content, $document, $offset, false);
 
         $this->assert->array($elements)->hasKey('NameType');
@@ -91,23 +89,23 @@ class Element extends atoum\test
         $this->assert->boolean($elements['BooleanType']->getContent())->isEqualTo(false);
 
         // Only_values = true.
-        $content  = '/NameType /FlateDecode';
-        $offset   = 0;
+        $content = '/NameType /FlateDecode';
+        $offset = 0;
         $elements = \Smalot\PdfParser\Element::parse($content, $document, $offset, true);
         $this->assert->array($elements)->hasSize(2);
         $this->assert->integer($offset)->isEqualTo(22);
 
         // Test error.
-        $content  = '/NameType /FlateDecode $$$';
-        $offset   = 0;
+        $content = '/NameType /FlateDecode $$$';
+        $offset = 0;
         $elements = \Smalot\PdfParser\Element::parse($content, $document, $offset, false);
         $this->assert->array($elements)->hasSize(1);
         $this->assert->integer($offset)->isEqualTo(22);
         $this->assert->string(key($elements))->isEqualTo('NameType');
         $this->assert->object(current($elements))->isInstanceOf('\Smalot\PdfParser\Element\ElementName');
 
-        $content  = '/NameType $$$';
-        $offset   = 0;
+        $content = '/NameType $$$';
+        $offset = 0;
         $elements = \Smalot\PdfParser\Element::parse($content, $document, $offset, false);
         $this->assert->integer($offset)->isEqualTo(0);
         $this->assert->array($elements)->isEmpty();
@@ -117,18 +115,18 @@ class Element extends atoum\test
         $this->assert->string($elements['NameType']->getContent())->isEqualTo('FlateDecode');*/
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new \Smalot\PdfParser\Element(42);
         $content = $element->getContent();
         $this->assert->integer($content)->isEqualTo(42);
 
-        $element = new \Smalot\PdfParser\Element(array(4, 2));
+        $element = new \Smalot\PdfParser\Element([4, 2]);
         $content = $element->getContent();
         $this->assert->array($content)->hasSize(2);
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new \Smalot\PdfParser\Element(2);
 
@@ -136,17 +134,17 @@ class Element extends atoum\test
         $this->assert->boolean($element->equals(8))->isEqualTo(false);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
-        $val_4   = new \Smalot\PdfParser\Element(4);
-        $val_2   = new \Smalot\PdfParser\Element(2);
-        $element = new \Smalot\PdfParser\Element(array($val_4, $val_2));
+        $val_4 = new \Smalot\PdfParser\Element(4);
+        $val_2 = new \Smalot\PdfParser\Element(2);
+        $element = new \Smalot\PdfParser\Element([$val_4, $val_2]);
 
         $this->assert->boolean($element->contains(2))->isEqualTo(true);
         $this->assert->boolean($element->contains(8))->isEqualTo(false);
     }
 
-    public function test__toString()
+    public function test__toString(): void
     {
         $element = new \Smalot\PdfParser\Element(2);
         $this->assert->castToString($element)->isEqualTo('2');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementArray.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementArray.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -36,54 +36,52 @@ use Smalot\PdfParser\Header;
 use Smalot\PdfParser\Page;
 
 /**
- * Class ElementArray
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementArray.
  */
 class ElementArray extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
-        $document = new \Smalot\PdfParser\Document(array());
+        $document = new \Smalot\PdfParser\Document([]);
 
         // Skipped.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementArray::parse('ABC', $document, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementArray::parse(' / [ 4 2 ] ', $document, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementArray::parse(' 0 [ 4 2 ] ', $document, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementArray::parse(" 0 \n [ 4 2 ] ", $document, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
 
         // Valid.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementArray::parse(' [ 4 2 ] ', $document, $offset);
         $this->assert->boolean($element->contains(4))->isEqualTo(true);
         $this->assert->boolean($element->contains(2))->isEqualTo(true);
         $this->assert->boolean($element->contains(8))->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(8);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementArray::parse(' [ 4 2 ]', $document, $offset);
         $this->assert->boolean($element->contains(4))->isEqualTo(true);
         $this->assert->boolean($element->contains(2))->isEqualTo(true);
         $this->assert->boolean($element->contains(8))->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(8);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementArray::parse('[ 4 2 ]', $document, $offset);
         $this->assert->boolean($element->contains(4))->isEqualTo(true);
         $this->assert->boolean($element->contains(2))->isEqualTo(true);
         $this->assert->boolean($element->contains(8))->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(7);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementArray::parse(" \n [ 4 2 ] ", $document, $offset);
         $this->assert->boolean($element->contains(4))->isEqualTo(true);
         $this->assert->boolean($element->contains(2))->isEqualTo(true);
@@ -91,34 +89,34 @@ class ElementArray extends atoum\test
         $this->assert->integer($offset)->isEqualTo(10);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
-        $val_4   = new \Smalot\PdfParser\Element\ElementNumeric('4');
-        $val_2   = new \Smalot\PdfParser\Element\ElementNumeric('2');
-        $element = new \Smalot\PdfParser\Element\ElementArray(array($val_4, $val_2));
+        $val_4 = new \Smalot\PdfParser\Element\ElementNumeric('4');
+        $val_2 = new \Smalot\PdfParser\Element\ElementNumeric('2');
+        $element = new \Smalot\PdfParser\Element\ElementArray([$val_4, $val_2]);
 
         $content = $element->getContent();
         $this->assert->array($content)->hasSize(2);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
-        $val_4   = new \Smalot\PdfParser\Element\ElementNumeric('4');
-        $val_2   = new \Smalot\PdfParser\Element\ElementNumeric('2');
-        $element = new \Smalot\PdfParser\Element\ElementArray(array($val_4, $val_2));
+        $val_4 = new \Smalot\PdfParser\Element\ElementNumeric('4');
+        $val_2 = new \Smalot\PdfParser\Element\ElementNumeric('2');
+        $element = new \Smalot\PdfParser\Element\ElementArray([$val_4, $val_2]);
 
         $this->assert->boolean($element->contains(2))->isEqualTo(true);
         $this->assert->boolean($element->contains(8))->isEqualTo(false);
     }
 
-    public function testResolveXRef()
+    public function testResolveXRef(): void
     {
         // Document with text.
-        $filename = __DIR__ . '/../../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
-        $parser   = new \Smalot\PdfParser\Parser();
+        $filename = __DIR__.'/../../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
-        $object   = $document->getObjectById('3_0');
-        $kids     = $object->get('Kids');
+        $object = $document->getObjectById('3_0');
+        $kids = $object->get('Kids');
 
         $this->assert->object($kids)->isInstanceOf('\Smalot\PdfParser\Element\ElementArray');
         $this->assert->array($kids->getContent())->hasSize(1);
@@ -127,7 +125,7 @@ class ElementArray extends atoum\test
         $this->assert->object(reset($pages))->isInstanceOf('\Smalot\PdfParser\Page');
     }
 
-    public function testGetDetails()
+    public function testGetDetails(): void
     {
 //        // Document with text.
 //        $filename = __DIR__ . '/../../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
@@ -141,49 +139,49 @@ class ElementArray extends atoum\test
 //        $this->assert->array($details)->hasSize(1);
 //        $this->assert->string($details[0]['Type'])->isEqualTo('Page');
 
-        $document          = new Document();
-        $content           = '<</Type/Page/Types[8]/Sizes[1 2 3 4 5 <</Subtype/XObject>> [8 [9 <</FontSize 10>>]]]>>';
-        $details_reference = array(
-            'Type'  => 'Page',
-            'Types' => array(
+        $document = new Document();
+        $content = '<</Type/Page/Types[8]/Sizes[1 2 3 4 5 <</Subtype/XObject>> [8 [9 <</FontSize 10>>]]]>>';
+        $details_reference = [
+            'Type' => 'Page',
+            'Types' => [
                 8,
-            ),
-            'Sizes' => array(
+            ],
+            'Sizes' => [
                 1,
                 2,
                 3,
                 4,
                 5,
-                array(
+                [
                     'Subtype' => 'XObject',
-                ),
-                array(
+                ],
+                [
                     8,
-                    array(
+                    [
                         9,
-                        array(
+                        [
                             'FontSize' => 10,
-                        ),
-                    ),
-                ),
-            ),
-        );
-        $header            = Header::parse($content, $document);
-        $details           = $header->getDetails();
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $header = Header::parse($content, $document);
+        $details = $header->getDetails();
 
         $this->assert->array($details)->hasSize(3);
         $this->assert->array($details)->isEqualTo($details_reference);
     }
 
-    public function test__toString()
+    public function test__toString(): void
     {
-        $val_4   = new \Smalot\PdfParser\Element\ElementNumeric('4');
-        $val_2   = new \Smalot\PdfParser\Element\ElementNumeric('2');
-        $element = new \Smalot\PdfParser\Element\ElementArray(array($val_4, $val_2));
+        $val_4 = new \Smalot\PdfParser\Element\ElementNumeric('4');
+        $val_2 = new \Smalot\PdfParser\Element\ElementNumeric('2');
+        $element = new \Smalot\PdfParser\Element\ElementArray([$val_4, $val_2]);
         $this->assert->castToString($element)->isEqualTo('4,2');
 
-        $document = new \Smalot\PdfParser\Document(array());
-        $element  = \Smalot\PdfParser\Element\ElementArray::parse(' [ 4 2 ]', $document);
+        $document = new \Smalot\PdfParser\Document([]);
+        $element = \Smalot\PdfParser\Element\ElementArray::parse(' [ 4 2 ]', $document);
         $this->assert->castToString($element)->isEqualTo('4,2');
     }
 }

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementArray.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementArray.php
@@ -36,7 +36,7 @@ use Smalot\PdfParser\Header;
 use Smalot\PdfParser\Page;
 
 /**
- * Class ElementArray.
+ * Class ElementArray
  */
 class ElementArray extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementArray.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementArray.php
@@ -40,7 +40,7 @@ use Smalot\PdfParser\Page;
  */
 class ElementArray extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         $document = new \Smalot\PdfParser\Document([]);
 
@@ -89,7 +89,7 @@ class ElementArray extends atoum\test
         $this->assert->integer($offset)->isEqualTo(10);
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $val_4 = new \Smalot\PdfParser\Element\ElementNumeric('4');
         $val_2 = new \Smalot\PdfParser\Element\ElementNumeric('2');
@@ -99,7 +99,7 @@ class ElementArray extends atoum\test
         $this->assert->array($content)->hasSize(2);
     }
 
-    public function testContains(): void
+    public function testContains()
     {
         $val_4 = new \Smalot\PdfParser\Element\ElementNumeric('4');
         $val_2 = new \Smalot\PdfParser\Element\ElementNumeric('2');
@@ -109,7 +109,7 @@ class ElementArray extends atoum\test
         $this->assert->boolean($element->contains(8))->isEqualTo(false);
     }
 
-    public function testResolveXRef(): void
+    public function testResolveXRef()
     {
         // Document with text.
         $filename = __DIR__.'/../../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
@@ -125,7 +125,7 @@ class ElementArray extends atoum\test
         $this->assert->object(reset($pages))->isInstanceOf('\Smalot\PdfParser\Page');
     }
 
-    public function testGetDetails(): void
+    public function testGetDetails()
     {
 //        // Document with text.
 //        $filename = __DIR__ . '/../../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
@@ -173,7 +173,7 @@ class ElementArray extends atoum\test
         $this->assert->array($details)->isEqualTo($details_reference);
     }
 
-    public function test__toString(): void
+    public function test__toString()
     {
         $val_4 = new \Smalot\PdfParser\Element\ElementNumeric('4');
         $val_2 = new \Smalot\PdfParser\Element\ElementNumeric('2');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementBoolean.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementBoolean.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -33,68 +33,66 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementBoolean
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementBoolean.
  */
 class ElementBoolean extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse('ABC', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse(' [ false ]', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse(' << true >>', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse(' / false ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse(' 0 true ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse(" 0 \n true ", null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
 
         // Valid.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse(' true ', null, $offset);
         $this->assert->boolean($element->getContent())->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(5);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse(' TRUE ', null, $offset);
         $this->assert->boolean($element->getContent())->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(5);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse(' True', null, $offset);
         $this->assert->boolean($element->getContent())->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(5);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse('true', null, $offset);
         $this->assert->boolean($element->getContent())->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(4);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse('False', null, $offset);
         $this->assert->boolean($element->getContent())->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(5);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementBoolean::parse(" \n true ", null, $offset);
         $this->assert->boolean($element->getContent())->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(7);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementBoolean('true');
         $this->assert->boolean($element->getContent())->isEqualTo(true);
@@ -102,7 +100,7 @@ class ElementBoolean extends atoum\test
         $this->assert->boolean($element->getContent())->isEqualTo(false);
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementBoolean('true');
         $this->assert->boolean($element->equals(true))->isEqualTo(true);
@@ -117,7 +115,7 @@ class ElementBoolean extends atoum\test
         $this->assert->boolean($element->equals(null))->isEqualTo(false);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementBoolean('true');
         $this->assert->boolean($element->contains(true))->isEqualTo(true);
@@ -125,7 +123,7 @@ class ElementBoolean extends atoum\test
         $this->assert->boolean($element->contains(1))->isEqualTo(false);
     }
 
-    public function test__toString()
+    public function test__toString(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementBoolean('true');
         $this->assert->castToString($element)->isEqualTo('true');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementBoolean.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementBoolean.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementBoolean.
+ * Class ElementBoolean
  */
 class ElementBoolean extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementBoolean.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementBoolean.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class ElementBoolean extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         // Skipped.
         $offset = 0;
@@ -92,7 +92,7 @@ class ElementBoolean extends atoum\test
         $this->assert->integer($offset)->isEqualTo(7);
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $element = new \Smalot\PdfParser\Element\ElementBoolean('true');
         $this->assert->boolean($element->getContent())->isEqualTo(true);
@@ -100,7 +100,7 @@ class ElementBoolean extends atoum\test
         $this->assert->boolean($element->getContent())->isEqualTo(false);
     }
 
-    public function testEquals(): void
+    public function testEquals()
     {
         $element = new \Smalot\PdfParser\Element\ElementBoolean('true');
         $this->assert->boolean($element->equals(true))->isEqualTo(true);
@@ -115,7 +115,7 @@ class ElementBoolean extends atoum\test
         $this->assert->boolean($element->equals(null))->isEqualTo(false);
     }
 
-    public function testContains(): void
+    public function testContains()
     {
         $element = new \Smalot\PdfParser\Element\ElementBoolean('true');
         $this->assert->boolean($element->contains(true))->isEqualTo(true);
@@ -123,7 +123,7 @@ class ElementBoolean extends atoum\test
         $this->assert->boolean($element->contains(1))->isEqualTo(false);
     }
 
-    public function test__toString(): void
+    public function test__toString()
     {
         $element = new \Smalot\PdfParser\Element\ElementBoolean('true');
         $this->assert->castToString($element)->isEqualTo('true');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementDate.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementDate.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -33,84 +33,82 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementDate
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementDate.
  */
 class ElementDate extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse('ABC', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(' [ (ABC) 5 6 ]', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(' << (invalid) >>', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(' / (FlateDecode) ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(' 0 (FlateDecode) ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(" 0 \n (FlateDecode) ", null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
 
         // Valid.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(' (D:20130901235555+02\'00\') ', null, $offset);
         $element->setFormat('c');
         $this->assert->object($element->getContent())->isInstanceOf('\DateTime');
         $this->assert->castToString($element)->isEqualTo('2013-09-01T23:55:55+02:00');
         $this->assert->integer($offset)->isEqualTo(26);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(' (D:20130901235555+02\'00\') ', null, $offset);
         $element->setFormat('c');
         $this->assert->object($element->getContent())->isInstanceOf('\DateTime');
         $this->assert->castToString($element)->isEqualTo('2013-09-01T23:55:55+02:00');
         $this->assert->integer($offset)->isEqualTo(26);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(' (D:20130901235555+02\'00\')', null, $offset);
         $element->setFormat('c');
         $this->assert->object($element->getContent())->isInstanceOf('\DateTime');
         $this->assert->castToString($element)->isEqualTo('2013-09-01T23:55:55+02:00');
         $this->assert->integer($offset)->isEqualTo(26);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse('(D:20130901235555+02\'00\')', null, $offset);
         $element->setFormat('c');
         $this->assert->object($element->getContent())->isInstanceOf('\DateTime');
         $this->assert->castToString($element)->isEqualTo('2013-09-01T23:55:55+02:00');
         $this->assert->integer($offset)->isEqualTo(25);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(" \n (D:20130901235555+02'00') ", null, $offset);
         $element->setFormat('c');
         $this->assert->object($element->getContent())->isInstanceOf('\DateTime');
         $this->assert->castToString($element)->isEqualTo('2013-09-01T23:55:55+02:00');
         $this->assert->integer($offset)->isEqualTo(28);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(" \n (D:20130901235555) ", null, $offset);
         $element->setFormat('c');
         $this->assert->object($element->getContent())->isInstanceOf('\DateTime');
         $this->assert->boolean($element->equals(new \DateTime('2013-09-01T23:55:55+00:00')))->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(21);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse("(D:20131206091846Z00'00')", null, $offset);
         $element->setFormat('c');
         $this->assert->object($element->getContent())->isInstanceOf('\DateTime');
         //$this->assert->boolean($element->equals(new \DateTime('2013-09-01T23:55:55')))->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(25);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(" \n (D:1-23-2014, 19:02:15-03'00') ", null, $offset);
         $element->setFormat('c');
         $this->assert->object($element->getContent())->isInstanceOf('\DateTime');
@@ -118,13 +116,13 @@ class ElementDate extends atoum\test
         $this->assert->integer($offset)->isEqualTo(33);
 
         // Format invalid
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementDate::parse(" \n (D:2013+02'00') ", null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementDate(new \DateTime('2013-09-01 23:55:55+02:00'));
         $this->assert->dateTime($element->getContent())->isEqualTo(new \DateTime('2013-09-01 21:55:55+00:00'));
@@ -137,7 +135,7 @@ class ElementDate extends atoum\test
         }
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementDate(new \DateTime('2013-09-01 23:55:55+02:00'));
         $element->setFormat('c');
@@ -148,14 +146,14 @@ class ElementDate extends atoum\test
         $this->assert->boolean($element->equals('ABC'))->isEqualTo(false);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementDate(new \DateTime('2013-09-01 23:55:55+02:00'));
         $this->assert->boolean($element->contains('2013-09-01T21:55:55+00:00'))->isEqualTo(true);
         $this->assert->boolean($element->contains('2013-06-15'))->isEqualTo(false);
     }
 
-    public function test__toString()
+    public function test__toString(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementDate(new \DateTime('2013-09-01 23:55:55+02:00'));
         $element->setFormat('c');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementDate.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementDate.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementDate.
+ * Class ElementDate
  */
 class ElementDate extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementDate.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementDate.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class ElementDate extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         // Skipped.
         $offset = 0;
@@ -122,7 +122,7 @@ class ElementDate extends atoum\test
         $this->assert->integer($offset)->isEqualTo(0);
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $element = new \Smalot\PdfParser\Element\ElementDate(new \DateTime('2013-09-01 23:55:55+02:00'));
         $this->assert->dateTime($element->getContent())->isEqualTo(new \DateTime('2013-09-01 21:55:55+00:00'));
@@ -135,7 +135,7 @@ class ElementDate extends atoum\test
         }
     }
 
-    public function testEquals(): void
+    public function testEquals()
     {
         $element = new \Smalot\PdfParser\Element\ElementDate(new \DateTime('2013-09-01 23:55:55+02:00'));
         $element->setFormat('c');
@@ -146,14 +146,14 @@ class ElementDate extends atoum\test
         $this->assert->boolean($element->equals('ABC'))->isEqualTo(false);
     }
 
-    public function testContains(): void
+    public function testContains()
     {
         $element = new \Smalot\PdfParser\Element\ElementDate(new \DateTime('2013-09-01 23:55:55+02:00'));
         $this->assert->boolean($element->contains('2013-09-01T21:55:55+00:00'))->isEqualTo(true);
         $this->assert->boolean($element->contains('2013-06-15'))->isEqualTo(false);
     }
 
-    public function test__toString(): void
+    public function test__toString()
     {
         $element = new \Smalot\PdfParser\Element\ElementDate(new \DateTime('2013-09-01 23:55:55+02:00'));
         $element->setFormat('c');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementHexa.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementHexa.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class ElementHexa extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         // Skipped.
         $offset = 0;

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementHexa.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementHexa.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementHexa.
+ * Class ElementHexa
  */
 class ElementHexa extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementHexa.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementHexa.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -33,71 +33,69 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementHexa
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementHexa.
  */
 class ElementHexa extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse('ABC', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(' [ <0020> 5 6 ]', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(' << <0020> >>', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(' / <0020> ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(' 0 <0020> ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(" 0 \n <0020> ", null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
 
         // Valid.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(' <0020> ', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo(' ');
         $this->assert->integer($offset)->isEqualTo(7);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(' <0020> ', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo(' ');
         $this->assert->integer($offset)->isEqualTo(7);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(' <0020>', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo(' ');
         $this->assert->integer($offset)->isEqualTo(7);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse('<0020>', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo(' ');
         $this->assert->integer($offset)->isEqualTo(6);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(" \n <0020> ", null, $offset);
         $this->assert->string($element->getContent())->isEqualTo(' ');
         $this->assert->integer($offset)->isEqualTo(9);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(" \n <5465616d204d616e6167656d656e742053797374656d73> ", null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Team Management Systems');
         $this->assert->integer($offset)->isEqualTo(51);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(" \n <5265706f72744275696c646572> ", null, $offset);
         $this->assert->object($element)->isInstanceOf('\Smalot\PdfParser\Element\ElementString');
         $this->assert->string($element->getContent())->isEqualTo('ReportBuilder');
         $this->assert->integer($offset)->isEqualTo(31);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementHexa::parse(" \n <443a3230313331323137313334303435303027303027> ", null, $offset);
         $this->assert->object($element)->isInstanceOf('\Smalot\PdfParser\Element\ElementDate');
         $this->assert->castToString($element)->isEqualTo('2013-12-17T13:40:45+00:00');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementMissing.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementMissing.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementMissing.
+ * Class ElementMissing
  */
 class ElementMissing extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementMissing.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementMissing.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class ElementMissing extends atoum\test
 {
-    public function testEquals(): void
+    public function testEquals()
     {
         $element = new \Smalot\PdfParser\Element\ElementMissing(null);
         $this->assert->boolean($element->equals(null))->isEqualTo(false);
@@ -46,13 +46,13 @@ class ElementMissing extends atoum\test
         $this->assert->boolean($element->equals(false))->isEqualTo(false);
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $element = new \Smalot\PdfParser\Element\ElementMissing(null);
         $this->assert->boolean($element->getContent())->isEqualTo(false);
     }
 
-    public function testContains(): void
+    public function testContains()
     {
         $element = new \Smalot\PdfParser\Element\ElementMissing(null);
         $this->assert->boolean($element->contains(null))->isEqualTo(false);
@@ -61,7 +61,7 @@ class ElementMissing extends atoum\test
         $this->assert->boolean($element->contains(false))->isEqualTo(false);
     }
 
-    public function test__toString(): void
+    public function test__toString()
     {
         $element = new \Smalot\PdfParser\Element\ElementMissing(null);
         $this->assert->castToString($element)->isEqualTo('');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementMissing.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementMissing.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -33,13 +33,11 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementMissing
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementMissing.
  */
 class ElementMissing extends atoum\test
 {
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementMissing(null);
         $this->assert->boolean($element->equals(null))->isEqualTo(false);
@@ -48,13 +46,13 @@ class ElementMissing extends atoum\test
         $this->assert->boolean($element->equals(false))->isEqualTo(false);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementMissing(null);
         $this->assert->boolean($element->getContent())->isEqualTo(false);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementMissing(null);
         $this->assert->boolean($element->contains(null))->isEqualTo(false);
@@ -63,7 +61,7 @@ class ElementMissing extends atoum\test
         $this->assert->boolean($element->contains(false))->isEqualTo(false);
     }
 
-    public function test__toString()
+    public function test__toString(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementMissing(null);
         $this->assert->castToString($element)->isEqualTo('');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementName.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementName.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementName.
+ * Class ElementName
  */
 class ElementName extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementName.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementName.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class ElementName extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         // Skipped.
         $offset = 0;
@@ -110,13 +110,13 @@ class ElementName extends atoum\test
         $this->assert->integer($offset)->isEqualTo(14);
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $element = new \Smalot\PdfParser\Element\ElementName('FlateDecode');
         $this->assert->string($element->getContent())->isEqualTo('FlateDecode');
     }
 
-    public function testEquals(): void
+    public function testEquals()
     {
         $element = new \Smalot\PdfParser\Element\ElementName('FlateDecode');
         $this->assert->boolean($element->equals('FlateDecode'))->isEqualTo(true);
@@ -131,7 +131,7 @@ class ElementName extends atoum\test
         $this->assert->boolean($element->equals('Flate-Decode3'))->isEqualTo(false);
     }
 
-    public function testContains(): void
+    public function testContains()
     {
         $element = new \Smalot\PdfParser\Element\ElementName('FlateDecode');
         $this->assert->boolean($element->contains('FlateDecode'))->isEqualTo(true);
@@ -146,7 +146,7 @@ class ElementName extends atoum\test
         $this->assert->boolean($element->contains('Flate-Decode3'))->isEqualTo(false);
     }
 
-    public function test__toString(): void
+    public function test__toString()
     {
         $element = new \Smalot\PdfParser\Element\ElementName('FlateDecode');
         $this->assert->castToString($element)->isEqualTo('FlateDecode');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementName.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementName.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -33,93 +33,90 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementName
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementName.
  */
 class ElementName extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse('ABC', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse(' [ /ABC 5 6 ]', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse(' << invalid >>', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse(' / FlateDecode ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse(' 0 /FlateDecode ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse(" 0 \n /FlateDecode ", null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
 
         // Valid.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse(' /FlateDecode ', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('FlateDecode');
         $this->assert->integer($offset)->isEqualTo(13);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse(' /FlateDecode', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('FlateDecode');
         $this->assert->integer($offset)->isEqualTo(13);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse('/FlateDecode', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('FlateDecode');
         $this->assert->integer($offset)->isEqualTo(12);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse(" \n /FlateDecode ", null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('FlateDecode');
         $this->assert->integer($offset)->isEqualTo(15);
 
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse('/FlateDecode2', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('FlateDecode2');
         $this->assert->integer($offset)->isEqualTo(13);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse('/Flate-Decode2', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Flate-Decode2');
         $this->assert->integer($offset)->isEqualTo(14);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse('/OJHCYD+Cambria', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('OJHCYD+Cambria');
         $this->assert->integer($offset)->isEqualTo(15);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse('/OJHCYD+Cambria,Bold', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('OJHCYD+Cambria,Bold');
         $this->assert->integer($offset)->isEqualTo(20);
 
-        //
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse('/Flate_Decode2', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Flate');
         $this->assert->integer($offset)->isEqualTo(6);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementName::parse('/Flate.Decode2', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Flate.Decode2');
         $this->assert->integer($offset)->isEqualTo(14);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementName('FlateDecode');
         $this->assert->string($element->getContent())->isEqualTo('FlateDecode');
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementName('FlateDecode');
         $this->assert->boolean($element->equals('FlateDecode'))->isEqualTo(true);
@@ -134,7 +131,7 @@ class ElementName extends atoum\test
         $this->assert->boolean($element->equals('Flate-Decode3'))->isEqualTo(false);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementName('FlateDecode');
         $this->assert->boolean($element->contains('FlateDecode'))->isEqualTo(true);
@@ -149,7 +146,7 @@ class ElementName extends atoum\test
         $this->assert->boolean($element->contains('Flate-Decode3'))->isEqualTo(false);
     }
 
-    public function test__toString()
+    public function test__toString(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementName('FlateDecode');
         $this->assert->castToString($element)->isEqualTo('FlateDecode');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementNull.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementNull.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementNull.
+ * Class ElementNull
  */
 class ElementNull extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementNull.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementNull.php
@@ -68,30 +68,30 @@ class ElementNull extends atoum\test
         // Valid.
         $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(' null ', null, $offset);
-        $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
+        $this->assert->boolean(null === $element->getContent())->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(5);
         $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(' null ', null, $offset);
-        $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
+        $this->assert->boolean(null === $element->getContent())->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(5);
         $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(' null', null, $offset);
-        $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
+        $this->assert->boolean(null === $element->getContent())->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(5);
         $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse('null', null, $offset);
-        $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
+        $this->assert->boolean(null === $element->getContent())->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(4);
         $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(" \n null ", null, $offset);
-        $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
+        $this->assert->boolean(null === $element->getContent())->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(7);
     }
 
     public function testGetContent()
     {
         $element = new \Smalot\PdfParser\Element\ElementNull('null');
-        $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
+        $this->assert->boolean(null === $element->getContent())->isEqualTo(true);
     }
 
     public function testEquals()

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementNull.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementNull.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class ElementNull extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         // Skipped.
         $offset = 0;
@@ -88,13 +88,13 @@ class ElementNull extends atoum\test
         $this->assert->integer($offset)->isEqualTo(7);
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $element = new \Smalot\PdfParser\Element\ElementNull('null');
         $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
     }
 
-    public function testEquals(): void
+    public function testEquals()
     {
         $element = new \Smalot\PdfParser\Element\ElementNull('null');
         $this->assert->boolean($element->equals(null))->isEqualTo(true);
@@ -103,7 +103,7 @@ class ElementNull extends atoum\test
         $this->assert->boolean($element->equals(1))->isEqualTo(false);
     }
 
-    public function testContains(): void
+    public function testContains()
     {
         $element = new \Smalot\PdfParser\Element\ElementNull('null');
         $this->assert->boolean($element->contains(null))->isEqualTo(true);
@@ -111,7 +111,7 @@ class ElementNull extends atoum\test
         $this->assert->boolean($element->contains(0))->isEqualTo(false);
     }
 
-    public function test__toString(): void
+    public function test__toString()
     {
         $element = new \Smalot\PdfParser\Element\ElementNull('null');
         $this->assert->castToString($element)->isEqualTo('null');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementNull.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementNull.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -33,70 +33,68 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementNull
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementNull.
  */
 class ElementNull extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse('ABC', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(' [ null ]', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(' << null >>', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(' / null ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(' 0 null ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(" 0 \n null ", null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
 
         // Valid.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(' null ', null, $offset);
         $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(5);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(' null ', null, $offset);
         $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(5);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(' null', null, $offset);
         $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(5);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse('null', null, $offset);
         $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(4);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNull::parse(" \n null ", null, $offset);
         $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
         $this->assert->integer($offset)->isEqualTo(7);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementNull('null');
         $this->assert->boolean(is_null($element->getContent()))->isEqualTo(true);
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementNull('null');
         $this->assert->boolean($element->equals(null))->isEqualTo(true);
@@ -105,7 +103,7 @@ class ElementNull extends atoum\test
         $this->assert->boolean($element->equals(1))->isEqualTo(false);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementNull('null');
         $this->assert->boolean($element->contains(null))->isEqualTo(true);
@@ -113,7 +111,7 @@ class ElementNull extends atoum\test
         $this->assert->boolean($element->contains(0))->isEqualTo(false);
     }
 
-    public function test__toString()
+    public function test__toString(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementNull('null');
         $this->assert->castToString($element)->isEqualTo('null');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementNumeric.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementNumeric.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementNumeric.
+ * Class ElementNumeric
  */
 class ElementNumeric extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementNumeric.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementNumeric.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class ElementNumeric extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         // Skipped.
         $offset = 0;
@@ -88,7 +88,7 @@ class ElementNumeric extends atoum\test
         $this->assert->integer($offset)->isEqualTo(5);
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $element = new \Smalot\PdfParser\Element\ElementNumeric('B');
         $this->assert->float($element->getContent())->isEqualTo(0.0);
@@ -104,7 +104,7 @@ class ElementNumeric extends atoum\test
         $this->assert->float($element->getContent())->isEqualTo(2.0);
     }
 
-    public function testEquals(): void
+    public function testEquals()
     {
         $element = new \Smalot\PdfParser\Element\ElementNumeric('1');
         $this->assert->boolean($element->equals('B'))->isEqualTo(false);
@@ -132,7 +132,7 @@ class ElementNumeric extends atoum\test
         $this->assert->boolean($element->equals('-3.5'))->isEqualTo(false);
     }
 
-    public function testContains(): void
+    public function testContains()
     {
         $element = new \Smalot\PdfParser\Element\ElementNumeric('1');
         $this->assert->boolean($element->contains('B'))->isEqualTo(false);
@@ -160,7 +160,7 @@ class ElementNumeric extends atoum\test
         $this->assert->boolean($element->contains('-3.5'))->isEqualTo(false);
     }
 
-    public function test__toString(): void
+    public function test__toString()
     {
         $element = new \Smalot\PdfParser\Element\ElementNumeric('B');
         $this->assert->castToString($element)->isEqualTo('0');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementNumeric.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementNumeric.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -33,64 +33,62 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementNumeric
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementNumeric.
  */
 class ElementNumeric extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse('ABC', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse(' [ 2 ]', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse(' /2', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse(" /2 \n 2", null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
 
         // Valid.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse(' -2', null, $offset);
         $this->assert->float($element->getContent())->isEqualTo(-2.0);
         $this->assert->integer($offset)->isEqualTo(3);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse('2BC', null, $offset);
         $this->assert->float($element->getContent())->isEqualTo(2.0);
         $this->assert->integer($offset)->isEqualTo(1);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse(' 2BC', null, $offset);
         $this->assert->float($element->getContent())->isEqualTo(2.0);
         $this->assert->integer($offset)->isEqualTo(2);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse(' -2BC', null, $offset);
         $this->assert->float($element->getContent())->isEqualTo(-2.0);
         $this->assert->integer($offset)->isEqualTo(3);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse(' -2', null, $offset);
         $this->assert->float($element->getContent())->isEqualTo(-2.0);
         $this->assert->integer($offset)->isEqualTo(3);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse(' 2 0 obj', null, $offset);
         $this->assert->float($element->getContent())->isEqualTo(2.0);
         $this->assert->integer($offset)->isEqualTo(2);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementNumeric::parse(" \n -2 ", null, $offset);
         $this->assert->float($element->getContent())->isEqualTo(-2.0);
         $this->assert->integer($offset)->isEqualTo(5);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementNumeric('B');
         $this->assert->float($element->getContent())->isEqualTo(0.0);
@@ -106,7 +104,7 @@ class ElementNumeric extends atoum\test
         $this->assert->float($element->getContent())->isEqualTo(2.0);
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementNumeric('1');
         $this->assert->boolean($element->equals('B'))->isEqualTo(false);
@@ -134,7 +132,7 @@ class ElementNumeric extends atoum\test
         $this->assert->boolean($element->equals('-3.5'))->isEqualTo(false);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementNumeric('1');
         $this->assert->boolean($element->contains('B'))->isEqualTo(false);
@@ -162,7 +160,7 @@ class ElementNumeric extends atoum\test
         $this->assert->boolean($element->contains('-3.5'))->isEqualTo(false);
     }
 
-    public function test__toString()
+    public function test__toString(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementNumeric('B');
         $this->assert->castToString($element)->isEqualTo('0');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementString.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementString.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -33,96 +33,94 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementString
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementString.
  */
 class ElementString extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse('ABC', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse(' [ (ABC) 5 6 ]', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse(' << (invalid) >>', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse(' / (FlateDecode) ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse(' 0 (FlateDecode) ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse(" 0 \n (FlateDecode) ", null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
 
         // Valid.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse(' (Copyright) ', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Copyright');
         $this->assert->integer($offset)->isEqualTo(12);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse(' (Copyright) ', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Copyright');
         $this->assert->integer($offset)->isEqualTo(12);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse(' (Copyright)', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Copyright');
         $this->assert->integer($offset)->isEqualTo(12);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse('(Copyright)', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Copyright');
         $this->assert->integer($offset)->isEqualTo(11);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse('(Copy-right2)', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Copy-right2');
         $this->assert->integer($offset)->isEqualTo(13);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse(" \n (Copyright) ", null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Copyright');
         $this->assert->integer($offset)->isEqualTo(14);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse('()', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('');
         $this->assert->integer($offset)->isEqualTo(2);
 
         // Complex study case : Unicode + octal.
-        $offset  = 0;
-        $element = \Smalot\PdfParser\Element\ElementString::parse("(ABC\\))", null, $offset);
+        $offset = 0;
+        $element = \Smalot\PdfParser\Element\ElementString::parse('(ABC\\))', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('ABC)');
         $this->assert->integer($offset)->isEqualTo(7);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementString::parse("(\xFE\xFF\\000M)", null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('M');
         $this->assert->integer($offset)->isEqualTo(9);
-        $offset  = 0;
-        $element = \Smalot\PdfParser\Element\ElementString::parse("(<20>)", null, $offset);
+        $offset = 0;
+        $element = \Smalot\PdfParser\Element\ElementString::parse('(<20>)', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo(' ');
         $this->assert->integer($offset)->isEqualTo(6);
-        $offset  = 0;
-        $element = \Smalot\PdfParser\Element\ElementString::parse("(Gutter\\ console\\ assembly)", null, $offset);
+        $offset = 0;
+        $element = \Smalot\PdfParser\Element\ElementString::parse('(Gutter\\ console\\ assembly)', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('Gutter console assembly');
         $this->assert->integer($offset)->isEqualTo(27);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementString('Copyright');
         $this->assert->string($element->getContent())->isEqualTo('Copyright');
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementString('CopyRight');
         $this->assert->boolean($element->equals('CopyRight'))->isEqualTo(true);
@@ -137,7 +135,7 @@ class ElementString extends atoum\test
         $this->assert->boolean($element->equals('Flate-Decode3'))->isEqualTo(false);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementString('CopyRight');
         $this->assert->boolean($element->contains('CopyRight'))->isEqualTo(true);
@@ -148,7 +146,7 @@ class ElementString extends atoum\test
         $this->assert->boolean($element->contains('CopyRight3'))->isEqualTo(false);
     }
 
-    public function test__toString()
+    public function test__toString(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementString('CopyRight');
         $this->assert->castToString($element)->isEqualTo('CopyRight');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementString.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementString.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class ElementString extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         // Skipped.
         $offset = 0;
@@ -114,13 +114,13 @@ class ElementString extends atoum\test
         $this->assert->integer($offset)->isEqualTo(27);
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $element = new \Smalot\PdfParser\Element\ElementString('Copyright');
         $this->assert->string($element->getContent())->isEqualTo('Copyright');
     }
 
-    public function testEquals(): void
+    public function testEquals()
     {
         $element = new \Smalot\PdfParser\Element\ElementString('CopyRight');
         $this->assert->boolean($element->equals('CopyRight'))->isEqualTo(true);
@@ -135,7 +135,7 @@ class ElementString extends atoum\test
         $this->assert->boolean($element->equals('Flate-Decode3'))->isEqualTo(false);
     }
 
-    public function testContains(): void
+    public function testContains()
     {
         $element = new \Smalot\PdfParser\Element\ElementString('CopyRight');
         $this->assert->boolean($element->contains('CopyRight'))->isEqualTo(true);
@@ -146,7 +146,7 @@ class ElementString extends atoum\test
         $this->assert->boolean($element->contains('CopyRight3'))->isEqualTo(false);
     }
 
-    public function test__toString(): void
+    public function test__toString()
     {
         $element = new \Smalot\PdfParser\Element\ElementString('CopyRight');
         $this->assert->castToString($element)->isEqualTo('CopyRight');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementString.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementString.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementString.
+ * Class ElementString
  */
 class ElementString extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementStruct.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementStruct.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -33,22 +33,20 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementStruct
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementStruct.
  */
 class ElementStruct extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
-        $document = new \Smalot\PdfParser\Document(array());
+        $document = new \Smalot\PdfParser\Document([]);
 
         // Skipped.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementStruct::parse('ABC', $document, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementStruct::parse(
             ' [ << /Filter /FlateDecode >> ]',
             $document,
@@ -56,15 +54,15 @@ class ElementStruct extends atoum\test
         );
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementStruct::parse(' / << /Filter /FlateDecode >> ', $document, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementStruct::parse(' 0 << /Filter /FlateDecode >> ', $document, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementStruct::parse(
             " 0 \n << /Filter /FlateDecode >> ",
             $document,
@@ -74,19 +72,19 @@ class ElementStruct extends atoum\test
         $this->assert->integer($offset)->isEqualTo(0);
 
         // Valid.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementStruct::parse(' << /Filter /FlateDecode >> ', $document, $offset);
         $this->assert->object($element)->isInstanceOf('\Smalot\PdfParser\Header');
         $this->assert->integer($offset)->isEqualTo(27);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementStruct::parse(' << /Filter /FlateDecode >>', $document, $offset);
         $this->assert->object($element)->isInstanceOf('\Smalot\PdfParser\Header');
         $this->assert->integer($offset)->isEqualTo(27);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementStruct::parse('<< /Filter /FlateDecode >>', $document, $offset);
         $this->assert->object($element)->isInstanceOf('\Smalot\PdfParser\Header');
         $this->assert->integer($offset)->isEqualTo(26);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementStruct::parse(
             " \n << /Filter /FlateDecode >> ",
             $document,

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementStruct.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementStruct.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class ElementStruct extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         $document = new \Smalot\PdfParser\Document([]);
 

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementStruct.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementStruct.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementStruct.
+ * Class ElementStruct
  */
 class ElementStruct extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementXRef.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementXRef.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units\Element;
@@ -33,76 +33,74 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementXRef
- *
- * @package Smalot\PdfParser\Tests\Units\Element
+ * Class ElementXRef.
  */
 class ElementXRef extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse('ABC', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse(' [ 5 0 R ]', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse(' << 5 0 R >>', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse(' / 5 0 R ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse(' 0 5 0 R ', null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse(" 0 \n 5 0 R ", null, $offset);
         $this->assert->boolean($element)->isEqualTo(false);
         $this->assert->integer($offset)->isEqualTo(0);
 
         // Valid.
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse(' 5 0 R ', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('5_0');
         $this->assert->integer($offset)->isEqualTo(6);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse(' 5 0 R ', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('5_0');
         $this->assert->integer($offset)->isEqualTo(6);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse(' 5 0 R', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('5_0');
         $this->assert->integer($offset)->isEqualTo(6);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse('5 0 R', null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('5_0');
         $this->assert->integer($offset)->isEqualTo(5);
-        $offset  = 0;
+        $offset = 0;
         $element = \Smalot\PdfParser\Element\ElementXRef::parse(" \n 5 0 R ", null, $offset);
         $this->assert->string($element->getContent())->isEqualTo('5_0');
         $this->assert->integer($offset)->isEqualTo(8);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementXRef('5_0');
         $this->assert->string($element->getContent())->isEqualTo('5_0');
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementXRef('5_0');
         $this->assert->string($element->getId())->isEqualTo('5_0');
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementXRef('5_0');
         $this->assert->boolean($element->equals(5))->isEqualTo(true);
@@ -110,7 +108,7 @@ class ElementXRef extends atoum\test
         $this->assert->boolean($element->equals($element))->isEqualTo(true);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementXRef('5_0');
         $this->assert->boolean($element->contains(5))->isEqualTo(true);
@@ -118,7 +116,7 @@ class ElementXRef extends atoum\test
         $this->assert->boolean($element->contains($element))->isEqualTo(true);
     }
 
-    public function test__toString()
+    public function test__toString(): void
     {
         $element = new \Smalot\PdfParser\Element\ElementXRef('5_0');
         $this->assert->castToString($element)->isEqualTo('#Obj#5_0');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementXRef.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementXRef.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class ElementXRef extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         // Skipped.
         $offset = 0;
@@ -88,19 +88,19 @@ class ElementXRef extends atoum\test
         $this->assert->integer($offset)->isEqualTo(8);
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $element = new \Smalot\PdfParser\Element\ElementXRef('5_0');
         $this->assert->string($element->getContent())->isEqualTo('5_0');
     }
 
-    public function testGetId(): void
+    public function testGetId()
     {
         $element = new \Smalot\PdfParser\Element\ElementXRef('5_0');
         $this->assert->string($element->getId())->isEqualTo('5_0');
     }
 
-    public function testEquals(): void
+    public function testEquals()
     {
         $element = new \Smalot\PdfParser\Element\ElementXRef('5_0');
         $this->assert->boolean($element->equals(5))->isEqualTo(true);
@@ -108,7 +108,7 @@ class ElementXRef extends atoum\test
         $this->assert->boolean($element->equals($element))->isEqualTo(true);
     }
 
-    public function testContains(): void
+    public function testContains()
     {
         $element = new \Smalot\PdfParser\Element\ElementXRef('5_0');
         $this->assert->boolean($element->contains(5))->isEqualTo(true);
@@ -116,7 +116,7 @@ class ElementXRef extends atoum\test
         $this->assert->boolean($element->contains($element))->isEqualTo(true);
     }
 
-    public function test__toString(): void
+    public function test__toString()
     {
         $element = new \Smalot\PdfParser\Element\ElementXRef('5_0');
         $this->assert->castToString($element)->isEqualTo('#Obj#5_0');

--- a/src/Smalot/PdfParser/Tests/Units/Element/ElementXRef.php
+++ b/src/Smalot/PdfParser/Tests/Units/Element/ElementXRef.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units\Element;
 use mageekguy\atoum;
 
 /**
- * Class ElementXRef.
+ * Class ElementXRef
  */
 class ElementXRef extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Font.php
+++ b/src/Smalot/PdfParser/Tests/Units/Font.php
@@ -34,7 +34,7 @@ use mageekguy\atoum;
 use Smalot\PdfParser\Header;
 
 /**
- * Class Font.
+ * Class Font
  */
 class Font extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Font.php
+++ b/src/Smalot/PdfParser/Tests/Units/Font.php
@@ -38,7 +38,7 @@ use Smalot\PdfParser\Header;
  */
 class Font extends atoum\test
 {
-    public function testGetName(): void
+    public function testGetName()
     {
         $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
         $parser = new \Smalot\PdfParser\Parser();
@@ -49,7 +49,7 @@ class Font extends atoum\test
         $this->assert->string($font->getName())->isEqualTo('OJHCYD+Cambria,Bold');
     }
 
-    public function testGetType(): void
+    public function testGetType()
     {
         $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
         $parser = new \Smalot\PdfParser\Parser();
@@ -60,7 +60,7 @@ class Font extends atoum\test
         $this->assert->string($font->getType())->isEqualTo('TrueType');
     }
 
-    public function testGetDetails(): void
+    public function testGetDetails()
     {
         $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
         $parser = new \Smalot\PdfParser\Parser();
@@ -107,7 +107,7 @@ class Font extends atoum\test
         $this->assert->array($font->getDetails())->isEqualTo($reference);
     }
 
-    public function testTranslateChar(): void
+    public function testTranslateChar()
     {
         $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
         $parser = new \Smalot\PdfParser\Parser();
@@ -123,7 +123,7 @@ class Font extends atoum\test
         $this->assert->string($font->translateChar("\x99"))->isEqualTo(\Smalot\PdfParser\Font::MISSING);
     }
 
-    public function testLoadTranslateTable(): void
+    public function testLoadTranslateTable()
     {
         $document = new \Smalot\PdfParser\Document();
 
@@ -203,7 +203,7 @@ end';
         $this->assert->string($table[92])->isEqualTo('y');
     }
 
-    public function testDecodeHexadecimal(): void
+    public function testDecodeHexadecimal()
     {
         $hexa = '<322041>';
         $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa))->isEqualTo('2 A');
@@ -242,24 +242,24 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
         $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa))->isEqualTo($hexa);
     }
 
-    public function testDecodeOctal(): void
+    public function testDecodeOctal()
     {
         $this->assert->string(\Smalot\PdfParser\Font::decodeOctal('\\101\\102\\040\\103'))->isEqualTo('AB C');
         $this->assert->string(\Smalot\PdfParser\Font::decodeOctal('\\101\\102\\040\\103D'))->isEqualTo('AB CD');
     }
 
-    public function testDecodeEntities(): void
+    public function testDecodeEntities()
     {
         $this->assert->string(\Smalot\PdfParser\Font::decodeEntities('File#20Type'))->isEqualTo('File Type');
         $this->assert->string(\Smalot\PdfParser\Font::decodeEntities('File##20Ty#pe'))->isEqualTo('File# Ty#pe');
     }
 
-    public function testDecodeUnicode(): void
+    public function testDecodeUnicode()
     {
         $this->assert->string(\Smalot\PdfParser\Font::decodeUnicode("\xFE\xFF\x00A\x00B"))->isEqualTo('AB');
     }
 
-    public function testDecodeText(): void
+    public function testDecodeText()
     {
         $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
         $parser = new \Smalot\PdfParser\Parser();
@@ -320,7 +320,7 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
         $this->assert->string($font->decodeText($commands))->isEqualTo('æöü');
     }
 
-    public function testXmlContent(): void
+    public function testXmlContent()
     {
         $filename = __DIR__.'/../../../../../samples/bugs/Issue18.pdf';
         $parser = new \Smalot\PdfParser\Parser();

--- a/src/Smalot/PdfParser/Tests/Units/Font.php
+++ b/src/Smalot/PdfParser/Tests/Units/Font.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units;
@@ -34,90 +34,85 @@ use mageekguy\atoum;
 use Smalot\PdfParser\Header;
 
 /**
- * Class Font
- *
- * @package Smalot\PdfParser\Tests\Units
+ * Class Font.
  */
 class Font extends atoum\test
 {
-    public function testGetName()
+    public function testGetName(): void
     {
-        $filename = __DIR__ . '/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
-        $parser   = new \Smalot\PdfParser\Parser();
+        $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
-        $fonts    = $document->getFonts();
-        $font     = reset($fonts);
+        $fonts = $document->getFonts();
+        $font = reset($fonts);
 
         $this->assert->string($font->getName())->isEqualTo('OJHCYD+Cambria,Bold');
     }
 
-    public function testGetType()
+    public function testGetType(): void
     {
-        $filename = __DIR__ . '/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
-        $parser   = new \Smalot\PdfParser\Parser();
+        $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
-        $fonts    = $document->getFonts();
-        $font     = reset($fonts);
+        $fonts = $document->getFonts();
+        $font = reset($fonts);
 
         $this->assert->string($font->getType())->isEqualTo('TrueType');
     }
 
-    public function testGetDetails()
+    public function testGetDetails(): void
     {
-        $filename  = __DIR__ . '/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
-        $parser    = new \Smalot\PdfParser\Parser();
-        $document  = $parser->parseFile($filename);
-        $fonts     = $document->getFonts();
-        $font      = reset($fonts);
-        $reference = array(
-            'Name'           => 'OJHCYD+Cambria,Bold',
-            'Type'           => 'TrueType',
-            'Encoding'       => 'Ansi',
-            'BaseFont'       => 'OJHCYD+Cambria,Bold',
-            'FontDescriptor' =>
-            array(
-                'Type'         => 'FontDescriptor',
-                'FontName'     => 'OJHCYD+Cambria,Bold',
-                'Flags'        => 4,
-                'Ascent'       => 699,
-                'CapHeight'    => 699,
-                'Descent'      => -7,
-                'ItalicAngle'  => 0,
-                'StemV'        => 128,
+        $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
+        $document = $parser->parseFile($filename);
+        $fonts = $document->getFonts();
+        $font = reset($fonts);
+        $reference = [
+            'Name' => 'OJHCYD+Cambria,Bold',
+            'Type' => 'TrueType',
+            'Encoding' => 'Ansi',
+            'BaseFont' => 'OJHCYD+Cambria,Bold',
+            'FontDescriptor' => [
+                'Type' => 'FontDescriptor',
+                'FontName' => 'OJHCYD+Cambria,Bold',
+                'Flags' => 4,
+                'Ascent' => 699,
+                'CapHeight' => 699,
+                'Descent' => -7,
+                'ItalicAngle' => 0,
+                'StemV' => 128,
                 'MissingWidth' => 658,
-            ),
-            'ToUnicode'      =>
-            array(
+            ],
+            'ToUnicode' => [
                 'Filter' => 'FlateDecode',
                 'Length' => 219,
-            ),
-            'FirstChar'      => 1,
-            'LastChar'       => 11,
-            'Widths'         =>
-            array(
-                0  => 705,
-                1  => 569,
-                2  => 469,
-                3  => 597,
-                4  => 890,
-                5  => 531,
-                6  => 604,
-                7  => 365,
-                8  => 220,
-                9  => 314,
+            ],
+            'FirstChar' => 1,
+            'LastChar' => 11,
+            'Widths' => [
+                0 => 705,
+                1 => 569,
+                2 => 469,
+                3 => 597,
+                4 => 890,
+                5 => 531,
+                6 => 604,
+                7 => 365,
+                8 => 220,
+                9 => 314,
                 10 => 308,
-            ),
-            'Subtype'        => 'TrueType',
-        );
+            ],
+            'Subtype' => 'TrueType',
+        ];
         $this->assert->array($font->getDetails())->isEqualTo($reference);
     }
 
-    public function testTranslateChar()
+    public function testTranslateChar(): void
     {
-        $filename = __DIR__ . '/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
-        $parser   = new \Smalot\PdfParser\Parser();
+        $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
-        $fonts    = $document->getFonts();
+        $fonts = $document->getFonts();
         /** @var \Smalot\PdfParser\Font $font */
         $font = reset($fonts);
 
@@ -128,13 +123,13 @@ class Font extends atoum\test
         $this->assert->string($font->translateChar("\x99"))->isEqualTo(\Smalot\PdfParser\Font::MISSING);
     }
 
-    public function testLoadTranslateTable()
+    public function testLoadTranslateTable(): void
     {
         $document = new \Smalot\PdfParser\Document();
 
         $content = '<</Type/Font /Subtype /Type0 /ToUnicode 2 0 R>>';
-        $header  = Header::parse($content, $document);
-        $font    = new \Smalot\PdfParser\Font($document, $header);
+        $header = Header::parse($content, $document);
+        $font = new \Smalot\PdfParser\Font($document, $header);
 
         $content = '/CIDInit /ProcSet findresource begin
 14 dict begin
@@ -188,7 +183,7 @@ end
 end';
         $unicode = new \Smalot\PdfParser\PDFObject($document, null, $content);
 
-        $document->setObjects(array('1_0' => $font, '2_0' => $unicode));
+        $document->setObjects(['1_0' => $font, '2_0' => $unicode]);
 
         $font->init();
         // Test reload
@@ -208,12 +203,12 @@ end';
         $this->assert->string($table[92])->isEqualTo('y');
     }
 
-    public function testDecodeHexadecimal()
+    public function testDecodeHexadecimal(): void
     {
         $hexa = '<322041>';
-        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa))->isEqualTo("2 A");
-        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa, false))->isEqualTo("2 A");
-        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa, true))->isEqualTo("(2 A)");
+        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa))->isEqualTo('2 A');
+        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa, false))->isEqualTo('2 A');
+        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa, true))->isEqualTo('(2 A)');
 
         $hexa = '<003200200041>';
         $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa))->isEqualTo("\x002\x00 \x00A");
@@ -228,9 +223,9 @@ end';
         );
 
         $hexa = '<3220> 8 <41>';
-        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa))->isEqualTo("2  8 A");
-        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa, false))->isEqualTo("2  8 A");
-        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa, true))->isEqualTo("(2 ) 8 (A)");
+        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa))->isEqualTo('2  8 A');
+        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa, false))->isEqualTo('2  8 A');
+        $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa, true))->isEqualTo('(2 ) 8 (A)');
 
         $hexa = '<00320020005C>-10<0041>';
         $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa))->isEqualTo("\x002\x00 \x00\\-10\x00A");
@@ -247,88 +242,88 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
         $this->assert->string(\Smalot\PdfParser\Font::decodeHexadecimal($hexa))->isEqualTo($hexa);
     }
 
-    public function testDecodeOctal()
+    public function testDecodeOctal(): void
     {
-        $this->assert->string(\Smalot\PdfParser\Font::decodeOctal("\\101\\102\\040\\103"))->isEqualTo('AB C');
-        $this->assert->string(\Smalot\PdfParser\Font::decodeOctal("\\101\\102\\040\\103D"))->isEqualTo('AB CD');
+        $this->assert->string(\Smalot\PdfParser\Font::decodeOctal('\\101\\102\\040\\103'))->isEqualTo('AB C');
+        $this->assert->string(\Smalot\PdfParser\Font::decodeOctal('\\101\\102\\040\\103D'))->isEqualTo('AB CD');
     }
 
-    public function testDecodeEntities()
+    public function testDecodeEntities(): void
     {
-        $this->assert->string(\Smalot\PdfParser\Font::decodeEntities("File#20Type"))->isEqualTo('File Type');
-        $this->assert->string(\Smalot\PdfParser\Font::decodeEntities("File##20Ty#pe"))->isEqualTo('File# Ty#pe');
+        $this->assert->string(\Smalot\PdfParser\Font::decodeEntities('File#20Type'))->isEqualTo('File Type');
+        $this->assert->string(\Smalot\PdfParser\Font::decodeEntities('File##20Ty#pe'))->isEqualTo('File# Ty#pe');
     }
 
-    public function testDecodeUnicode()
+    public function testDecodeUnicode(): void
     {
         $this->assert->string(\Smalot\PdfParser\Font::decodeUnicode("\xFE\xFF\x00A\x00B"))->isEqualTo('AB');
     }
 
-    public function testDecodeText()
+    public function testDecodeText(): void
     {
-        $filename = __DIR__ . '/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
-        $parser   = new \Smalot\PdfParser\Parser();
+        $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
-        $fonts    = $document->getFonts();
+        $fonts = $document->getFonts();
         /** @var \Smalot\PdfParser\Font $font */
         // Cambria
-        $font     = reset($fonts);
-        $commands = array(
-            array(
+        $font = reset($fonts);
+        $commands = [
+            [
                 't' => '',
                 'c' => "\x01\x02",
-            ),
-            array(
+            ],
+            [
                 't' => 'n',
                 'c' => -10,
-            ),
-            array(
+            ],
+            [
                 't' => '',
                 'c' => "\x03",
-            ),
-            array(
+            ],
+            [
                 't' => '',
                 'c' => "\x04",
-            ),
-            array(
+            ],
+            [
                 't' => 'n',
                 'c' => -100,
-            ),
-            array(
+            ],
+            [
                 't' => '<',
-                'c' => "01020304",
-            ),
-        );
+                'c' => '01020304',
+            ],
+        ];
         $this->assert->string($font->decodeText($commands))->isEqualTo('Docu Docu');
 
         //Check if ANSI/Unicode detection is working properly
-        $filename = __DIR__ . '/../../../../../samples/bugs/Issue95_ANSI.pdf';
-        $parser   = new \Smalot\PdfParser\Parser();
+        $filename = __DIR__.'/../../../../../samples/bugs/Issue95_ANSI.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
-        $fonts    = $document->getFonts();
+        $fonts = $document->getFonts();
         /** @var \Smalot\PdfParser\Font $font */
-        $font     = reset($fonts);
-        $commands = array(
-            array(
+        $font = reset($fonts);
+        $commands = [
+            [
                 't' => '<',
-                'c' => "E6F6FC", //ANSI encoded string
-            ),
-        );
+                'c' => 'E6F6FC', //ANSI encoded string
+            ],
+        ];
         $this->assert->string($font->decodeText($commands))->isEqualTo('æöü');
 
-        $commands = array(
-            array(
+        $commands = [
+            [
                 't' => '<',
-                'c' => "C3A6C3B6C3BC", //Unicode encoded string
-            ),
-        );
+                'c' => 'C3A6C3B6C3BC', //Unicode encoded string
+            ],
+        ];
         $this->assert->string($font->decodeText($commands))->isEqualTo('æöü');
     }
 
-    public function testXmlContent()
+    public function testXmlContent(): void
     {
-        $filename = __DIR__ . '/../../../../../samples/bugs/Issue18.pdf';
-        $parser   = new \Smalot\PdfParser\Parser();
+        $filename = __DIR__.'/../../../../../samples/bugs/Issue18.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
         $pages = $document->getPages();
         $text = trim($pages[0]->getText());

--- a/src/Smalot/PdfParser/Tests/Units/Header.php
+++ b/src/Smalot/PdfParser/Tests/Units/Header.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class Header extends atoum\test
 {
-    public function testParse(): void
+    public function testParse()
     {
         $document = new \Smalot\PdfParser\Document();
 
@@ -71,7 +71,7 @@ class Header extends atoum\test
         $this->assert->array($header->getElements())->hasSize(1);
     }
 
-    public function testGetElements(): void
+    public function testGetElements()
     {
         $document = new \Smalot\PdfParser\Document();
 
@@ -88,7 +88,7 @@ class Header extends atoum\test
         $this->assert->string($types['Subtype'])->isEqualTo('Smalot\PdfParser\Element\ElementName');
     }
 
-    public function testHas(): void
+    public function testHas()
     {
         $document = new \Smalot\PdfParser\Document();
 
@@ -102,7 +102,7 @@ class Header extends atoum\test
         $this->assert->boolean($header->has('Text'))->isEqualTo(false);
     }
 
-    public function testGet(): void
+    public function testGet()
     {
         $document = new \Smalot\PdfParser\Document();
 
@@ -119,7 +119,7 @@ class Header extends atoum\test
         $this->assert->object($header->get('Resources'))->isInstanceOf('\Smalot\PdfParser\Element\ElementMissing');
     }
 
-    public function testResolveXRef(): void
+    public function testResolveXRef()
     {
         $document = new \Smalot\PdfParser\Document();
         $content = '<</Type/Page/SubType/Text/Font 5 0 R/Resources 8 0 R>>foo';

--- a/src/Smalot/PdfParser/Tests/Units/Header.php
+++ b/src/Smalot/PdfParser/Tests/Units/Header.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units;
@@ -33,19 +33,17 @@ namespace Smalot\PdfParser\Tests\Units;
 use mageekguy\atoum;
 
 /**
- * Class Header
- *
- * @package Smalot\PdfParser\Tests\Units
+ * Class Header.
  */
 class Header extends atoum\test
 {
-    public function testParse()
+    public function testParse(): void
     {
         $document = new \Smalot\PdfParser\Document();
 
-        $content  = '<</Type/Page/SubType/Text>>foo';
+        $content = '<</Type/Page/SubType/Text>>foo';
         $position = 0;
-        $header   = \Smalot\PdfParser\Header::parse($content, $document, $position);
+        $header = \Smalot\PdfParser\Header::parse($content, $document, $position);
 
         $this->assert->object($header)->isInstanceOf('\Smalot\PdfParser\Header');
         $this->assert->integer($position)->isEqualTo(27);
@@ -53,33 +51,33 @@ class Header extends atoum\test
 
         // No header to parse
         $this->assert->castToString($header->get('Type'))->isEqualTo('Page');
-        $content  = 'foo';
+        $content = 'foo';
         $position = 0;
-        $header   = \Smalot\PdfParser\Header::parse($content, $document, $position);
+        $header = \Smalot\PdfParser\Header::parse($content, $document, $position);
 
         $this->assert->object($header)->isInstanceOf('\Smalot\PdfParser\Header');
         $this->assert->integer($position)->isEqualTo(0);
         $this->assert->array($header->getElements())->hasSize(0);
 
         $position = 0;
-        $content  = "<</CreationDate(D:20100309184803+01'00')/Author(Utilisateur)/Creator(PScript5.dll Version 5.2.2)/Producer(Acrobat Distiller 7.0.5 \(Windows\))/ModDate(D:20100310104810+01'00')/Title(Microsoft Word - CLEMI.docx)>>";
-        $header   = \Smalot\PdfParser\Header::parse($content, $document, $position);
+        $content = "<</CreationDate(D:20100309184803+01'00')/Author(Utilisateur)/Creator(PScript5.dll Version 5.2.2)/Producer(Acrobat Distiller 7.0.5 \(Windows\))/ModDate(D:20100310104810+01'00')/Title(Microsoft Word - CLEMI.docx)>>";
+        $header = \Smalot\PdfParser\Header::parse($content, $document, $position);
         $this->assert->integer($position)->isEqualTo(212);
 
         $position = 0;
-        $content  = '[5 0 R ] foo';
-        $header   = \Smalot\PdfParser\Header::parse($content, $document, $position);
+        $content = '[5 0 R ] foo';
+        $header = \Smalot\PdfParser\Header::parse($content, $document, $position);
         $this->assert->integer($position)->isEqualTo(8);
         $this->assert->array($header->getElements())->hasSize(1);
     }
 
-    public function testGetElements()
+    public function testGetElements(): void
     {
         $document = new \Smalot\PdfParser\Document();
 
-        $content  = '<</Type/Page/Subtype/Text>>foo';
+        $content = '<</Type/Page/Subtype/Text>>foo';
         $position = 0;
-        $header   = \Smalot\PdfParser\Header::parse($content, $document, $position);
+        $header = \Smalot\PdfParser\Header::parse($content, $document, $position);
 
         $this->assert->array($elements = $header->getElements())->hasSize(2);
         $this->assert->object(current($elements))->isInstanceOf('\Smalot\PdfParser\Element\ElementName');
@@ -90,13 +88,13 @@ class Header extends atoum\test
         $this->assert->string($types['Subtype'])->isEqualTo('Smalot\PdfParser\Element\ElementName');
     }
 
-    public function testHas()
+    public function testHas(): void
     {
         $document = new \Smalot\PdfParser\Document();
 
-        $content  = '<</Type/Page/SubType/Text/Font 5 0 R>>foo';
+        $content = '<</Type/Page/SubType/Text/Font 5 0 R>>foo';
         $position = 0;
-        $header   = \Smalot\PdfParser\Header::parse($content, $document, $position);
+        $header = \Smalot\PdfParser\Header::parse($content, $document, $position);
 
         $this->assert->boolean($header->has('Type'))->isEqualTo(true);
         $this->assert->boolean($header->has('SubType'))->isEqualTo(true);
@@ -104,15 +102,15 @@ class Header extends atoum\test
         $this->assert->boolean($header->has('Text'))->isEqualTo(false);
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $document = new \Smalot\PdfParser\Document();
 
-        $content  = '<</Type/Page/SubType/Text/Font 5 0 R/Resources 8 0 R>>foo';
+        $content = '<</Type/Page/SubType/Text/Font 5 0 R/Resources 8 0 R>>foo';
         $position = 0;
-        $header   = \Smalot\PdfParser\Header::parse($content, $document, $position);
-        $object   = new \Smalot\PdfParser\Page($document, $header);
-        $document->setObjects(array('5_0' => $object));
+        $header = \Smalot\PdfParser\Header::parse($content, $document, $position);
+        $object = new \Smalot\PdfParser\Page($document, $header);
+        $document->setObjects(['5_0' => $object]);
 
         $this->assert->object($header->get('Type'))->isInstanceOf('\Smalot\PdfParser\Element\ElementName');
         $this->assert->object($header->get('SubType'))->isInstanceOf('\Smalot\PdfParser\Element\ElementName');
@@ -121,14 +119,14 @@ class Header extends atoum\test
         $this->assert->object($header->get('Resources'))->isInstanceOf('\Smalot\PdfParser\Element\ElementMissing');
     }
 
-    public function testResolveXRef()
+    public function testResolveXRef(): void
     {
         $document = new \Smalot\PdfParser\Document();
-        $content  = '<</Type/Page/SubType/Text/Font 5 0 R/Resources 8 0 R>>foo';
+        $content = '<</Type/Page/SubType/Text/Font 5 0 R/Resources 8 0 R>>foo';
         $position = 0;
-        $header   = \Smalot\PdfParser\Header::parse($content, $document, $position);
-        $object   = new \Smalot\PdfParser\Page($document, $header);
-        $document->setObjects(array('5_0' => $object));
+        $header = \Smalot\PdfParser\Header::parse($content, $document, $position);
+        $object = new \Smalot\PdfParser\Page($document, $header);
+        $document->setObjects(['5_0' => $object]);
 
         $this->assert->object($header->get('Font'))->isInstanceOf('\Smalot\PdfParser\PDFObject');
 

--- a/src/Smalot/PdfParser/Tests/Units/Header.php
+++ b/src/Smalot/PdfParser/Tests/Units/Header.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units;
 use mageekguy\atoum;
 
 /**
- * Class Header.
+ * Class Header
  */
 class Header extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/PDFObject.php
+++ b/src/Smalot/PdfParser/Tests/Units/PDFObject.php
@@ -43,7 +43,7 @@ class PDFObject extends atoum\test
 
     const COMMAND = 'c';
 
-    public function testGetTextParts(): void
+    public function testGetTextParts()
     {
     }
 
@@ -125,7 +125,7 @@ class PDFObject extends atoum\test
 //        $this->assert->integer($offset)->isEqualTo(83);
 //    }
 
-    public function testGetCommandsText(): void
+    public function testGetCommandsText()
     {
         $content = "/R14 30 Tf 0.999016 0 0 1 137.4
 342.561 Tm
@@ -229,7 +229,7 @@ BI";
         $this->assert->integer($offset)->isEqualTo(172);
     }
 
-    public function testCleanContent(): void
+    public function testCleanContent()
     {
         $content = '/Shape <</MCID << /Font<8>>> BT >>BDC
 Q
@@ -277,7 +277,7 @@ q
         $this->assert->string($cleaned)->isEqualTo($expected);
     }
 
-    public function testGetSectionText(): void
+    public function testGetSectionText()
     {
         $content = '/Shape <</MCID 1 >>BDC
 Q

--- a/src/Smalot/PdfParser/Tests/Units/PDFObject.php
+++ b/src/Smalot/PdfParser/Tests/Units/PDFObject.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units;
@@ -33,9 +33,7 @@ namespace Smalot\PdfParser\Tests\Units;
 use mageekguy\atoum;
 
 /**
- * Class PDFObject
- *
- * @package Smalot\PdfParser\Tests\Units
+ * Class PDFObject.
  */
 class PDFObject extends atoum\test
 {
@@ -45,25 +43,25 @@ class PDFObject extends atoum\test
 
     const COMMAND = 'c';
 
-    public function testGetTextParts()
+    public function testGetTextParts(): void
     {
     }
 
 //    public function testGetCommandsImage()
 //    {
 //        $content = "/CS/RGB
-///W 22
-///H 1
-///BPC 8
-///F/Fl
-///DP<</Predictor 15
-///Columns 22
-///Colors 3>>
-//ID \x00\x50c\x63
-//EI Q
-//q -124.774 124.127 5.64213 5.67154 930.307 4436.95 cm
-//BI
-//";
+    ///W 22
+    ///H 1
+    ///BPC 8
+    ///F/Fl
+    ///DP<</Predictor 15
+    ///Columns 22
+    ///Colors 3>>
+    //ID \x00\x50c\x63
+    //EI Q
+    //q -124.774 124.127 5.64213 5.67154 930.307 4436.95 cm
+    //BI
+    //";
 //
 //        $document  = new \Smalot\PdfParser\Document();
 //        $object    = new \Smalot\PdfParser\PDFObject($document);
@@ -127,7 +125,7 @@ class PDFObject extends atoum\test
 //        $this->assert->integer($offset)->isEqualTo(83);
 //    }
 
-    public function testGetCommandsText()
+    public function testGetCommandsText(): void
     {
         $content = "/R14 30 Tf 0.999016 0 0 1 137.4
 342.561 Tm
@@ -139,99 +137,99 @@ ET Q
 q -124.774 124.127 5.64213 5.67154 930.307 4436.95 cm
 BI";
 
-        $document  = new \Smalot\PdfParser\Document();
-        $object    = new \Smalot\PdfParser\PDFObject($document);
-        $offset    = 0;
-        $parts     = $object->getCommandsText($content, $offset);
-        $reference = array(
-            array(
-                self::TYPE     => '/',
+        $document = new \Smalot\PdfParser\Document();
+        $object = new \Smalot\PdfParser\PDFObject($document);
+        $offset = 0;
+        $parts = $object->getCommandsText($content, $offset);
+        $reference = [
+            [
+                self::TYPE => '/',
                 self::OPERATOR => 'Tf',
-                self::COMMAND  => 'R14 30',
-            ),
-            array(
-                self::TYPE     => '',
+                self::COMMAND => 'R14 30',
+            ],
+            [
+                self::TYPE => '',
                 self::OPERATOR => 'Tm',
-                self::COMMAND  => "0.999016 0 0 1 137.4\n342.561",
-            ),
-            array(
-                self::TYPE     => '[',
+                self::COMMAND => "0.999016 0 0 1 137.4\n342.561",
+            ],
+            [
+                self::TYPE => '[',
                 self::OPERATOR => 'TJ',
-                self::COMMAND  => array(
-                    array(
-                        self::TYPE     => '(',
+                self::COMMAND => [
+                    [
+                        self::TYPE => '(',
                         self::OPERATOR => '',
-                        self::COMMAND  => 'A',
-                    ),
-                    array(
-                        self::TYPE     => 'n',
+                        self::COMMAND => 'A',
+                    ],
+                    [
+                        self::TYPE => 'n',
                         self::OPERATOR => '',
-                        self::COMMAND  => '-168.854',
-                    ),
-                    array(
-                        self::TYPE     => '(',
+                        self::COMMAND => '-168.854',
+                    ],
+                    [
+                        self::TYPE => '(',
                         self::OPERATOR => '',
-                        self::COMMAND  => ' BC D',
-                    ),
-                    array(
-                        self::TYPE     => 'n',
+                        self::COMMAND => ' BC D',
+                    ],
+                    [
+                        self::TYPE => 'n',
                         self::OPERATOR => '',
-                        self::COMMAND  => '-220.905',
-                    ),
-                    array(
-                        self::TYPE     => '(',
+                        self::COMMAND => '-220.905',
+                    ],
+                    [
+                        self::TYPE => '(',
                         self::OPERATOR => '',
-                        self::COMMAND  => '\\(E\\)',
-                    ),
-                    array(
-                        self::TYPE     => 'n',
+                        self::COMMAND => '\\(E\\)',
+                    ],
+                    [
+                        self::TYPE => 'n',
                         self::OPERATOR => '',
-                        self::COMMAND  => '20.905',
-                    ),
-                    array(
-                        self::TYPE     => '<',
+                        self::COMMAND => '20.905',
+                    ],
+                    [
+                        self::TYPE => '<',
                         self::OPERATOR => '',
-                        self::COMMAND  => '20',
-                    ),
-                ),
-            ),
-            array(
-                self::TYPE     => '/',
+                        self::COMMAND => '20',
+                    ],
+                ],
+            ],
+            [
+                self::TYPE => '/',
                 self::OPERATOR => 'Tf',
-                self::COMMAND  => 'R14 17.16',
-            ),
-            array(
-                self::TYPE     => '<',
+                self::COMMAND => 'R14 17.16',
+            ],
+            [
+                self::TYPE => '<',
                 self::OPERATOR => 'Tj',
-                self::COMMAND  => '20',
-            ),
-            array(
-                self::TYPE     => '',
+                self::COMMAND => '20',
+            ],
+            [
+                self::TYPE => '',
                 self::OPERATOR => 'Tm',
-                self::COMMAND  => '0.999014 0 0 1 336.84 319.161',
-            ),
-            array(
-                self::TYPE     => '',
+                self::COMMAND => '0.999014 0 0 1 336.84 319.161',
+            ],
+            [
+                self::TYPE => '',
                 self::OPERATOR => 'T*',
-                self::COMMAND  => '',
-            ),
-            array(
-                self::TYPE     => '(',
+                self::COMMAND => '',
+            ],
+            [
+                self::TYPE => '(',
                 self::OPERATOR => 'Tj',
-                self::COMMAND  => " \x00m",
-            ),
-            array(
-                self::TYPE     => '/',
+                self::COMMAND => " \x00m",
+            ],
+            [
+                self::TYPE => '/',
                 self::OPERATOR => 'Tf',
-                self::COMMAND  => 'R14 20.04',
-            ),
-        );
+                self::COMMAND => 'R14 20.04',
+            ],
+        ];
 
         $this->assert->array($parts)->isEqualTo($reference);
         $this->assert->integer($offset)->isEqualTo(172);
     }
 
-    public function testCleanContent()
+    public function testCleanContent(): void
     {
         $content = '/Shape <</MCID << /Font<8>>> BT >>BDC
 Q
@@ -272,14 +270,14 @@ q
 0.03 841';
 
         $document = new \Smalot\PdfParser\Document();
-        $object   = new \Smalot\PdfParser\PDFObject($document);
-        $cleaned  = $object->cleanContent($content, '_');
+        $object = new \Smalot\PdfParser\PDFObject($document);
+        $cleaned = $object->cleanContent($content, '_');
 
         $this->assert->string($cleaned)->length->isEqualTo(strlen($content));
         $this->assert->string($cleaned)->isEqualTo($expected);
     }
 
-    public function testGetSectionText()
+    public function testGetSectionText(): void
     {
         $content = '/Shape <</MCID 1 >>BDC
 Q
@@ -301,7 +299,7 @@ q
 0.03 841';
 
         $document = new \Smalot\PdfParser\Document();
-        $object   = new \Smalot\PdfParser\PDFObject($document);
+        $object = new \Smalot\PdfParser\PDFObject($document);
         $sections = $object->getSectionsText($content);
 
 //        $this->assert->string($cleaned)->length->isEqualTo(strlen($content));

--- a/src/Smalot/PdfParser/Tests/Units/PDFObject.php
+++ b/src/Smalot/PdfParser/Tests/Units/PDFObject.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units;
 use mageekguy\atoum;
 
 /**
- * Class PDFObject.
+ * Class PDFObject
  */
 class PDFObject extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/PDFObject.php
+++ b/src/Smalot/PdfParser/Tests/Units/PDFObject.php
@@ -273,7 +273,7 @@ q
         $object = new \Smalot\PdfParser\PDFObject($document);
         $cleaned = $object->cleanContent($content, '_');
 
-        $this->assert->string($cleaned)->length->isEqualTo(strlen($content));
+        $this->assert->string($cleaned)->length->isEqualTo(\strlen($content));
         $this->assert->string($cleaned)->isEqualTo($expected);
     }
 

--- a/src/Smalot/PdfParser/Tests/Units/Page.php
+++ b/src/Smalot/PdfParser/Tests/Units/Page.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units;
@@ -33,20 +33,18 @@ namespace Smalot\PdfParser\Tests\Units;
 use mageekguy\atoum;
 
 /**
- * Class Page
- *
- * @package Smalot\PdfParser\Tests\Units
+ * Class Page.
  */
 class Page extends atoum\test
 {
-    public function testGetFonts()
+    public function testGetFonts(): void
     {
         // Document with text.
-        $filename = __DIR__ . '/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
-        $parser   = new \Smalot\PdfParser\Parser();
+        $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
-        $pages    = $document->getPages();
-        $page     = $pages[0];
+        $pages = $document->getPages();
+        $page = $pages[0];
 
         // the first to load data.
         $fonts = $page->getFonts();
@@ -60,10 +58,10 @@ class Page extends atoum\test
 
         // ------------------------------------------------------
         // Document without text.
-        $filename = __DIR__ . '/../../../../../samples/Document3_pdfcreator_nocompressed.pdf';
+        $filename = __DIR__.'/../../../../../samples/Document3_pdfcreator_nocompressed.pdf';
         $document = $parser->parseFile($filename);
-        $pages    = $document->getPages();
-        $page     = $pages[0];
+        $pages = $document->getPages();
+        $page = $pages[0];
 
         // the first to load data.
         $fonts = $page->getFonts();
@@ -73,14 +71,14 @@ class Page extends atoum\test
         $this->assert->array($fonts)->isEmpty();
     }
 
-    public function testGetFont()
+    public function testGetFont(): void
     {
         // Document with text.
-        $filename = __DIR__ . '/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
-        $parser   = new \Smalot\PdfParser\Parser();
+        $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
-        $pages    = $document->getPages();
-        $page     = $pages[0];
+        $pages = $document->getPages();
+        $page = $pages[0];
 
         // the first to load data.
         $font = $page->getFont('R7');
@@ -89,15 +87,15 @@ class Page extends atoum\test
         $this->assert->object($font)->isInstanceOf('\Smalot\PdfParser\Font');
     }
 
-    public function testGetText()
+    public function testGetText(): void
     {
         // Document with text.
-        $filename = __DIR__ . '/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
-        $parser   = new \Smalot\PdfParser\Parser();
+        $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
+        $parser = new \Smalot\PdfParser\Parser();
         $document = $parser->parseFile($filename);
-        $pages    = $document->getPages();
-        $page     = $pages[0];
-        $text     = $page->getText();
+        $pages = $document->getPages();
+        $page = $pages[0];
+        $text = $page->getText();
 
         $this->assert->string($text)->hasLengthGreaterThan(150);
         $this->assert->string($text)->contains('Document title');

--- a/src/Smalot/PdfParser/Tests/Units/Page.php
+++ b/src/Smalot/PdfParser/Tests/Units/Page.php
@@ -33,7 +33,7 @@ namespace Smalot\PdfParser\Tests\Units;
 use mageekguy\atoum;
 
 /**
- * Class Page.
+ * Class Page
  */
 class Page extends atoum\test
 {

--- a/src/Smalot/PdfParser/Tests/Units/Page.php
+++ b/src/Smalot/PdfParser/Tests/Units/Page.php
@@ -37,7 +37,7 @@ use mageekguy\atoum;
  */
 class Page extends atoum\test
 {
-    public function testGetFonts(): void
+    public function testGetFonts()
     {
         // Document with text.
         $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
@@ -71,7 +71,7 @@ class Page extends atoum\test
         $this->assert->array($fonts)->isEmpty();
     }
 
-    public function testGetFont(): void
+    public function testGetFont()
     {
         // Document with text.
         $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';
@@ -87,7 +87,7 @@ class Page extends atoum\test
         $this->assert->object($font)->isInstanceOf('\Smalot\PdfParser\Font');
     }
 
-    public function testGetText(): void
+    public function testGetText()
     {
         // Document with text.
         $filename = __DIR__.'/../../../../../samples/Document1_pdfcreator_nocompressed.pdf';

--- a/src/Smalot/PdfParser/Tests/Units/Parser.php
+++ b/src/Smalot/PdfParser/Tests/Units/Parser.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,7 +26,6 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\Tests\Units;
@@ -34,37 +34,34 @@ use Exception;
 use mageekguy\atoum;
 
 /**
- * Class Parser
- *
- * @package Smalot\PdfParser\Tests\Units
+ * Class Parser.
  */
 class Parser extends atoum\test
 {
-
     /**
      * @throws \Exception
      */
-    public function testParseFile()
+    public function testParseFile(): void
     {
-        $directory = getcwd() . '/samples/bugs';
+        $directory = getcwd().'/samples/bugs';
 
         if (is_dir($directory)) {
-            $files  = scandir($directory);
+            $files = scandir($directory);
             $parser = new \Smalot\PdfParser\Parser();
 
             foreach ($files as $file) {
                 if (preg_match('/^.*\.pdf$/i', $file)) {
                     try {
-                        $document = $parser->parseFile($directory . '/' . $file);
-                        $pages    = $document->getPages();
+                        $document = $parser->parseFile($directory.'/'.$file);
+                        $pages = $document->getPages();
                         $this->assert->integer(count($pages))->isGreaterThan(0);
 
                         foreach ($pages as $page) {
-                            $content  = $page->getText();
+                            $content = $page->getText();
                             $this->assert->string($content);
                         }
                     } catch (Exception $e) {
-                        if ($e->getMessage() !== 'Secured pdf file are currently not supported.' && strpos($e->getMessage(), 'TCPDF_PARSER') != 0) {
+                        if ('Secured pdf file are currently not supported.' !== $e->getMessage() && 0 != strpos($e->getMessage(), 'TCPDF_PARSER')) {
                             throw $e;
                         }
                     }

--- a/src/Smalot/PdfParser/Tests/Units/Parser.php
+++ b/src/Smalot/PdfParser/Tests/Units/Parser.php
@@ -54,7 +54,7 @@ class Parser extends atoum\test
                     try {
                         $document = $parser->parseFile($directory.'/'.$file);
                         $pages = $document->getPages();
-                        $this->assert->integer(count($pages))->isGreaterThan(0);
+                        $this->assert->integer(\count($pages))->isGreaterThan(0);
 
                         foreach ($pages as $page) {
                             $content = $page->getText();

--- a/src/Smalot/PdfParser/Tests/Units/Parser.php
+++ b/src/Smalot/PdfParser/Tests/Units/Parser.php
@@ -41,7 +41,7 @@ class Parser extends atoum\test
     /**
      * @throws \Exception
      */
-    public function testParseFile(): void
+    public function testParseFile()
     {
         $directory = getcwd().'/samples/bugs';
 

--- a/src/Smalot/PdfParser/Tests/Units/Parser.php
+++ b/src/Smalot/PdfParser/Tests/Units/Parser.php
@@ -34,7 +34,7 @@ use Exception;
 use mageekguy\atoum;
 
 /**
- * Class Parser.
+ * Class Parser
  */
 class Parser extends atoum\test
 {

--- a/src/Smalot/PdfParser/XObject/Form.php
+++ b/src/Smalot/PdfParser/XObject/Form.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,19 +26,16 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\XObject;
 
 use Smalot\PdfParser\Header;
-use Smalot\PdfParser\PDFObject;
 use Smalot\PdfParser\Page;
+use Smalot\PdfParser\PDFObject;
 
 /**
- * Class Form
- *
- * @package Smalot\PdfParser\XObject
+ * Class Form.
  */
 class Form extends Page
 {
@@ -48,7 +46,7 @@ class Form extends Page
      */
     public function getText(Page $page = null)
     {
-        $header   = new Header(array(), $this->document);
+        $header = new Header([], $this->document);
         $contents = new PDFObject($this->document, $header, $this->content);
 
         return $contents->getText($this);

--- a/src/Smalot/PdfParser/XObject/Form.php
+++ b/src/Smalot/PdfParser/XObject/Form.php
@@ -35,7 +35,7 @@ use Smalot\PdfParser\Page;
 use Smalot\PdfParser\PDFObject;
 
 /**
- * Class Form.
+ * Class Form
  */
 class Form extends Page
 {

--- a/src/Smalot/PdfParser/XObject/Image.php
+++ b/src/Smalot/PdfParser/XObject/Image.php
@@ -34,7 +34,7 @@ use Smalot\PdfParser\Page;
 use Smalot\PdfParser\PDFObject;
 
 /**
- * Class Image.
+ * Class Image
  */
 class Image extends PDFObject
 {

--- a/src/Smalot/PdfParser/XObject/Image.php
+++ b/src/Smalot/PdfParser/XObject/Image.php
@@ -6,6 +6,7 @@
  *
  * @author  Sébastien MALOT <sebastien@malot.fr>
  * @date    2017-01-03
+ *
  * @license LGPLv3
  * @url     <https://github.com/smalot/pdfparser>
  *
@@ -25,18 +26,15 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.
  *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
- *
  */
 
 namespace Smalot\PdfParser\XObject;
 
-use Smalot\PdfParser\PDFObject;
 use Smalot\PdfParser\Page;
+use Smalot\PdfParser\PDFObject;
 
 /**
- * Class Image
- *
- * @package Smalot\PdfParser\XObject
+ * Class Image.
  */
 class Image extends PDFObject
 {


### PR DESCRIPTION
[PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) is a very handy tool which not only allows to setup coding styles but also automatically deploying them. It is used by many big projects and proofed helpful to me in other projects.

Just run

> php vendor/bin/php-cs-fixer fix

in the project root folder. If adaptions were made output may look like:

```
Loaded config default from "/var/www/html/.php_cs".
   1) src/Smalot/PdfParser/Font/FontTrueType.php
   2) src/Smalot/PdfParser/Font/FontCIDFontType2.php
   3) src/Smalot/PdfParser/Font/FontType3.php
   4) src/Smalot/PdfParser/Font/FontCIDFontType0.php
   5) src/Smalot/PdfParser/Font/FontType1.php
   6) src/Smalot/PdfParser/Font/FontType0.php
```

Configuration is located in the new `.php_cs` file.

I strongly suggest we use this (or if available a better alternative) to automatically adapt files so we have consistent coding styles. One of the reasons why i made this PR was the amount of PR's using "messy" or broken coding styles.

One downside could be, that forks or older PR can't be merged automatically anymore. But that should be manageable.

What do you think?