### PR TITLE
Fixes YAML of coding-standards.yml

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -31,7 +31,7 @@ jobs:
         run: make install-dev-tools
       -
         name: Run PHP CS Fixer
-        run: make run-php-cs-fixer ARGS="--verbose --dry-run --format=checkstyle" | cs2pr
+        run: 'make run-php-cs-fixer ARGS="--verbose --dry-run --format=checkstyle" | cs2pr'
       -
         name: Run PHPStan
-        run: make run-phpstan ARGS="--no-progress --error-format=checkstyle" | cs2pr
+        run: 'make run-phpstan ARGS="--no-progress --error-format=checkstyle" | cs2pr'

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -31,7 +31,7 @@ jobs:
         run: make install-dev-tools
       -
         name: Run PHP CS Fixer
-        run: 'make run-php-cs-fixer ARGS="--verbose --dry-run --format=checkstyle" | cs2pr'
+        run: 'make run-php-cs-fixer ARGS="--verbose --dry-run"'
       -
         name: Run PHPStan
         run: 'make run-phpstan ARGS="--no-progress --error-format=checkstyle" | cs2pr'

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           coverage: none
           php-version: "7.4"
-          tools: "cs2pr, composer:v1"
+          tools: "composer:v1"
       -
         name: Install dependencies with Composer
         uses: ramsey/composer-install@v1
@@ -34,4 +34,4 @@ jobs:
         run: 'make run-php-cs-fixer ARGS="--verbose --dry-run"'
       -
         name: Run PHPStan
-        run: 'make run-phpstan ARGS="--no-progress --error-format=checkstyle" | cs2pr'
+        run: 'make run-phpstan ARGS="--no-progress"'

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,29 +9,29 @@ on:
 jobs:
   coding-standards:
     name: "CS Fixer & PHPStan"
-    runs-on: "ubuntu-20.04"
-
+    runs-on: ubuntu-20.04
     steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v2"
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          coverage: "none"
-          php-version: "7.4"
-          tools: cs2pr, composer:v1
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
-
-      - name: "Install dev tools"
-        run: "make install-dev-tools"
-
-      - name: "Run PHP CS Fixer"
-        run: "make run-php-cs-fixer ARGS="--verbose --dry-run --format=checkstyle" | cs2pr"
-
-      - name: "Run PHPStan"
-        run: "make run-phpstan ARGS="--no-progress --error-format=checkstyle" | cs2pr"
+          COMPOSER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+          php-version: "7.4"
+          tools: "cs2pr, composer:v1"
+      -
+        name: Install dependencies with Composer
+        uses: ramsey/composer-install@v1
+      -
+        name: Install dev tools
+        run: make install-dev-tools
+      -
+        name: Run PHP CS Fixer
+        run: make run-php-cs-fixer ARGS="--verbose --dry-run --format=checkstyle" | cs2pr
+      -
+        name: Run PHPStan
+        run: make run-phpstan ARGS="--no-progress --error-format=checkstyle" | cs2pr

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ run-php-cs-fixer:
 	dev-tools/vendor/bin/php-cs-fixer fix $(ARGS)
 
 run-phpstan:
-	dev-tools/vendor/bin/phpstan/phpstan/phpstan analyze $(ARGS)
+	dev-tools/vendor/bin/phpstan analyze $(ARGS)
 
 run-phpunit:
 	dev-tools/vendor/bin/phpunit $(ARGS)


### PR DESCRIPTION
Our coding standards workflow is failing for a while: https://github.com/smalot/pdfparser/actions/workflows/coding-standards.yml

Example: https://github.com/smalot/pdfparser/actions/runs/763299759

Error: `You have an error in your yaml syntax on line 33`