### PR TITLE
ElementName.php: Improve regex performance by removing group naming

### DIFF
--- a/src/Smalot/PdfParser/Element/ElementName.php
+++ b/src/Smalot/PdfParser/Element/ElementName.php
@@ -64,8 +64,8 @@ class ElementName extends Element
      */
     public static function parse($content, Document $document = null, &$offset = 0)
     {
-        if (preg_match('/^\s*\/(?P<name>[A-Z0-9\-\+,#\.]+)/is', $content, $match)) {
-            $name = $match['name'];
+        if (preg_match('/^\s*\/([A-Z0-9\-\+,#\.]+)/is', $content, $match)) {
+            $name = $match[1];
             $offset += strpos($content, $name) + \strlen($name);
             $name = Font::decodeEntities($name);
 


### PR DESCRIPTION
I removed group naming from the regular expression to decrease memory usage and improve performance, in very large files I was experiencing memory limit problems.