### PR TITLE
Fix invalid return type on unknown glyph

### DIFF
--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -110,7 +110,10 @@ class Encoding extends PDFObject
         return $details;
     }
 
-    public function translateChar($dec): int
+    /**
+     * @return int|float|mixed
+     */
+    public function translateChar($dec)
     {
         if (isset($this->mapping[$dec])) {
             $dec = $this->mapping[$dec];

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -110,10 +110,7 @@ class Encoding extends PDFObject
         return $details;
     }
 
-    /**
-     * @return int|float|mixed
-     */
-    public function translateChar($dec)
+    public function translateChar($dec): ?int
     {
         if (isset($this->mapping[$dec])) {
             $dec = $this->mapping[$dec];

--- a/src/Smalot/PdfParser/Encoding/PostScriptGlyphs.php
+++ b/src/Smalot/PdfParser/Encoding/PostScriptGlyphs.php
@@ -1084,10 +1084,7 @@ class PostScriptGlyphs
         ];
     }
 
-    /**
-     * @return float|int|mixed
-     */
-    public static function getCodePoint($glyph)
+    public static function getCodePoint($glyph): ?int
     {
         $glyphsMap = static::getGlyphs();
 
@@ -1095,6 +1092,6 @@ class PostScriptGlyphs
             return hexdec($glyphsMap[$glyph]);
         }
 
-        return $glyph;
+        return null;
     }
 }

--- a/src/Smalot/PdfParser/Encoding/PostScriptGlyphs.php
+++ b/src/Smalot/PdfParser/Encoding/PostScriptGlyphs.php
@@ -1084,6 +1084,9 @@ class PostScriptGlyphs
         ];
     }
 
+    /**
+     * @return float|int|mixed
+     */
     public static function getCodePoint($glyph)
     {
         $glyphsMap = static::getGlyphs();

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -428,7 +428,7 @@ class Font extends PDFObject
                 foreach ($chars as $char) {
                     $dec_av = hexdec(bin2hex($char));
                     $dec_ap = $encoding->translateChar($dec_av);
-                    $result .= self::uchr($dec_ap);
+                    $result .= self::uchr($dec_ap ?? $dec_av);
                 }
             } else {
                 $length = \strlen($text);
@@ -436,7 +436,7 @@ class Font extends PDFObject
                 for ($i = 0; $i < $length; ++$i) {
                     $dec_av = hexdec(bin2hex($text[$i]));
                     $dec_ap = $encoding->translateChar($dec_av);
-                    $result .= self::uchr($dec_ap);
+                    $result .= self::uchr($dec_ap ?? $dec_av);
                 }
             }
             $text = $result;

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -8,14 +8,8 @@ use Smalot\PdfParser\Document;
 use Smalot\PdfParser\Encoding;
 use Tests\Smalot\PdfParser\TestCase;
 
-/**
- * @coversDefaultClass \Smalot\PdfParser\Encoding
- */
 class EncodingTest extends TestCase
 {
-    /**
-     * @covers ::translateChar
-     */
     public function testTranslateCharOnUnknownGlyph(): void
     {
         $encoding = new Encoding(new Document());

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Smalot\PdfParser\Unit;

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -20,6 +20,6 @@ class EncodingTest extends TestCase
     {
         $encoding = new Encoding(new Document());
 
-        static::assertNull($encoding->translateChar('foo'));
+        $this->assertNull($encoding->translateChar('foo'));
     }
 }

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -19,6 +19,6 @@ class EncodingTest extends TestCase
     {
         $encoding = new Encoding(new Document());
 
-        static::assertSame('foo', $encoding->translateChar('foo'));
+        static::assertNull($encoding->translateChar('foo'));
     }
 }

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Smalot\PdfParser\Unit;
+
+use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Encoding;
+use Tests\Smalot\PdfParser\TestCase;
+
+/**
+ * @coversDefaultClass \Smalot\PdfParser\Encoding
+ */
+class EncodingTest extends TestCase
+{
+    /**
+     * @covers ::translateChar
+     */
+    public function testTranslateCharOnUnknownGlyph(): void
+    {
+        $encoding = new Encoding(new Document());
+
+        static::assertSame('foo', $encoding->translateChar('foo'));
+    }
+}


### PR DESCRIPTION
When an unknown glyph is encountered, the glyph itself is returned, which is a string:
```php
// Encoding/PostScriptGlpyhs.php

/**
 * @return float|int|mixed
 */
public static function getCodePoint($glyph)
{
    $glyphsMap = static::getGlyphs();

    if (isset($glyphsMap[$glyph])) {
        return hexdec($glyphsMap[$glyph]);
    }

    return $glyph; // <======
}
```

The function 'translateChar' in Encoding.php directly returns the result of the above function, but has a return type of 'int'.
```php
// Encoding.php

public function translateChar($dec): int // <=====
{
    if (isset($this->mapping[$dec])) {
        $dec = $this->mapping[$dec];
    }

    return PostScriptGlyphs::getCodePoint($dec);
}
```

This PR returns null on an unknown glyph instead, and passes the $dec_av to the encoding function instead to preserve the glyph representation in the final result as in the test for issue #359 

The Newly added test throws a TypeError about strings when the return type should be an int for unknown glyphs without these changes.