### PR TITLE
Don't throw an exception if Encoding doesn't have BaseEncoding

### DIFF
--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -148,7 +148,7 @@ class Encoding extends PDFObject
     /**
      * @return string
      *
-     * @throws \Exception
+     * @throws EncodingNotFoundException
      */
     protected function getEncodingClass()
     {

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -157,7 +157,7 @@ class Encoding extends PDFObject
         $className = '\\Smalot\\PdfParser\\Encoding\\'.$baseEncoding;
 
         if (!class_exists($className)) {
-            throw new Exception('Missing encoding data for: "'.$baseEncoding.'".');
+            throw new EncodingNotFoundException('Missing encoding data for: "'.$baseEncoding.'".');
         }
 
         return $className;

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -33,6 +33,7 @@ namespace Smalot\PdfParser;
 use Exception;
 use Smalot\PdfParser\Element\ElementNumeric;
 use Smalot\PdfParser\Encoding\PostScriptGlyphs;
+use Smalot\PdfParser\Exception\EncodingNotFoundException;
 
 /**
  * Class Encoding

--- a/src/Smalot/PdfParser/EncodingNotFoundException.php
+++ b/src/Smalot/PdfParser/EncodingNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Smalot\PdfParser;
+
+class EncodingNotFoundException extends \Exception
+{
+}

--- a/src/Smalot/PdfParser/Exception/EncodingNotFoundException.php
+++ b/src/Smalot/PdfParser/Exception/EncodingNotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Smalot\PdfParser;
+namespace Smalot\PdfParser\Exception;
 
 class EncodingNotFoundException extends \Exception
 {

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -113,7 +113,7 @@ class Font extends PDFObject
                     $fallbackDecoded = self::uchr($dec);
                 }
             } catch (EncodingNotFoundException $e) {
-                // Encoding->getEncodingClass() throws an exception when BaseEncoding doesn't exists
+                // Encoding->getEncodingClass() throws EncodingNotFoundException when BaseEncoding doesn't exists
                 // See table 5.11 on PDF 1.5 specs for more info
             }
         }

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -107,9 +107,15 @@ class Font extends PDFObject
             \strlen($char) < 2
             && $this->has('Encoding')
             && $this->get('Encoding') instanceof Encoding
-            && WinAnsiEncoding::class === $this->get('Encoding')->__toString()
         ) {
-            $fallbackDecoded = self::uchr($dec);
+            try {
+                if (WinAnsiEncoding::class === $this->get('Encoding')->__toString()) {
+                    $fallbackDecoded = self::uchr($dec);
+                }
+            } catch (\Exception $e) {
+                // Encoding->getEncodingClass() throws an exception when BaseEncoding doesn't exists
+                // See table 5.11 on PDF 1.5 specs for more info
+            }
         }
 
         return $use_default ? self::MISSING : $fallbackDecoded;

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -112,7 +112,7 @@ class Font extends PDFObject
                 if (WinAnsiEncoding::class === $this->get('Encoding')->__toString()) {
                     $fallbackDecoded = self::uchr($dec);
                 }
-            } catch (\Exception $e) {
+            } catch (EncodingNotFoundException $e) {
                 // Encoding->getEncodingClass() throws an exception when BaseEncoding doesn't exists
                 // See table 5.11 on PDF 1.5 specs for more info
             }

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -31,6 +31,7 @@
 namespace Smalot\PdfParser;
 
 use Smalot\PdfParser\Encoding\WinAnsiEncoding;
+use Smalot\PdfParser\Exception\EncodingNotFoundException;
 
 /**
  * Class Font

--- a/tests/Integration/EncodingTest.php
+++ b/tests/Integration/EncodingTest.php
@@ -37,7 +37,7 @@ use Smalot\PdfParser\Document;
 use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Encoding;
 use Smalot\PdfParser\Encoding\StandardEncoding;
-use Smalot\PdfParser\EncodingNotFoundException;
+use Smalot\PdfParser\Exception\EncodingNotFoundException;
 use Smalot\PdfParser\Header;
 use Tests\Smalot\PdfParser\TestCase;
 

--- a/tests/Integration/EncodingTest.php
+++ b/tests/Integration/EncodingTest.php
@@ -37,6 +37,7 @@ use Smalot\PdfParser\Document;
 use Smalot\PdfParser\Element;
 use Smalot\PdfParser\Encoding;
 use Smalot\PdfParser\Encoding\StandardEncoding;
+use Smalot\PdfParser\EncodingNotFoundException;
 use Smalot\PdfParser\Header;
 use Tests\Smalot\PdfParser\TestCase;
 
@@ -62,7 +63,7 @@ class EncodingTest extends TestCase
      */
     public function testInitGetEncodingClassMissingClassException()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(EncodingNotFoundException::class);
         $this->expectExceptionMessage('Missing encoding data for: "invalid"');
 
         $header = new Header(['BaseEncoding' => new Element('invalid')]);

--- a/tests/Integration/FontTest.php
+++ b/tests/Integration/FontTest.php
@@ -379,4 +379,17 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
 
         $this->assertEquals('Example PDF', $text);
     }
+
+    /**
+     * Create a header containing a Encoding that doesn't have a BaseEncoding
+     * so I test if the Font won't raise a exception because Encoding don't have BaseEncoding
+     */
+    public function testEncodingWithoutBaseEncoding()
+    {
+        $document = new Document();
+        $header = new Header(['Encoding' => new Encoding($document)]);
+        $font = new Font(new Document(), $header);
+        $font->setTable([]);
+        $this->assertEquals('?', $font->translateChar('a'));
+    }
 }

--- a/tests/Integration/FontTest.php
+++ b/tests/Integration/FontTest.php
@@ -381,8 +381,8 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
     }
 
     /**
-     * Create a header containing a Encoding that doesn't have a BaseEncoding
-     * so I test if the Font won't raise a exception because Encoding don't have BaseEncoding
+     * Create an instance of Header containing an instance of Encoding that doesn't have a BaseEncoding.
+     * Test if the Font won't raise a exception because Encoding don't have BaseEncoding.
      */
     public function testEncodingWithoutBaseEncoding()
     {


### PR DESCRIPTION
Fixes #432 

`$this->get('Encoding')->__toString()` throws an exception when Encoding don't have BaseEncoding attribute, so I put it on a try catch because if Encoding don't have BaseEncoding, of course `WinAnsiEncoding::class === $this->get('Encoding')->__toString()` will return false

I didn't make any unit test because I only have a confidential PDF file which cause this bug