### PR TITLE
Refactor: declare pdf whitespaces in global variable to avoid bug

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -141,18 +141,14 @@ jobs:
     name: "Tests alternative autoloader (PHP ${{ matrix.php }})"
     runs-on: "ubuntu-20.04"
 
-    env:
-      SYMFONY_PHPUNIT_VERSION: 7.5
-
     strategy:
       matrix:
         php:
-          - "5.6"
-          - "7.0"
           - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"
+          - "8.0"
 
     steps:
       - name: "Checkout"

--- a/src/Smalot/PdfParser/Config.php
+++ b/src/Smalot/PdfParser/Config.php
@@ -42,8 +42,14 @@ class Config
 
     /**
      * Represents: (NUL, HT, LF, FF, CR, SP)
+     * @var string
      */
     private $pdfWhitespaces = "\0\t\n\f\r ";
+
+    /**
+     * Represents: (NUL, HT, LF, FF, CR, SP)
+     * @var string
+     */
     private $pdfWhitespacesRegex = '[\0\t\n\f\r ]';
 
     public function getFontSpaceLimit()
@@ -56,22 +62,22 @@ class Config
         $this->fontSpaceLimit = $value;
     }
 
-    public function getPdfWhitespaces()
+    public function getPdfWhitespaces(): string
     {
         return $this->pdfWhitespaces;
     }
 
-    public function setPdfWhitespaces(string $pdfWhitespaces)
+    public function setPdfWhitespaces(string $pdfWhitespaces): void
     {
         $this->pdfWhitespaces = $pdfWhitespaces;
     }
 
-    public function getPdfWhitespacesRegex()
+    public function getPdfWhitespacesRegex(): string
     {
         return $this->pdfWhitespacesRegex;
     }
 
-    public function setPdfWhitespacesRegex(string $pdfWhitespacesRegex)
+    public function setPdfWhitespacesRegex(string $pdfWhitespacesRegex): void
     {
         $this->pdfWhitespacesRegex = $pdfWhitespacesRegex;
     }

--- a/src/Smalot/PdfParser/Config.php
+++ b/src/Smalot/PdfParser/Config.php
@@ -40,6 +40,12 @@ class Config
 {
     private $fontSpaceLimit = -50;
 
+    /**
+     * Represents: (NUL, HT, LF, FF, CR, SP)
+     */
+    private $pdfWhitespaces = "\0\t\n\f\r ";
+    private $pdfWhitespacesRegex = '[\0\t\n\f\r ]';
+
     public function getFontSpaceLimit()
     {
         return $this->fontSpaceLimit;
@@ -48,5 +54,25 @@ class Config
     public function setFontSpaceLimit($value)
     {
         $this->fontSpaceLimit = $value;
+    }
+
+    public function getPdfWhitespaces(): string
+    {
+        return $this->pdfWhitespaces;
+    }
+
+    public function setPdfWhitespaces(string $pdfWhitespaces): void
+    {
+        $this->pdfWhitespaces = $pdfWhitespaces;
+    }
+
+    public function getPdfWhitespacesRegex(): string
+    {
+        return $this->pdfWhitespacesRegex;
+    }
+
+    public function setPdfWhitespacesRegex(string $pdfWhitespacesRegex): void
+    {
+        $this->pdfWhitespacesRegex = $pdfWhitespacesRegex;
     }
 }

--- a/src/Smalot/PdfParser/Config.php
+++ b/src/Smalot/PdfParser/Config.php
@@ -56,22 +56,22 @@ class Config
         $this->fontSpaceLimit = $value;
     }
 
-    public function getPdfWhitespaces(): string
+    public function getPdfWhitespaces()
     {
         return $this->pdfWhitespaces;
     }
 
-    public function setPdfWhitespaces(string $pdfWhitespaces): void
+    public function setPdfWhitespaces(string $pdfWhitespaces)
     {
         $this->pdfWhitespaces = $pdfWhitespaces;
     }
 
-    public function getPdfWhitespacesRegex(): string
+    public function getPdfWhitespacesRegex()
     {
         return $this->pdfWhitespacesRegex;
     }
 
-    public function setPdfWhitespacesRegex(string $pdfWhitespacesRegex): void
+    public function setPdfWhitespacesRegex(string $pdfWhitespacesRegex)
     {
         $this->pdfWhitespacesRegex = $pdfWhitespacesRegex;
     }

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -60,8 +60,8 @@ class Parser
 
     public function __construct($cfg = [], Config $config = null)
     {
-        $this->rawDataParser = new RawDataParser($cfg);
         $this->config = $config ?: new Config();
+        $this->rawDataParser = new RawDataParser($cfg, $this->config);
     }
 
     /**

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -470,13 +470,13 @@ class RawDataParser
         return $xref;
     }
 
-    protected function getObjectHeaderPattern($objRefArr)
+    protected function getObjectHeaderPattern($objRefArr): string
     {
         // consider all whitespace character (PDF specifications)
         return '/'.$objRefArr[0].$this->config->getPdfWhitespacesRegex().$objRefArr[1].$this->config->getPdfWhitespacesRegex().'obj'.'/';
     }
 
-    protected function getObjectHeaderLen($objRefArr)
+    protected function getObjectHeaderLen($objRefArr): int
     {
         // "4 0 obj"
         // 2 whitespaces + strlen("obj") = 5

--- a/tests/Integration/RawData/RawDataParserTest.php
+++ b/tests/Integration/RawData/RawDataParserTest.php
@@ -32,6 +32,7 @@
 
 namespace Tests\Smalot\PdfParser\Integration\RawData;
 
+use Smalot\PdfParser\Config;
 use Smalot\PdfParser\RawData\RawDataParser;
 use Tests\Smalot\PdfParser\TestCase;
 
@@ -52,7 +53,7 @@ class RawDataParserTest extends TestCase
     {
         parent::setUp();
 
-        $this->fixture = new RawDataParserHelper();
+        $this->fixture = new RawDataParserHelper([], new Config());
     }
 
     /**


### PR DESCRIPTION
Hi,

I made some refactor in RawDataParser, I declared a global variable containing pdf whitespaces so we don't need to hardcode were use whitespace, avoiding bug if forget to consider all pdf whitespaces