### PR TITLE
Ignore some files for the end user

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,11 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+/.atoum.php export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs export-ignore
+/.travis.yml export-ignore
+/samples export-ignore
+/src/Smalot/PdfParser/Tests export-ignore

--- a/README.md
+++ b/README.md
@@ -38,10 +38,8 @@ As a result, users must expect BC breaks when using the master version.
 
 [Read the documentation on website](http://www.pdfparser.org/documentation?utm_source=GitHub&utm_medium=documentation&utm_campaign=GitHub).
 
-Original PDF References files can be downloaded from this url : http://www.adobe.com/devnet/pdf/pdf_reference_archive.html
-
+Original PDF References files can be downloaded from this url: http://www.adobe.com/devnet/pdf/pdf_reference_archive.html
 
 ## License ##
 
 This library is under the [LGPLv3 license](https://github.com/smalot/pdfparser/blob/master/LICENSE.txt).
-


### PR DESCRIPTION
As of now, the whole repository is download to people who are using the lib.

Some files don't need to be available for the end user in a production environment:
- all _dotfiles_ which are usually only for development
- tests files which are only for test
- samples PDF files (saving 1,2Mo!)

Also adding [`.editorconfig`](https://editorconfig.org/) so everyone should have the same behavior in its editor.