### PR TITLE
fix missing BT command before each section (could result in wrong crdinates) and its resetting of Tm

### DIFF
--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -301,6 +301,8 @@ class Page extends PDFObject
         } else {
             $sectionsText = $content->getSectionsText($content->getContent());
             foreach ($sectionsText as $sectionText) {
+                $extractedData[] = ['t' => '', 'o' => 'BT', 'c' => ''];
+
                 $commandsText = $content->getCommandsText($sectionText);
                 foreach ($commandsText as $command) {
                     $extractedData[] = $command;
@@ -573,7 +575,7 @@ class Page extends PDFObject
                  * Begin a text object, inicializind the Tm and Tlm to identity matrix
                  */
                 case 'BT':
-                    $Tm = $defaultTl;
+                    $Tm = $defaultTm;
                     $Tl = $defaultTl; //review this.
                     $Tx = 0;
                     $Ty = 0;
@@ -584,7 +586,7 @@ class Page extends PDFObject
                  * End a text object, discarding the text matrix
                  */
                 case 'ET':
-                    $Tm = $defaultTl;
+                    $Tm = $defaultTm;
                     $Tl = $defaultTl;  //review this
                     $Tx = 0;
                     $Ty = 0;

--- a/tests/Integration/PageTest.php
+++ b/tests/Integration/PageTest.php
@@ -150,9 +150,18 @@ class PageTest extends TestCase
         $pages = $document->getPages();
         $page = $pages[0];
         $extractedRawData = $page->extractRawData();
-        $tmItem = $extractedRawData[1];
 
-        $this->assertcount(172, $extractedRawData);
+        $btItem = $extractedRawData[0];
+        $this->assertCount(3, $btItem);
+        $this->assertArrayHasKey('t', $btItem);
+        $this->assertArrayHasKey('o', $btItem);
+        $this->assertArrayHasKey('c', $btItem);
+
+        $this->assertEquals('BT', $btItem['o']);
+
+        $tmItem = $extractedRawData[2];
+
+        $this->assertcount(174, $extractedRawData);
         $this->assertCount(3, $tmItem);
 
         $this->assertArrayHasKey('t', $tmItem);
@@ -172,8 +181,8 @@ class PageTest extends TestCase
         $pages = $document->getPages();
         $page = $pages[0];
         $extractedDecodedRawData = $page->extractDecodedRawData();
-        $tmItem = $extractedDecodedRawData[1];
-        $this->assertCount(172, $extractedDecodedRawData);
+        $tmItem = $extractedDecodedRawData[2];
+        $this->assertCount(174, $extractedDecodedRawData);
         $this->assertCount(3, $tmItem);
 
         $this->assertArrayHasKey('t', $tmItem);
@@ -188,7 +197,7 @@ class PageTest extends TestCase
         $this->assertArrayHasKey('o', $tmItem);
         $this->assertArrayHasKey('c', $tmItem);
 
-        $tjItem = $extractedDecodedRawData[2];
+        $tjItem = $extractedDecodedRawData[3];
         $this->assertContains('TJ', $tjItem['o']);
         $this->assertContains('(', $tjItem['c'][0]['t']);
         $this->assertContains('D', $tjItem['c'][0]['c']);
@@ -218,9 +227,9 @@ class PageTest extends TestCase
         $pages = $document->getPages();
         $page = $pages[0];
         $dataCommands = $page->getDataCommands();
-        $this->assertCount(166, $dataCommands);
+        $this->assertCount(168, $dataCommands);
 
-        $tmItem = $dataCommands[0];
+        $tmItem = $dataCommands[1];
         $this->assertCount(3, $tmItem);
         $this->assertArrayHasKey('t', $tmItem);
         $this->assertArrayHasKey('o', $tmItem);
@@ -228,8 +237,8 @@ class PageTest extends TestCase
 
         $this->assertContains('Tm', $tmItem['o']);
         $this->assertContains('0.999429 0 0 1 201.96 720.68', $tmItem['c']);
-        $tjItem = $dataCommands[1];
 
+        $tjItem = $dataCommands[2];
         $this->assertCount(3, $tjItem);
         $this->assertArrayHasKey('t', $tjItem);
         $this->assertArrayHasKey('o', $tjItem);


### PR DESCRIPTION
See also the discussion in #336.

Some information about what I did and why I did it:
* as the RegEx in `getSectionsText()` assumes all sections starting with BT and ending with ET, we can also safely add the BT command before each section in `$extractedData`
* (we do not, hovever, need to explicitly add ET afterwards, as the reset will happen with the following BT anyway; actually, adding ET explicitly resulted in several tests failing because it messes up the text decoding due to different array sizes when having #340 implemented, because the text has already been added to the `$extractedData` when ET is being encountered!)
* `$Tm` was erroneously reset to `$defaultTl` instead of `$defaultTm` for both BT and ET in the switch/case statement of `getDataTm()`
* I had to adjust some tests, because they would obviously assume a wrong count of commands now with the added BT. Apart from that, the tests run through successfully.
* I also added a test for the BT command in the extracted data

I have also already written a test for the coordinates of the two "Lorem" texts in the sample PDF to be the same, but I'd like to add that after the PR is merged as well as #340, so I can test the decoding and coordinates in one go.