### PR TITLE
Replace usage of str_starts_with in Page.php::isFpdf

### DIFF
--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -236,7 +236,7 @@ class Page extends PDFObject
     {
         if (\array_key_exists('Producer', $this->document->getDetails()) &&
             \is_string($this->document->getDetails()['Producer']) &&
-            0 === strncmp($this->document->getDetails()['Producer'], 'FPDF', \strlen('FPDF'))) {
+            0 === strncmp($this->document->getDetails()['Producer'], 'FPDF', 4)) {
             return true;
         }
 

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -236,7 +236,7 @@ class Page extends PDFObject
     {
         if (\array_key_exists('Producer', $this->document->getDetails()) &&
             \is_string($this->document->getDetails()['Producer']) &&
-            0 === strncmp($this->document->getDetails()['Producer'], 'FPDF', \strlen('FPDF')) {
+            0 === strncmp($this->document->getDetails()['Producer'], 'FPDF', \strlen('FPDF'))) {
             return true;
         }
 

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -236,7 +236,7 @@ class Page extends PDFObject
     {
         if (\array_key_exists('Producer', $this->document->getDetails()) &&
             \is_string($this->document->getDetails()['Producer']) &&
-            str_starts_with($this->document->getDetails()['Producer'], 'FPDF')) {
+            0 === strncmp($this->document->getDetails()['Producer'], 'FPDF', \strlen('FPDF')) {
             return true;
         }
 


### PR DESCRIPTION
Fixes #483 reported by @dpanzer.

Problem was usage of `str_starts_with` which is only available in PHP 8.