### PR TITLE
replace ext-mbstring requirement with symfony/polyfill-mbstring to support PHP 8.0.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "homepage": "https://www.pdfparser.org",
     "require": {
         "php": ">=5.6",
-        "ext-mbstring": "*",
+        "symfony/polyfill-mbstring": "^1.18.1",
         "ext-zlib": "*"
     },
     "require-dev": {


### PR DESCRIPTION
This should fix my own issue #335 - tested and confirmed to be working with PHP 8.0.0 beta 3.

Fixes #335 