### PR TITLE
Added a few tests to check current behavior of RawData/FilterHelper.php

### DIFF
--- a/tests/Integration/RawData/FilterHelperTest.php
+++ b/tests/Integration/RawData/FilterHelperTest.php
@@ -45,6 +45,34 @@ class FilterHelperTest extends TestCase
         $this->fixture = new FilterHelper();
     }
 
+    /*
+     * Tests for filter ASCII85Decode
+     */
+
+    public function testDecodeFilterASCII85Decode()
+    {
+        $compressed = '6Z6g\Eb0<5ARlp)FE2)5B)'; // = Compressed string
+        $result = $this->fixture->decodeFilter('ASCII85Decode', $compressed);
+
+        $this->assertEquals('Compressed string', $result);
+    }
+
+    /*
+     * Tests for filter ASCIIHexDecode
+     */
+
+    public function testDecodeFilterASCIIHexDecode()
+    {
+        $compressed = '43 6f 6d 70 72 65 73 73 65 64 20 73 74 72 69 6e 67'; // = Compressed string
+        $result = $this->fixture->decodeFilter('ASCIIHexDecode', $compressed);
+
+        $this->assertEquals('Compressed string', $result);
+    }
+
+    /*
+     * Tests for filter FlateDecode
+     */
+
     public function testDecodeFilterFlateDecode()
     {
         $compressed = gzcompress('Compress me', 9);
@@ -73,5 +101,73 @@ class FilterHelperTest extends TestCase
         $this->expectExceptionMessage('gzuncompress(): data error');
 
         $this->fixture->decodeFilter('FlateDecode', 'something');
+    }
+
+    /**
+     * How does function behave if an uncompressed string was given.
+     */
+    public function testDecodeFilterUnknownFilter()
+    {
+        $result = $this->fixture->decodeFilter('a string '.rand(), 'something');
+        $this->assertEquals('something', $result);
+    }
+
+    /*
+     * Test for filters not being implemented yet.
+     */
+
+    /**
+     * CCITTFaxDecode
+     */
+    public function testDecodeFilterCCITTFaxDecode()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Decode CCITTFaxDecode not implemented yet.');
+
+        $this->fixture->decodeFilter('CCITTFaxDecode', '');
+    }
+
+    /**
+     * Crypt
+     */
+    public function testDecodeFilterCrypt()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Decode Crypt not implemented yet.');
+
+        $this->fixture->decodeFilter('Crypt', '');
+    }
+
+    /**
+     * DCTDecode
+     */
+    public function testDecodeFilterDCTDecode()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Decode DCTDecode not implemented yet.');
+
+        $this->fixture->decodeFilter('DCTDecode', '');
+    }
+
+    /**
+     * JBIG2Decode
+     */
+    public function testDecodeFilterJBIG2Decode()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Decode JBIG2Decode not implemented yet.');
+
+        $this->fixture->decodeFilter('JBIG2Decode', '');
+    }
+
+    /**
+     * JPXDecode
+     */
+    public function testDecodeFilterJPXDecode()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Decode JPXDecode not implemented yet.');
+
+        $this->fixture->decodeFilter('JPXDecode', '');
     }
 }


### PR DESCRIPTION
## About

This PR extends test coverage of `RawData/FilterHelper.php` by adding a few tests which check current behavior (ref: https://github.com/smalot/pdfparser/blob/master/src/Smalot/PdfParser/RawData/FilterHelper.php).

I had problems testing the following filters, because I couldn't get my original data in the end: 
* LZWDecode
* RunLengthDecode

### LZWDecode

Because LZW is using binary data an online encoder was not usable. I tried the following code to generate a string during the tests but had no success:
* https://webdevwonders.com/lzw-compression-and-decompression-with-javascript-and-php/
* https://www.programmersought.com/article/87352186122/
* https://github.com/vrana/php-lzw/blob/master/lzw.inc.php#L13

### RunLengthDecode

For "RunLengthDecode" I am not sure if our decoder or the online tools I tried are faulty (or I lack basic understanding of it). AFAIK the string "Compressed string" results to "C1O1M1P1R1E1S2E1D1S1T1R1I1N1G1" using the online encoder https://www.dcode.fr/rle-compression. But the test fails when trying to decode it.

---

Any feedback on these two is appreciated.