### PR TITLE
Added decodeMemoryLimit to Config to avoid memory leaks.

### DIFF
--- a/src/Smalot/PdfParser/Config.php
+++ b/src/Smalot/PdfParser/Config.php
@@ -61,6 +61,13 @@ class Config
      */
     private $retainImageContent = true;
 
+    /**
+     * Memory limit to use when de-compressing files, in bytes.
+     *
+     * @var int
+     */
+    private $decodeMemoryLimit = 0;
+
     public function getFontSpaceLimit()
     {
         return $this->fontSpaceLimit;
@@ -99,5 +106,15 @@ class Config
     public function setRetainImageContent(bool $retainImageContent): void
     {
         $this->retainImageContent = $retainImageContent;
+    }
+
+    public function getDecodeMemoryLimit(): int
+    {
+        return $this->decodeMemoryLimit;
+    }
+
+    public function setDecodeMemoryLimit(int $decodeMemoryLimit): void
+    {
+        $this->decodeMemoryLimit = $decodeMemoryLimit;
     }
 }

--- a/src/Smalot/PdfParser/RawData/FilterHelper.php
+++ b/src/Smalot/PdfParser/RawData/FilterHelper.php
@@ -56,7 +56,7 @@ class FilterHelper
      *
      * @throws Exception if a certain decode function is not implemented yet
      */
-    public function decodeFilter(string $filter, string $data, $decodeMemoryLimit): string
+    public function decodeFilter(string $filter, string $data, $decodeMemoryLimit=0): string
     {
         switch ($filter) {
             case 'ASCIIHexDecode':

--- a/src/Smalot/PdfParser/RawData/FilterHelper.php
+++ b/src/Smalot/PdfParser/RawData/FilterHelper.php
@@ -56,7 +56,7 @@ class FilterHelper
      *
      * @throws Exception if a certain decode function is not implemented yet
      */
-    public function decodeFilter(string $filter, string $data): string
+    public function decodeFilter(string $filter, string $data, $decodeMemoryLimit): string
     {
         switch ($filter) {
             case 'ASCIIHexDecode':
@@ -69,7 +69,7 @@ class FilterHelper
                 return $this->decodeFilterLZWDecode($data);
 
             case 'FlateDecode':
-                return $this->decodeFilterFlateDecode($data);
+                return $this->decodeFilterFlateDecode($data, $decodeMemoryLimit);
 
             case 'RunLengthDecode':
                 return $this->decodeFilterRunLengthDecode($data);
@@ -224,13 +224,14 @@ class FilterHelper
      *
      * Decompresses data encoded using the zlib/deflate compression method, reproducing the original text or binary data.
      *
-     * @param string $data Data to decode
+     * @param string $data              Data to decode
+     * @param int    $decodeMemoryLimit Memory limit on deflation
      *
      * @return string data string
      *
      * @throws Exception
      */
-    protected function decodeFilterFlateDecode(string $data): ?string
+    protected function decodeFilterFlateDecode(string $data, int $decodeMemoryLimit): ?string
     {
         /*
          * gzuncompress may throw a not catchable E_WARNING in case of an error (like $data is empty)
@@ -249,7 +250,7 @@ class FilterHelper
 
         // initialize string to return
         try {
-            $decoded = gzuncompress($data);
+            $decoded = gzuncompress($data, $decodeMemoryLimit);
             if (false === $decoded) {
                 throw new Exception('decodeFilterFlateDecode: invalid code');
             }

--- a/src/Smalot/PdfParser/RawData/FilterHelper.php
+++ b/src/Smalot/PdfParser/RawData/FilterHelper.php
@@ -56,7 +56,7 @@ class FilterHelper
      *
      * @throws Exception if a certain decode function is not implemented yet
      */
-    public function decodeFilter(string $filter, string $data, $decodeMemoryLimit=0): string
+    public function decodeFilter(string $filter, string $data, int $decodeMemoryLimit = 0): string
     {
         switch ($filter) {
             case 'ASCIIHexDecode':

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -78,15 +78,16 @@ class RawDataParser
     /**
      * Decode the specified stream.
      *
-     * @param string $pdfData PDF data
-     * @param array  $sdic    Stream's dictionary array
-     * @param string $stream  Stream to decode
+     * @param string $pdfData           PDF data
+     * @param array  $sdic              Stream's dictionary array
+     * @param string $stream            Stream to decode
+     * @param int    $decodeMemoryLimit Optional memory limit to decode
      *
      * @return array containing decoded stream data and remaining filters
      *
      * @throws Exception
      */
-    protected function decodeStream(string $pdfData, array $xref, array $sdic, string $stream): array
+    protected function decodeStream(string $pdfData, array $xref, array $sdic, string $stream, int $decodeMemoryLimit): array
     {
         // get stream length and filters
         $slength = \strlen($stream);
@@ -126,7 +127,7 @@ class RawDataParser
         foreach ($filters as $filter) {
             if (\in_array($filter, $this->filterHelper->getAvailableFilters())) {
                 try {
-                    $stream = $this->filterHelper->decodeFilter($filter, $stream);
+                    $stream = $this->filterHelper->decodeFilter($filter, $stream, $decodeMemoryLimit);
                 } catch (Exception $e) {
                     $emsg = $e->getMessage();
                     if ((('~' == $emsg[0]) && !$this->cfg['ignore_missing_filter_decoders'])
@@ -537,7 +538,7 @@ class RawDataParser
             $offset = $element[2];
             // decode stream using stream's dictionary information
             if ($decoding && ('stream' === $element[0]) && (isset($objContentArr[($i - 1)][0])) && ('<<' === $objContentArr[($i - 1)][0])) {
-                $element[3] = $this->decodeStream($pdfData, $xref, $objContentArr[($i - 1)][1], $element[1]);
+                $element[3] = $this->decodeStream($pdfData, $xref, $objContentArr[($i - 1)][1], $element[1], $this->config->getDecodeMemoryLimit());
             }
             $objContentArr[$i] = $element;
             ++$i;

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -81,13 +81,12 @@ class RawDataParser
      * @param string $pdfData           PDF data
      * @param array  $sdic              Stream's dictionary array
      * @param string $stream            Stream to decode
-     * @param int    $decodeMemoryLimit Optional memory limit to decode
      *
      * @return array containing decoded stream data and remaining filters
      *
      * @throws Exception
      */
-    protected function decodeStream(string $pdfData, array $xref, array $sdic, string $stream, int $decodeMemoryLimit): array
+    protected function decodeStream(string $pdfData, array $xref, array $sdic, string $stream): array
     {
         // get stream length and filters
         $slength = \strlen($stream);
@@ -127,7 +126,7 @@ class RawDataParser
         foreach ($filters as $filter) {
             if (\in_array($filter, $this->filterHelper->getAvailableFilters())) {
                 try {
-                    $stream = $this->filterHelper->decodeFilter($filter, $stream, $decodeMemoryLimit);
+                    $stream = $this->filterHelper->decodeFilter($filter, $stream, $this->config->getDecodeMemoryLimit());
                 } catch (Exception $e) {
                     $emsg = $e->getMessage();
                     if ((('~' == $emsg[0]) && !$this->cfg['ignore_missing_filter_decoders'])
@@ -538,7 +537,7 @@ class RawDataParser
             $offset = $element[2];
             // decode stream using stream's dictionary information
             if ($decoding && ('stream' === $element[0]) && (isset($objContentArr[($i - 1)][0])) && ('<<' === $objContentArr[($i - 1)][0])) {
-                $element[3] = $this->decodeStream($pdfData, $xref, $objContentArr[($i - 1)][1], $element[1], $this->config->getDecodeMemoryLimit());
+                $element[3] = $this->decodeStream($pdfData, $xref, $objContentArr[($i - 1)][1], $element[1]);
             }
             $objContentArr[$i] = $element;
             ++$i;

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -78,9 +78,9 @@ class RawDataParser
     /**
      * Decode the specified stream.
      *
-     * @param string $pdfData           PDF data
-     * @param array  $sdic              Stream's dictionary array
-     * @param string $stream            Stream to decode
+     * @param string $pdfData PDF data
+     * @param array  $sdic    Stream's dictionary array
+     * @param string $stream  Stream to decode
      *
      * @return array containing decoded stream data and remaining filters
      *


### PR DESCRIPTION
Per issue #475, we have potential for a memory leak, especially with Flate compressed data. 

This PR adds an optional memory limit in the config, that can be used by any filter. 

By default, the limit is set to 0 or unlimited. 

This may not be the best way to propagate the setting, but I wanted it to be a configurable option, rather than hard-coded. 