### PR TITLE
Fix error when Font aren't available

### DIFF
--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -64,6 +64,10 @@ class Page extends PDFObject
         $resources = $this->get('Resources');
 
         if (method_exists($resources, 'has') && $resources->has('Font')) {
+            if ($resources->get('Font') instanceof ElementMissing) {
+                return [];
+            }
+
             if ($resources->get('Font') instanceof Header) {
                 $fonts = $resources->get('Font')->getElements();
             } else {

--- a/tests/Integration/PageTest.php
+++ b/tests/Integration/PageTest.php
@@ -32,7 +32,10 @@
 
 namespace Tests\Smalot\PdfParser\Integration;
 
+use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element\ElementMissing;
 use Smalot\PdfParser\Font;
+use Smalot\PdfParser\Page;
 use Tests\Smalot\PdfParser\TestCase;
 
 class PageTest extends TestCase
@@ -69,6 +72,35 @@ class PageTest extends TestCase
         // the second to use cache.
         $fonts = $page->getFonts();
         $this->assertEquals(0, \count($fonts));
+    }
+
+    public function testGetFontsElementMissing()
+    {
+        $headerResources = $this->getMockBuilder('Smalot\PdfParser\Header')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $headerResources->expects($this->once())
+            ->method('has')
+            ->willReturn(true);
+
+        $headerResources->expects($this->once())
+            ->method('get')
+            ->willReturn(new ElementMissing());
+
+        $header = $this->getMockBuilder('Smalot\PdfParser\Header')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $header->expects($this->once())
+            ->method('get')
+            ->willReturn($headerResources);
+
+        $page = new Page(new Document(), $header);
+        $fonts = $page->getFonts();
+
+        $this->assertEmpty($fonts);
+        $this->assertEquals([], $fonts);
     }
 
     public function testGetFont()


### PR DESCRIPTION
This can happen (like in many places of `Page.php`) when the retrieved element is missing (and the instance if `ElementMissing`. In that case, we just return an empty array (the default value).

Fix https://github.com/smalot/pdfparser/issues/321