### PR TITLE
Fixes #367 (Call to a member function init() on boolean in Header.php on line 66)

### DIFF
--- a/src/Smalot/PdfParser/Header.php
+++ b/src/Smalot/PdfParser/Header.php
@@ -63,7 +63,7 @@ class Header
     public function init()
     {
         foreach ($this->elements as $element) {
-            if($element instanceof Element) {
+            if ($element instanceof Element) {
                 $element->init();
             }
         }

--- a/src/Smalot/PdfParser/Header.php
+++ b/src/Smalot/PdfParser/Header.php
@@ -62,8 +62,10 @@ class Header
 
     public function init()
     {
-        foreach ($this->elements as $name => $element) {
-            $element->init();
+        foreach ($this->elements as $element) {
+            if($element instanceof Element) {
+                $element->init();
+            }
         }
     }
 

--- a/tests/Integration/HeaderTest.php
+++ b/tests/Integration/HeaderTest.php
@@ -32,6 +32,7 @@
 
 namespace Tests\Smalot\PdfParser\Integration;
 
+use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Element\ElementMissing;
 use Smalot\PdfParser\Element\ElementName;
 use Smalot\PdfParser\Header;
@@ -44,6 +45,35 @@ use Tests\Smalot\PdfParser\TestCase;
  */
 class HeaderTest extends TestCase
 {
+    /**
+     * Checks that init function is called for each element.
+     */
+    public function testInitHappyPath()
+    {
+        $element = $this->createMock(Element::class);
+        $element->expects($this->exactly(1))->method('init');
+
+        $fixture = new Header([$element]);
+        $fixture->init();
+    }
+
+    /**
+     * Checks buggy behavior if an element was given which is not of type Element.
+     *
+     * Problem was, it always called $element::init(), even if its not an object at all.
+     *
+     * @see https://github.com/smalot/pdfparser/issues/367
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testInitInvalidElement()
+    {
+        $element = false;
+
+        $fixture = new Header([$element]);
+        $fixture->init();
+    }
+
     public function testParse()
     {
         $document = $this->getDocumentInstance();


### PR DESCRIPTION
Fix was provided by @lukgru ([ref](https://github.com/smalot/pdfparser/issues/367#issuecomment-729722831)).

Fixes #367.

I added two tests to demonstrate expected behavior.