### PR TITLE
Prevent endless loops during Page->getText() because of faulty recursionStack

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -437,8 +437,6 @@ class PDFObject
             $result .= $text;
         }
 
-        array_pop(self::$recursionStack);
-
         return $result.' ';
     }
 

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -176,6 +176,8 @@ class Page extends PDFObject
 
     public function getText(self $page = null): string
     {
+        PDFObject::$recursionStack = [];
+        
         if ($contents = $this->get('Contents')) {
             if ($contents instanceof ElementMissing) {
                 return '';

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -210,9 +210,11 @@ class Page extends PDFObject
                 $contents = new PDFObject($this->document, $header, $new_content, $this->config);
             }
 
-            // Elements referecing eachother on the same page can cause endless loops during text parsing.
-            // To combat this we keep a recursionStack containing already parsed elements on the page.
-            // The stack is only emptied here after getting text from a page.
+            /*
+             * Elements referecing eachother on the same page can cause endless loops during text parsing.
+             * To combat this we keep a recursionStack containing already parsed elements on the page.
+             * The stack is only emptied here after getting text from a page.
+             */
             $contentsText = $contents->getText($this);
             PDFObject::$recursionStack = [];
 

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -176,8 +176,6 @@ class Page extends PDFObject
 
     public function getText(self $page = null): string
     {
-        PDFObject::$recursionStack = [];
-        
         if ($contents = $this->get('Contents')) {
             if ($contents instanceof ElementMissing) {
                 return '';
@@ -212,7 +210,10 @@ class Page extends PDFObject
                 $contents = new PDFObject($this->document, $header, $new_content, $this->config);
             }
 
-            return $contents->getText($this);
+            $contentsText = $contents->getText($this);
+            PDFObject::$recursionStack = [];
+
+            return $contentsText
         }
 
         return '';

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -211,7 +211,7 @@ class Page extends PDFObject
             }
 
             /*
-             * Elements referecing eachother on the same page can cause endless loops during text parsing.
+             * Elements referencing each other on the same page can cause endless loops during text parsing.
              * To combat this we keep a recursionStack containing already parsed elements on the page.
              * The stack is only emptied here after getting text from a page.
              */

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -210,6 +210,9 @@ class Page extends PDFObject
                 $contents = new PDFObject($this->document, $header, $new_content, $this->config);
             }
 
+            // Elements referecing eachother on the same page can cause endless loops during text parsing.
+            // To combat this we keep a recursionStack containing already parsed elements on the page.
+            // The stack is only emptied here after getting text from a page.
             $contentsText = $contents->getText($this);
             PDFObject::$recursionStack = [];
 

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -213,7 +213,7 @@ class Page extends PDFObject
             $contentsText = $contents->getText($this);
             PDFObject::$recursionStack = [];
 
-            return $contentsText
+            return $contentsText;
         }
 
         return '';

--- a/tests/Integration/PageTest.php
+++ b/tests/Integration/PageTest.php
@@ -162,15 +162,6 @@ class PageTest extends TestCase
         $this->assertStringContainsString('Snelfilterkoffie', $text);
         $this->assertStringContainsString('AardappelenZak', $text);
         $this->assertStringContainsString('ALL', $text);
-
-        // Force garbage collection to not interfere with other tests.
-        unset($filename);
-        unset($parser);
-        unset($document);
-        unset($pages);
-        unset($page);
-        unset($text);
-        gc_collect_cycles();
     }
 
     public function testExtractRawData()

--- a/tests/Integration/PageTest.php
+++ b/tests/Integration/PageTest.php
@@ -163,11 +163,14 @@ class PageTest extends TestCase
         $this->assertStringContainsString('AardappelenZak', $text);
         $this->assertStringContainsString('ALL', $text);
 
+        // Force garbage collection to not interfere with other tests.
+        unset($filename);
         unset($parser);
         unset($document);
         unset($pages);
         unset($page);
         unset($text);
+        gc_collect_cycles();
     }
 
     public function testExtractRawData()

--- a/tests/Integration/PageTest.php
+++ b/tests/Integration/PageTest.php
@@ -141,6 +141,26 @@ class PageTest extends TestCase
         $this->assertStringContainsString('Verdana', $text);
     }
 
+    public function testGetTextPullRequest457()
+    {
+        // Document with text.
+        $filename = $this->rootDir.'/samples/bugs/PullRequest457.pdf';
+        $parser = $this->getParserInstance();
+        $document = $parser->parseFile($filename);
+        $pages = $document->getPages();
+        $page = $pages[0];
+        $text = $page->getText();
+
+        $this->assertTrue(1000 < \strlen($text));
+        $this->assertStringContainsString('SUPER', $text);
+        $this->assertStringContainsString('VOORDEEL', $text);
+        $this->assertStringContainsString('KRANT', $text);
+        $this->assertStringContainsString('DINSDAG', $text);
+        $this->assertStringContainsString('Snelfilterkoffie', $text);
+        $this->assertStringContainsString('AardappelenZak', $text);
+        $this->assertStringContainsString('ALL', $text);
+    }
+
     public function testExtractRawData()
     {
         // Document with text.

--- a/tests/Integration/PageTest.php
+++ b/tests/Integration/PageTest.php
@@ -162,6 +162,12 @@ class PageTest extends TestCase
         $this->assertStringContainsString('Snelfilterkoffie', $text);
         $this->assertStringContainsString('AardappelenZak', $text);
         $this->assertStringContainsString('ALL', $text);
+
+        unset($parser);
+        unset($document);
+        unset($pages);
+        unset($page);
+        unset($text);
     }
 
     public function testExtractRawData()

--- a/tests/Integration/PageTest.php
+++ b/tests/Integration/PageTest.php
@@ -141,6 +141,9 @@ class PageTest extends TestCase
         $this->assertStringContainsString('Verdana', $text);
     }
 
+    /**
+     * @see https://github.com/smalot/pdfparser/pull/457
+     */
     public function testGetTextPullRequest457()
     {
         // Document with text.

--- a/tests/Integration/ParserTest.php
+++ b/tests/Integration/ParserTest.php
@@ -338,7 +338,7 @@ class ParserTest extends TestCase
         }
 
         $usedMemory = memory_get_usage(true);
-        $this->assertTrue($usedMemory > 200000000, 'Memory is only '.$usedMemory);
+        $this->assertTrue($usedMemory > ($baselineMemory * 1.5), 'Memory is only '.$usedMemory);
         $this->assertTrue(null != $document && 0 < \strlen($document->getText()));
 
         // force garbage collection

--- a/tests/Integration/ParserTest.php
+++ b/tests/Integration/ParserTest.php
@@ -320,6 +320,9 @@ class ParserTest extends TestCase
             $this->markTestSkipped('Garbage collection doesn\'t work reliably enough for this test in PHP < 7.3');
         }
 
+        gc_collect_cycles();
+        $baselineMemory = memory_get_usage(true);
+
         $filename = $this->rootDir.'/samples/bugs/Issue104a.pdf';
         $iterations = 2;
 
@@ -359,7 +362,7 @@ class ParserTest extends TestCase
          * note: the following memory value is set manually and may differ from system to system.
          *       it must be high enough to not produce a false negative though.
          */
-        $this->assertTrue($usedMemory < 107000000, 'Memory is '.$usedMemory);
+        $this->assertTrue($usedMemory < ($baselineMemory * 1.05), 'Memory is '.$usedMemory);
         $this->assertTrue(0 < \strlen($document->getText()));
     }
 }


### PR DESCRIPTION
The $recursionStack used in the getText() function of PDFObject to prevent "Do" commands from causing endless loops removes items from it's stack prematurely during the parsing of pages. Meaning endless loops can and are still being caused by the Do command.

Only reseting the recursionStack at the end of the getText() function for every page prevents this bug.