### PR TITLE
Fixed remaining parameter lists which miss Config parameter

### DIFF
--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -211,7 +211,7 @@ class Page extends PDFObject
                     }
 
                     $header = new Header([], $this->document);
-                    $contents = new PDFObject($this->document, $header, $new_content);
+                    $contents = new PDFObject($this->document, $header, $new_content, $this->config);
                 }
             } elseif ($contents instanceof ElementArray) {
                 // Create a virtual global content.
@@ -222,7 +222,7 @@ class Page extends PDFObject
                 }
 
                 $header = new Header([], $this->document);
-                $contents = new PDFObject($this->document, $header, $new_content);
+                $contents = new PDFObject($this->document, $header, $new_content, $this->config);
             }
 
             return $contents->getText($this);
@@ -259,7 +259,7 @@ class Page extends PDFObject
                     }
 
                     $header = new Header([], $this->document);
-                    $contents = new PDFObject($this->document, $header, $new_content);
+                    $contents = new PDFObject($this->document, $header, $new_content, $this->config);
                 }
             } elseif ($contents instanceof ElementArray) {
                 // Create a virtual global content.
@@ -271,7 +271,7 @@ class Page extends PDFObject
                 }
 
                 $header = new Header([], $this->document);
-                $contents = new PDFObject($this->document, $header, $new_content);
+                $contents = new PDFObject($this->document, $header, $new_content, $this->config);
             }
 
             return $contents->getTextArray($this);


### PR DESCRIPTION
This PR should fix the following error message once and for all:

> Call to a member function getFontSpaceLimit() on null

Closes #423

I tested it with https://github.com/smalot/pdfparser/files/6492106/Martucci.et.al.pdf successfully. Mentioned PDF seems to be a copyright protected paper, therefore it was not added to our tests.