### PR TITLE
Implement undefined method in Encoding class

### DIFF
--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -60,15 +60,7 @@ class Encoding extends PDFObject
         $this->encoding = [];
 
         if ($this->has('BaseEncoding')) {
-            // Load reference table charset.
-            $baseEncoding = preg_replace('/[^A-Z0-9]/is', '', $this->get('BaseEncoding')->getContent());
-            $className = '\\Smalot\\PdfParser\\Encoding\\'.$baseEncoding;
-
-            if (!class_exists($className)) {
-                throw new \Exception('Missing encoding data for: "'.$baseEncoding.'".');
-            }
-
-            $class = new $className();
+            $class = $this->getEncodingClass();
             $this->encoding = $class->getTranslations();
 
             // Build table including differences.
@@ -129,5 +121,24 @@ class Encoding extends PDFObject
         }
 
         return PostScriptGlyphs::getCodePoint($dec);
+    }
+
+    public function __toString()
+    {
+        return $this->getEncodingClass();
+    }
+
+
+    protected function getEncodingClass()
+    {
+        // Load reference table charset.
+        $baseEncoding = preg_replace('/[^A-Z0-9]/is', '', $this->get('BaseEncoding')->getContent());
+        $className = '\\Smalot\\PdfParser\\Encoding\\'.$baseEncoding;
+
+        if (!class_exists($className)) {
+            throw new \Exception('Missing encoding data for: "'.$baseEncoding.'".');
+        }
+
+        return new $className();
     }
 }

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -60,7 +60,8 @@ class Encoding extends PDFObject
         $this->encoding = [];
 
         if ($this->has('BaseEncoding')) {
-            $class = $this->getEncodingClass();
+            $className = $this->getEncodingClass();
+            $class = new $className();
             $this->encoding = $class->getTranslations();
 
             // Build table including differences.
@@ -123,12 +124,19 @@ class Encoding extends PDFObject
         return PostScriptGlyphs::getCodePoint($dec);
     }
 
+    /**
+     * @return string
+     * @throws \Exception
+     */
     public function __toString()
     {
         return $this->getEncodingClass();
     }
 
-
+    /**
+     * @return string
+     * @throws \Exception
+     */
     protected function getEncodingClass()
     {
         // Load reference table charset.
@@ -139,6 +147,6 @@ class Encoding extends PDFObject
             throw new \Exception('Missing encoding data for: "'.$baseEncoding.'".');
         }
 
-        return new $className();
+        return $className;
     }
 }

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -126,6 +126,7 @@ class Encoding extends PDFObject
 
     /**
      * @return string
+     *
      * @throws \Exception
      */
     public function __toString()
@@ -135,6 +136,7 @@ class Encoding extends PDFObject
 
     /**
      * @return string
+     *
      * @throws \Exception
      */
     protected function getEncodingClass()

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -30,6 +30,7 @@
 
 namespace Smalot\PdfParser;
 
+use Exception;
 use Smalot\PdfParser\Element\ElementNumeric;
 use Smalot\PdfParser\Encoding\PostScriptGlyphs;
 
@@ -146,7 +147,7 @@ class Encoding extends PDFObject
         $className = '\\Smalot\\PdfParser\\Encoding\\'.$baseEncoding;
 
         if (!class_exists($className)) {
-            throw new \Exception('Missing encoding data for: "'.$baseEncoding.'".');
+            throw new Exception('Missing encoding data for: "'.$baseEncoding.'".');
         }
 
         return $className;

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -30,6 +30,8 @@
 
 namespace Smalot\PdfParser;
 
+use Smalot\PdfParser\Encoding\WinAnsiEncoding;
+
 /**
  * Class Font
  */
@@ -101,7 +103,11 @@ class Font extends PDFObject
 
         // fallback for decoding single-byte ANSI characters that are not in the lookup table
         $fallbackDecoded = $char;
-        if (\strlen($char) < 2 && $this->has('Encoding') && '\Smalot\PdfParser\Encoding\WinAnsiEncoding' === $this->get('Encoding')->__toString()) {
+        if (
+            \strlen($char) < 2
+            && $this->has('Encoding')
+            && WinAnsiEncoding::class === $this->get('Encoding')->__toString()
+        ) {
             $fallbackDecoded = self::uchr($dec);
         }
 

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -101,7 +101,7 @@ class Font extends PDFObject
 
         // fallback for decoding single-byte ANSI characters that are not in the lookup table
         $fallbackDecoded = $char;
-        if (\strlen($char) < 2 && $this->has('Encoding') && 'WinAnsiEncoding' === $this->get('Encoding')->__toString()) {
+        if (\strlen($char) < 2 && $this->has('Encoding') && '\Smalot\PdfParser\Encoding\WinAnsiEncoding' === $this->get('Encoding')->__toString()) {
             $fallbackDecoded = self::uchr($dec);
         }
 

--- a/tests/Integration/EncodingTest.php
+++ b/tests/Integration/EncodingTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @file This file is part of the PdfParser library.
+ *
+ * @author  Konrad Abicht <k.abicht@gmail.com>
+ * @date    2020-06-01
+ *
+ * @author  Sébastien MALOT <sebastien@malot.fr>
+ * @date    2017-01-03
+ *
+ * @license LGPLv3
+ * @url     <https://github.com/smalot/pdfparser>
+ *
+ *  PdfParser is a pdf library written in PHP, extraction oriented.
+ *  Copyright (C) 2017 - Sébastien MALOT <sebastien@malot.fr>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.
+ *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
+ */
+
+namespace Tests\Smalot\PdfParser\Integration;
+
+use Exception;
+use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
+use Smalot\PdfParser\Encoding;
+use Smalot\PdfParser\Encoding\StandardEncoding;
+use Smalot\PdfParser\Header;
+use Tests\Smalot\PdfParser\TestCase;
+
+class EncodingTest extends TestCase
+{
+    public function testGetEncodingClass()
+    {
+        $header = new Header(['BaseEncoding' => new Element('StandardEncoding')]);
+
+        $encoding = new Encoding(new Document(), $header);
+        $encoding->init();
+
+        $this->assertEquals('\\'.StandardEncoding::class, $encoding->__toString());
+    }
+
+    /**
+     * This tests checks behavior if given Encoding class doesn't exist.
+     */
+    public function testGetEncodingClassMissingClassException()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Missing encoding data for: "invalid"');
+
+        $header = new Header(['BaseEncoding' => new Element('invalid')]);
+
+        $encoding = new Encoding(new Document(), $header);
+        $encoding->init();
+
+        $encoding->__toString();
+    }
+}


### PR DESCRIPTION
The __toString method was missing/not implemented, even though it is called in some cases.

Fixes #364