### PR TITLE
Fix problems in decodeFilterASCII85Decode

### DIFF
--- a/src/Smalot/PdfParser/RawData/FilterHelper.php
+++ b/src/Smalot/PdfParser/RawData/FilterHelper.php
@@ -146,8 +146,8 @@ class FilterHelper
         // all white-space characters shall be ignored
         $data = preg_replace('/[\s]/', '', $data);
         // remove start sequence 2-character sequence <~ (3Ch)(7Eh)
-        if (false !== strpos($data, '<~')) {
-            // remove EOD and extra data (if any)
+        if (0 !== strpos($data, '<~')) {
+            // remove start sequence
             $data = substr($data, 2);
         }
         // check for EOD: 2-character sequence ~> (7Eh)(3Eh)
@@ -159,7 +159,7 @@ class FilterHelper
         // data length
         $data_length = \strlen($data);
         // check for invalid characters
-        if (preg_match('/[^\x21-\x75,\x74]/', $data) > 0) {
+        if (preg_match('/[^\x21-\x75,\x7A]/', $data) > 0) {
             throw new Exception('decodeFilterASCII85Decode: invalid code');
         }
         // z sequence

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -655,9 +655,11 @@ class RawDataParser
                         $objtype = $char;
                         ++$offset;
                         $pregResult = preg_match(
-                            '/^([0-9A-Fa-f\x09\x0a\x0c\x0d\x20]+)>/iU',
-                            substr($pdfData, $offset),
-                            $matches
+                            '/\G([0-9A-Fa-f\x09\x0a\x0c\x0d\x20]+)>/iU',
+                            $pdfData,
+                            $matches,
+                            0,
+                            $offset
                         );
                         if (('<' == $char) && 1 == $pregResult) {
                             // remove white space characters
@@ -693,17 +695,18 @@ class RawDataParser
                         // start stream object
                         $objtype = 'stream';
                         $offset += 6;
-                        if (1 == preg_match('/^([\r]?[\n])/isU', substr($pdfData, $offset), $matches)) {
+                        if (1 == preg_match('/\G([\r]?[\n])/isU', $pdfData, $matches, 0, $offset)) {
                             $offset += \strlen($matches[0]);
                             $pregResult = preg_match(
                                 '/(endstream)[\x09\x0a\x0c\x0d\x20]/isU',
-                                substr($pdfData, $offset),
+                                $pdfData,
                                 $matches,
-                                PREG_OFFSET_CAPTURE
+                                PREG_OFFSET_CAPTURE,
+                                $offset
                             );
                             if (1 == $pregResult) {
-                                $objval = substr($pdfData, $offset, $matches[0][1]);
-                                $offset += $matches[1][1];
+                                $objval = substr($pdfData, $offset, $matches[0][1] - $offset);
+                                $offset = $matches[1][1];
                             }
                         }
                     } elseif ('endstream' == substr($pdfData, $offset, 9)) {


### PR DESCRIPTION
Only check for the start sequence at the start of the data.
This fixes a problem where the encoded data ends with a < (3Ch), with the EOD characters this becomes <~>
In this case the first characters are removed when they shouldn't.

Fix problem in preg_match, \x74 (t) should be \x7A (z)