### PR TITLE
update .travis.yml to add a PHP 8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 8.0
 
 jobs:
   include:
@@ -16,13 +15,11 @@ jobs:
       env: SYMFONY_PHPUNIT_VERSION=7.5 COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.4
       env: SYMFONY_PHPUNIT_VERSION=7.5 LINTER_RUN=run COVERAGE_FLAGS="--coverage-clover coverage/clover.xml"
-    - php: 8.0
+    - php: nightly
       env: SYMFONY_PHPUNIT_VERSION=9.3
-    - php: nightly
-      env: SYMFONY_PHPUNIT_VERSION=7.5
   fast_finish: true
-  allow_failures:
-    - php: nightly
+#   allow_failures:
+#     - php: nightly
 
 before_install:
   - if [ "$LINTER_RUN" = "run" ]; then composer require phpstan/phpstan phpstan/phpstan-phpunit --dev --no-progress --no-suggest ; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 8.0
 
 jobs:
   include:
@@ -15,6 +16,8 @@ jobs:
       env: SYMFONY_PHPUNIT_VERSION=7.5 COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.4
       env: SYMFONY_PHPUNIT_VERSION=7.5 LINTER_RUN=run COVERAGE_FLAGS="--coverage-clover coverage/clover.xml"
+    - php: 8.0
+      env: SYMFONY_PHPUNIT_VERSION=9.3
     - php: nightly
       env: SYMFONY_PHPUNIT_VERSION=7.5
   fast_finish: true


### PR DESCRIPTION
Let's hope that the Travis CI build runs through... But it doesn't seem to be that trivial according to
* https://github.com/sebastianbergmann/phpunit/issues/4325
* https://github.com/sebastianbergmann/phpunit/issues/3526

Seems like we'd also have to use PHPUnit 9 to increase our chances, but as far as I understood, even with that not all the dependencies support PHP8 yet. Well, we'll see, fingers crossed...