### PR TITLE
fix linebreaks

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -260,7 +260,6 @@ class PDFObject
         $sections = $this->getSectionsText($this->content);
         $current_font = $this->getDefaultFont($page);
 
-        $current_position_td = ['x' => false, 'y' => false];
         $current_position_tm = ['x' => false, 'y' => false];
 
         array_push(self::$recursionStack, $this->getUniqueId());
@@ -276,34 +275,18 @@ class PDFObject
 
                     // move text current point
                     case 'Td':
-                        $args = preg_split('/\s/s', $command[self::COMMAND]);
-                        $y = array_pop($args);
-                        $x = array_pop($args);
-                        if (((float) $x <= 0) ||
-                            (false !== $current_position_td['y'] && (float) $y < (float) ($current_position_td['y']))
-                        ) {
-                            // vertical offset
-                            $text .= "\n";
-                        } elseif (false !== $current_position_td['x'] && (float) $x > (float) (
-                                $current_position_td['x']
-                            )
-                        ) {
-                            // horizontal offset
-                            $text .= ' ';
-                        }
-                        $current_position_td = ['x' => $x, 'y' => $y];
-                        break;
-
-                    // move text current point and set leading
                     case 'TD':
                         $args = preg_split('/\s/s', $command[self::COMMAND]);
                         $y = array_pop($args);
                         $x = array_pop($args);
-                        if ((float) $y < 0) {
+                        if ($y != 0) {
+                            // vertical offset
                             $text .= "\n";
-                        } elseif ((float) $x <= 0) {
+                        } elseif ((float) $x > 0) {
+                            // horizontal offset
                             $text .= ' ';
                         }
+
                         break;
 
                     case 'Tf':
@@ -323,6 +306,8 @@ class PDFObject
                         break;
 
                     case "'":
+                        $text .= "\n";
+                        // no break
                     case 'Tj':
                         $command[self::COMMAND] = [$command];
                         // no break


### PR DESCRIPTION
Hello,
i want to read out adresses from pdf via regex and the regex i built works perfectly fine but unfortionatly i have cases where the some line breaks dont appear where they should appear after parsing the pdf, so i had a look into the code and tried to find out why. i came up with the code of this PR.

i had problems with 2 cases:

first case, "Datum" apends to City which is wrong:

/F 9 Tf
8.503937 -62.812488 Td
(Herr)Tj
0 -10.346457 Td
(Max Mustermann)Tj
0 -10.35 Td
(Musterstraße. 7)Tj
0 -10.35 Td
(98765 Musterburg)Tj
-0.14173228 Tc
/F 8 Tf
249.42899 78.030315 Td
(Datum)Tj
71.163896 0 Td
(12. Juni 2020)Tj
->
**Herr
Max Mustermann
Musterstraße. 7
98765 Musterburg Datum
12. Juni 2020**

second case, everything is appended except salutation, which is even more wrong:

/R8 9 Tf
-23.8359 -62.8125 Td
(Herr)Tj
10.3465 TL
(Max Mustermann)Tj
10.35 TL
(Musterstraße 2 a)'
(98765 Musterburg)'
-0.141732 Tc
/R8 8 Tf
249.429 78.0305 Td
[(Datum)-6039.04(20. Mai 2020)]TJ
->
**Herr
Max Mustermann Musterstraße 2 a98765 Musterburg Datum 20. Mai 2020**

now what did i (try to) fix:
- i found out, that the x and y args of "Td" commands are actually NOT absolute but instead they are already relative to the LAST occured "Td", but the code instead seems to expect absolute values, so fixed it and then i noticed its almost the same as the logic of "TD", but in "TD" on the other hand i noticed that it is comparing "$x <= 0" for horizontal whitespace which makes no sense, since $x is increasing to the right direction and not decreasing so i made it "$x > 0"
for $y it can either increase or decrease and in both cases we most probably want a new line in the result

- i found that the apostrophe command actually needs a new line before appending text according to my second case.


i am not sure if this commit actually destroys other cases. I hope not, but please can someone with experience in here please check this carefully ?

Thank you