### PR TITLE
Fix TypeError on default font when no fonts available

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -223,7 +223,7 @@ class PDFObject
         }
 
         $firstFont = $this->document->getFirstFont();
-        if ($firstFont !== null) {
+        if (null !== $firstFont) {
             $fonts[] = $firstFont;
         }
 

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Smalot\PdfParser\Unit;


### PR DESCRIPTION
When there is no font available for a page, 'getFirstFont' returns null. GetDefaultFont then returns that null value, where the returntype is 'Font', causing a TypeError. This PR fixes that issue.