### PR TITLE
Fix Fatal Error when Encoding is not Encoding

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -106,6 +106,7 @@ class Font extends PDFObject
         if (
             \strlen($char) < 2
             && $this->has('Encoding')
+            && $this->get('Encoding') instanceof Encoding
             && WinAnsiEncoding::class === $this->get('Encoding')->__toString()
         ) {
             $fallbackDecoded = self::uchr($dec);


### PR DESCRIPTION
make sure that the header encoding is instance of class Encoding before converting it to string

**Prevent this Error from happening:**
Uncaught Error: Call to undefined method Smalot\PdfParser\Header::__toString() in /var/www/vendor/smalot/pdfparser/src/Smalot/PdfParser/Font.php:109
Stack trace:
#0 /var/www/vendor/smalot/pdfparser/src/Smalot/PdfParser/Font.php(430): Smalot\PdfParser\Font->translateChar('R', false)
#1 /var/www/vendor/smalot/pdfparser/src/Smalot/PdfParser/Font.php(406): Smalot\PdfParser\Font->decodeContent('8\x12\tC\v\x14\x11\x12 \t"\x12\x15\x0F\x16...')
#2 /var/www/vendor/smalot/pdfparser/src/Smalot/PdfParser/PDFObject.php(341): Smalot\PdfParser\Font->decodeText(Array)
#3 /var/www/vendor/smalot/pdfparser/src/Smalot/PdfParser/Page.php(228): Smalot\PdfParser\PDFObject->getText(Object(Smalot\PdfParser\Page))
#4 /var/www/vendor/smalot/pdfparser/src/Smalot/PdfParser/Document.php(259): Smalot\PdfParser\Page->getText()

In this case $this->header->elements["Encoding"] is instance of Smalot\PdfParser\Header (don't know why - maybe corrupted pdf).

Any way - this prevents an fatal error.