### PR TITLE
Encoding::__toString complies with PHP specification from now on

### DIFF
--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -128,9 +128,9 @@ class Encoding extends PDFObject
     /**
      * Returns the name of the encoding class, if available.
      *
-     * @return string
+     * @return string Returns encoding class name if available or empty string (only prior PHP 7.4).
      *
-     * @throws \Exception On PHP 7.4 an exception is thrown if encoding class doesn't exist.
+     * @throws \Exception On PHP 7.4+ an exception is thrown if encoding class doesn't exist.
      */
     public function __toString()
     {

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -126,13 +126,24 @@ class Encoding extends PDFObject
     }
 
     /**
+     * Returns the name of the encoding class, if available.
+     *
      * @return string
      *
-     * @throws \Exception
+     * @throws \Exception On PHP 7.4 an exception is thrown if encoding class doesn't exist.
      */
     public function __toString()
     {
-        return $this->getEncodingClass();
+        try {
+            return $this->getEncodingClass();
+        } catch (Exception $e) {
+            // prior to PHP 7.4 toString has to return an empty string.
+            if (version_compare(PHP_VERSION, '7.4.0', '<')) {
+                return '';
+            } else {
+                throw $e;
+            }
+        }
     }
 
     /**

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -138,7 +138,7 @@ class Encoding extends PDFObject
             return $this->getEncodingClass();
         } catch (Exception $e) {
             // prior to PHP 7.4 toString has to return an empty string.
-            if (version_compare(PHP_VERSION, '7.4.0', '<')) {
+            if (version_compare(\PHP_VERSION, '7.4.0', '<')) {
                 return '';
             } else {
                 throw $e;

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -140,9 +140,8 @@ class Encoding extends PDFObject
             // prior to PHP 7.4 toString has to return an empty string.
             if (version_compare(\PHP_VERSION, '7.4.0', '<')) {
                 return '';
-            } else {
-                throw $e;
             }
+            throw $e;
         }
     }
 


### PR DESCRIPTION
Besides an if-else I also added more details in code and text.

Hint came from @igor-krein in https://github.com/smalot/pdfparser/issues/85#issuecomment-808087939:

> Currently, in the Encoding.php, there is a "magic" function __toString() implementation, which calls a getEncodingClass() function, which, in its turn, may throw an exception (line 150).

> **From php.net:** *Warning It was not possible to throw an exception from within a __toString() method prior to PHP 7.4.0. Doing so will result in a fatal error.*

> I think, if there is a need to keep a PHP 7.4 support, better change the line 150 somehow (for example, simply return an empty string). Note that __toString() method must return a string.