### PR TITLE
Font.php: Optimization of the uchr function

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -114,10 +114,9 @@ class Font extends PDFObject
     
     public static function uchr(int $code): string
     {
-        $code = (int) $code;
-		if (isset(self::$uchrCache[$code])) {
-			return self::$uchrCache[$code];
-		}
+        if (isset(self::$uchrCache[$code])) {
+		    return self::$uchrCache[$code];
+        }
         // html_entity_decode() will not work with UTF-16 or UTF-32 char entities,
         // therefore, we use mb_convert_encoding() instead
         return self::$uchrCache[$code] = mb_convert_encoding("&#{$code};", 'UTF-8', 'HTML-ENTITIES');

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -115,7 +115,7 @@ class Font extends PDFObject
     public static function uchr(int $code): string
     {
         if (isset(self::$uchrCache[$code])) {
-		    return self::$uchrCache[$code];
+            return self::$uchrCache[$code];
         }
         // html_entity_decode() will not work with UTF-16 or UTF-32 char entities,
         // therefore, we use mb_convert_encoding() instead

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -110,11 +110,17 @@ class Font extends PDFObject
         return $use_default ? self::MISSING : $fallbackDecoded;
     }
 
+    private static $uchrCache = [];
+    
     public static function uchr(int $code): string
     {
+        $code = (int) $code;
+		if (isset(self::$uchrCache[$code])) {
+			return self::$uchrCache[$code];
+		}
         // html_entity_decode() will not work with UTF-16 or UTF-32 char entities,
         // therefore, we use mb_convert_encoding() instead
-        return mb_convert_encoding('&#'.((int) $code).';', 'UTF-8', 'HTML-ENTITIES');
+        return self::$uchrCache[$code] = mb_convert_encoding("&#{$code};", 'UTF-8', 'HTML-ENTITIES');
     }
 
     public function loadTranslateTable(): array

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -111,7 +111,7 @@ class Font extends PDFObject
     }
 
     private static $uchrCache = [];
-    
+
     public static function uchr(int $code): string
     {
         if (isset(self::$uchrCache[$code])) {

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -50,6 +50,13 @@ class Font extends PDFObject
      */
     protected $tableSizes = null;
 
+    /**
+     * Caches results from uchr.
+     *
+     * @var array
+     */
+    private static $uchrCache = [];
+
     public function init()
     {
         // Load translate table.
@@ -110,16 +117,15 @@ class Font extends PDFObject
         return $use_default ? self::MISSING : $fallbackDecoded;
     }
 
-    private static $uchrCache = [];
-
     public static function uchr(int $code): string
     {
-        if (isset(self::$uchrCache[$code])) {
-            return self::$uchrCache[$code];
+        if (!isset(self::$uchrCache[$code])) {
+            // html_entity_decode() will not work with UTF-16 or UTF-32 char entities,
+            // therefore, we use mb_convert_encoding() instead
+            self::$uchrCache[$code] = mb_convert_encoding("&#{$code};", 'UTF-8', 'HTML-ENTITIES');
         }
-        // html_entity_decode() will not work with UTF-16 or UTF-32 char entities,
-        // therefore, we use mb_convert_encoding() instead
-        return self::$uchrCache[$code] = mb_convert_encoding("&#{$code};", 'UTF-8', 'HTML-ENTITIES');
+
+        return self::$uchrCache[$code];
     }
 
     public function loadTranslateTable(): array


### PR DESCRIPTION
I noticed that the mb_convert_encoding function is called multiple times for the same value, which is redundant