### PR TITLE
Fix Scrutinizer-integration: mark PageTest::testGetTextPullRequest457 as "memory-heavy"

### DIFF
--- a/tests/Integration/PageTest.php
+++ b/tests/Integration/PageTest.php
@@ -142,6 +142,8 @@ class PageTest extends TestCase
     }
 
     /**
+     * @group memory-heavy
+     *
      * @see https://github.com/smalot/pdfparser/pull/457
      */
     public function testGetTextPullRequest457()


### PR DESCRIPTION
## Why this change?

Scrutinizer was failing for a [while](https://scrutinizer-ci.com/g/smalot/pdfparser/inspections), because one test run into a fatal error (out of memory).

## About the fix

I marked the test, which lead to a fatal error, with group `memory-heavy`.

It may dilute/distort the code coverage.

## Background information

Ref: https://scrutinizer-ci.com/g/smalot/pdfparser/inspections/3d55f5db-2e8a-479d-96f9-44f6ee4c3d9b/log

```
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 9059496 bytes) in /home/scrutinizer/build/src/Smalot/PdfParser/RawData/RawDataParser.php on line 742

Call Stack:
    0.0001     408848   1. {main}() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/phpunit:0
    0.0024     925856   2. PHPUnit\TextUI\Command::main() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/phpunit:61
    0.0024     925968   3. PHPUnit\TextUI\Command->run() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/src/TextUI/Command.php:162
    0.1027    6272464   4. PHPUnit\TextUI\TestRunner->doRun() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/src/TextUI/Command.php:206
    0.1121    6683656   5. PHPUnit\Framework\TestSuite->run() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:652
    1.1034   18691584   6. PHPUnit\Framework\TestSuite->run() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/src/Framework/TestSuite.php:746
    1.5203   19472096   7. Tests\Smalot\PdfParser\Integration\PageTest->run() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/src/Framework/TestSuite.php:746
    1.5204   19472096   8. PHPUnit\Framework\TestResult->run() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/src/Framework/TestCase.php:796
    1.5206   19472096   9. Tests\Smalot\PdfParser\Integration\PageTest->runBare() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/src/Framework/TestResult.php:693
    1.5209   19488656  10. Tests\Smalot\PdfParser\Integration\PageTest->runTest() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/src/Framework/TestCase.php:842
    1.5209   19488656  11. Tests\Smalot\PdfParser\Integration\PageTest->testGetTextPullRequest457() /home/scrutinizer/build/dev-tools/vendor/phpunit/phpunit/src/Framework/TestCase.php:1154
    1.5209   19489128  12. Smalot\PdfParser\Parser->parseFile() /home/scrutinizer/build/tests/Integration/PageTest.php:152
    1.5269   36000128  13. Smalot\PdfParser\Parser->parseContent() /home/scrutinizer/build/src/Smalot/PdfParser/Parser.php:88
    1.5269   36000128  14. Smalot\PdfParser\RawData\RawDataParser->parseData() /home/scrutinizer/build/src/Smalot/PdfParser/Parser.php:100
   33.6310  121301048  15. Smalot\PdfParser\RawData\RawDataParser->getIndirectObject() /home/scrutinizer/build/src/Smalot/PdfParser/RawData/RawDataParser.php:878
   33.6313  121304384  16. Smalot\PdfParser\RawData\RawDataParser->getRawObject() /home/scrutinizer/build/src/Smalot/PdfParser/RawData/RawDataParser.php:536
   33.6313  121304384  17. substr() /home/scrutinizer/build/src/Smalot/PdfParser/RawData/RawDataParser.php:742
```