### PR TITLE
Allow PHP 8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@
 /.travis.yml export-ignore
 /samples export-ignore
 /src/Smalot/PdfParser/Tests export-ignore
+/phpstan.neon export-ignore

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,11 +1,14 @@
-# For more information about code coverage
-# See: https://scrutinizer-ci.com/docs/build/code_coverage
 build:
-  nodes:
-    coverage:
-      tests:
-        override:
-          - command: vendor/bin/phpunit --coverage-clover coverage/clover.xml
-            coverage:
-              file: coverage/clover.xml
-              format: clover
+    nodes:
+        analysis:
+            tests:
+                override:
+                    - php-scrutinizer-run
+                    -
+                        command: SYMFONY_PHPUNIT_VERSION=7.5 php vendor/bin/simple-phpunit --coverage-clover coverage/clover.xml
+                        coverage:
+                            file: coverage/clover.xml
+                            format: clover
+            environment:
+                php:
+                    version: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,30 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 7.2
-  - 7.3
-  - nightly
 
 jobs:
+  include:
+    - php: 7.2
+      env: SYMFONY_PHPUNIT_VERSION=7.5
+    - php: 7.3
+      env: SYMFONY_PHPUNIT_VERSION=7.5 COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+      env: SYMFONY_PHPUNIT_VERSION=7.5 LINTER_RUN=run COVERAGE_FLAGS="--coverage-clover coverage/clover.xml"
+    - php: nightly
+      env: SYMFONY_PHPUNIT_VERSION=7.5
   fast_finish: true
   allow_failures:
     - php: nightly
-  include:
-    - php: 7.4
-      env: COMPOSER_FLAGS="--prefer-lowest" LINTER_RUN=run COVERAGE_FLAGS="--coverage-clover coverage/clover.xml"
+
+before_install:
+  - if [ "$LINTER_RUN" = "run" ]; then composer require phpstan/phpstan phpstan/phpstan-phpunit --dev --no-progress --no-suggest ; fi;
+  - if [ "$LINTER_RUN" != "run" ]; then composer remove friendsofphp/php-cs-fixer --dev --no-progress --no-update ; fi;
 
 install:
   - composer update --prefer-dist --no-progress --no-suggest --optimize-autoloader $COMPOSER_FLAGS
+  - php vendor/bin/simple-phpunit install
 
 script:
   - if [ "$LINTER_RUN" = "run" ]; then php vendor/bin/php-cs-fixer fix --verbose --dry-run ; fi;
-  - if [ "$LINTER_RUN" = "run" ]; then composer require phpstan/phpstan --no-progress --no-suggest ; fi;
-  - if [ "$LINTER_RUN" = "run" ]; then php vendor/bin/phpstan analyse src test tests --no-progress --level 3 ; fi;
-  - php vendor/bin/phpunit $COVERAGE_FLAGS
+  - if [ "$LINTER_RUN" = "run" ]; then php vendor/bin/phpstan analyse src test tests --level 3 ; fi;
+  - php vendor/bin/simple-phpunit -v $COVERAGE_FLAGS

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     },
     "homepage": "http://www.pdfparser.org",
     "require": {
-        "php": "^5.6|^7.0",
+        "php": ">=5.6",
         "ext-mbstring": "*",
         "ext-zlib": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27|^6",
-        "friendsofphp/php-cs-fixer": "^2.16.3"
+        "friendsofphp/php-cs-fixer": "^2.16.3",
+        "symfony/phpunit-bridge": "^4.2.3"
     },
     "autoload": {
         "psr-0": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+    # https://github.com/phpstan/phpstan/issues/694#issuecomment-350724288
+    autoload_files:
+        - vendor/bin/.phpunit/phpunit-7.5-0/vendor/autoload.php


### PR DESCRIPTION
And enable tests for it using PHPUnit Bridge from Symfony (I wasn't able to find a proper restriction in composer to allow PHPUnit to work from PHP 5.6 to PHP 8).

Also:
- use custom config for PHPStan (to specify phpunit path (because of simple-phpunit))
- force PHPUnit version in Scrutinizer as long as the PHP version
- move `COMPOSER_FLAGS` outside linter stuff to avoid side behavior (because of lower deps version)
- remove php-cs-fixer for non linter build because it enforce PHP < 8
- force PHPUnit version to avoid error with lower PHP version