### PR TITLE
Fix TypeError on Document::getFirstFont when no fonts are available

### DIFF
--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -213,7 +213,7 @@ class Document
     public function getFirstFont(): ?Font
     {
         $fonts = $this->getFonts();
-        if ($fonts === []) {
+        if ([] === $fonts) {
             return null;
         }
 

--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -213,6 +213,9 @@ class Document
     public function getFirstFont(): ?Font
     {
         $fonts = $this->getFonts();
+        if ($fonts === []) {
+            return null;
+        }
 
         return reset($fonts);
     }

--- a/tests/Unit/DocumentTest.php
+++ b/tests/Unit/DocumentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Smalot\PdfParser\Unit;

--- a/tests/Unit/DocumentTest.php
+++ b/tests/Unit/DocumentTest.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Smalot\PdfParser\Unit;
+
+use Smalot\PdfParser\Document;
+use Tests\Smalot\PdfParser\TestCase;
+
+class DocumentTest extends TestCase
+{
+    public function testGetFirstFontWhenNoFontAvailable(): void
+    {
+        $document = new Document();
+
+        $this->assertNull($document->getFirstFont());
+    }
+}


### PR DESCRIPTION
When there is no font available in a document, an empty array is passed to the reset function. Reset can return ["false if the array is empty"](https://www.php.net/manual/en/function.reset), causing a TypeError as the return type of the function "getFirstFont" is set to "?Font". This PR fixes this issue.