### PR TITLE
Add return types to tests methods. Fix todos in phpDocs. Add method's descriptions for Font class.

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -117,6 +117,9 @@ class Font extends PDFObject
         return $use_default ? self::MISSING : $fallbackDecoded;
     }
 
+    /**
+     * Convert unicode character code to "utf-8" encoded string.
+     */
     public static function uchr(int $code): string
     {
         if (!isset(self::$uchrCache[$code])) {
@@ -128,6 +131,9 @@ class Font extends PDFObject
         return self::$uchrCache[$code];
     }
 
+    /**
+     * Init internal chars translation table by ToUnicode CMap.
+     */
     public function loadTranslateTable(): array
     {
         if (null !== $this->table) {
@@ -236,11 +242,21 @@ class Font extends PDFObject
         return $this->table;
     }
 
+    /**
+     * Set custom char translation table where:
+     * - key - integer character code;
+     * - value - "utf-8" encoded value;
+     *
+     * @return void
+     */
     public function setTable(array $table)
     {
         $this->table = $table;
     }
 
+    /**
+     * Decode hexadecimal encoded string. If $add_braces is true result value would be wrapped by parentheses.
+     */
     public static function decodeHexadecimal(string $hexa, bool $add_braces = false): string
     {
         // Special shortcut for XML content.
@@ -274,6 +290,9 @@ class Font extends PDFObject
         return $text;
     }
 
+    /**
+     * Decode string with octal-decoded chunks.
+     */
     public static function decodeOctal(string $text): string
     {
         $parts = preg_split('/(\\\\[0-7]{3})/s', $text, -1, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE);
@@ -290,6 +309,9 @@ class Font extends PDFObject
         return $text;
     }
 
+    /**
+     * Decode string with html entity encoded chars.
+     */
     public static function decodeEntities(string $text): string
     {
         $parts = preg_split('/(#\d{2})/s', $text, -1, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE);
@@ -306,6 +328,13 @@ class Font extends PDFObject
         return $text;
     }
 
+    /**
+     * Check if given string is Unicode text (by BOM);
+     * If true - decode to "utf-8" encoded string.
+     * Otherwise - return text as is.
+     *
+     * @todo Rename in next major release to make the name correspond to reality (for ex. decodeIfUnicode())
+     */
     public static function decodeUnicode(string $text): string
     {
         if (preg_match('/^\xFE\xFF/i', $text)) {
@@ -330,6 +359,9 @@ class Font extends PDFObject
         return $this->config->getFontSpaceLimit();
     }
 
+    /**
+     * Decode text by commands array.
+     */
     public function decodeText(array $commands): string
     {
         $word_position = 0;

--- a/tests/Integration/DocumentTest.php
+++ b/tests/Integration/DocumentTest.php
@@ -42,27 +42,27 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class DocumentTest extends TestCase
 {
-    protected function getDocumentInstance()
+    protected function getDocumentInstance(): Document
     {
         return new Document();
     }
 
-    protected function getPDFObjectInstance(Document $document, ?Header $header = null)
+    protected function getPDFObjectInstance(Document $document, ?Header $header = null): PDFObject
     {
         return new PDFObject($document, $header);
     }
 
-    protected function getPageInstance(Document $document, Header $header)
+    protected function getPageInstance(Document $document, Header $header): PDFObject
     {
         return new Page($document, $header);
     }
 
-    protected function getPagesInstance(Document $document, Header $header)
+    protected function getPagesInstance(Document $document, Header $header): PDFObject
     {
         return new Pages($document, $header);
     }
 
-    public function testSetObjects()
+    public function testSetObjects(): void
     {
         $document = $this->getDocumentInstance();
         $object = $this->getPDFObjectInstance($document);
@@ -86,7 +86,7 @@ class DocumentTest extends TestCase
         $this->assertTrue($document->getObjectById(2) instanceof PDFObject);
     }
 
-    public function testGetObjects()
+    public function testGetObjects(): void
     {
         $document = $this->getDocumentInstance();
         $object1 = $this->getPDFObjectInstance($document);
@@ -103,7 +103,7 @@ class DocumentTest extends TestCase
         $this->assertTrue($objects[2] instanceof Page);
     }
 
-    public function testDictionary()
+    public function testDictionary(): void
     {
         $document = $this->getDocumentInstance();
         $objects = $document->getDictionary();
@@ -121,7 +121,7 @@ class DocumentTest extends TestCase
         $this->assertEquals($object2, $objects['Page']['all'][2]);
     }
 
-    public function testGetObjectsByType()
+    public function testGetObjectsByType(): void
     {
         $document = $this->getDocumentInstance();
         $object1 = $this->getPDFObjectInstance($document);
@@ -136,7 +136,7 @@ class DocumentTest extends TestCase
         $this->assertTrue($objects[2] instanceof Page);
     }
 
-    public function testGetPages()
+    public function testGetPages(): void
     {
         $document = $this->getDocumentInstance();
 
@@ -218,7 +218,7 @@ class DocumentTest extends TestCase
         $this->assertTrue($pages[2] instanceof Page);
     }
 
-    public function testGetPagesMissingCatalog()
+    public function testGetPagesMissingCatalog(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Missing catalog.');

--- a/tests/Integration/Element/ElementArrayTest.php
+++ b/tests/Integration/Element/ElementArrayTest.php
@@ -41,7 +41,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementArrayTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         $document = $this->getDocumentInstance();
 
@@ -96,7 +96,7 @@ class ElementArrayTest extends TestCase
         $this->assertEquals(10, $offset);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $val_4 = new ElementNumeric('4');
         $val_2 = new ElementNumeric('2');
@@ -106,7 +106,7 @@ class ElementArrayTest extends TestCase
         $this->assertCount(2, $content);
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $val_4 = new ElementNumeric('4');
         $val_2 = new ElementNumeric('2');
@@ -118,7 +118,7 @@ class ElementArrayTest extends TestCase
         $this->assertFalse($element->contains(8));
     }
 
-    public function testResolveXRef()
+    public function testResolveXRef(): void
     {
         // Document with text.
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
@@ -134,7 +134,7 @@ class ElementArrayTest extends TestCase
         $this->assertTrue(reset($pages) instanceof Page);
     }
 
-    public function testGetDetails()
+    public function testGetDetails(): void
     {
         $document = $this->getDocumentInstance();
         $content = '<</Type/Page/Types[8]/Sizes[1 2 3 4 5 <</Subtype/XObject>> [8 [9 <</FontSize 10>>]]]>>';
@@ -170,7 +170,7 @@ class ElementArrayTest extends TestCase
         $this->assertEquals($details_reference, $details);
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $val_4 = new ElementNumeric('4');
         $val_2 = new ElementNumeric('2');

--- a/tests/Integration/Element/ElementBooleanTest.php
+++ b/tests/Integration/Element/ElementBooleanTest.php
@@ -37,7 +37,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementBooleanTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
         $offset = 0;
@@ -102,7 +102,7 @@ class ElementBooleanTest extends TestCase
         $this->assertEquals(7, $offset);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new ElementBoolean('true');
         $this->assertTrue($element->getContent());
@@ -111,7 +111,7 @@ class ElementBooleanTest extends TestCase
         $this->assertFalse($element->getContent());
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new ElementBoolean('true');
         $this->assertTrue($element->equals(true));
@@ -126,7 +126,7 @@ class ElementBooleanTest extends TestCase
         $this->assertFalse($element->equals(null));
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new ElementBoolean('true');
         $this->assertTrue($element->contains(true));
@@ -134,7 +134,7 @@ class ElementBooleanTest extends TestCase
         $this->assertFalse($element->contains(1));
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $element = new ElementBoolean('true');
         $this->assertEquals('true', (string) $element);

--- a/tests/Integration/Element/ElementDateTest.php
+++ b/tests/Integration/Element/ElementDateTest.php
@@ -39,7 +39,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementDateTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
         $offset = 0;
@@ -136,13 +136,13 @@ class ElementDateTest extends TestCase
         $this->assertEquals(0, $offset);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new ElementDate(new DateTime('2013-09-01 23:55:55+02:00'));
         $this->assertEquals(new DateTime('2013-09-01 21:55:55+00:00'), $element->getContent());
     }
 
-    public function testGetContentInvalidParameter()
+    public function testGetContentInvalidParameter(): void
     {
         $this->expectException(Exception::class);
 
@@ -150,7 +150,7 @@ class ElementDateTest extends TestCase
         $this->assertEquals(new DateTime('2013-09-01 21:55:55+02:00'), $element->getContent());
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new ElementDate(new DateTime('2013-09-01 23:55:55+02:00'));
         $element->setFormat('c');
@@ -164,7 +164,7 @@ class ElementDateTest extends TestCase
         $this->assertFalse($element->equals('ABC'));
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new ElementDate(new DateTime('2013-09-01 23:55:55+02:00'));
 
@@ -172,7 +172,7 @@ class ElementDateTest extends TestCase
         $this->assertFalse($element->contains('2013-06-15'));
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $element = new ElementDate(new DateTime('2013-09-01 23:55:55+02:00'));
 

--- a/tests/Integration/Element/ElementHexaTest.php
+++ b/tests/Integration/Element/ElementHexaTest.php
@@ -39,7 +39,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementHexaTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
         $offset = 0;

--- a/tests/Integration/Element/ElementMissingTest.php
+++ b/tests/Integration/Element/ElementMissingTest.php
@@ -37,7 +37,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementMissingTest extends TestCase
 {
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new ElementMissing();
         $this->assertFalse($element->equals(null));
@@ -46,13 +46,13 @@ class ElementMissingTest extends TestCase
         $this->assertFalse($element->equals(false));
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new ElementMissing();
         $this->assertFalse($element->getContent());
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new ElementMissing();
         $this->assertFalse($element->contains(null));
@@ -61,7 +61,7 @@ class ElementMissingTest extends TestCase
         $this->assertFalse($element->contains(false));
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $element = new ElementMissing();
         $this->assertEquals('', (string) $element);

--- a/tests/Integration/Element/ElementNameTest.php
+++ b/tests/Integration/Element/ElementNameTest.php
@@ -37,7 +37,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementNameTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
         $offset = 0;
@@ -117,13 +117,13 @@ class ElementNameTest extends TestCase
         $this->assertEquals(14, $offset);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new ElementName('FlateDecode');
         $this->assertEquals('FlateDecode', $element->getContent());
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new ElementName('FlateDecode');
         $this->assertTrue($element->equals('FlateDecode'));
@@ -138,7 +138,7 @@ class ElementNameTest extends TestCase
         $this->assertFalse($element->equals('Flate-Decode3'));
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new ElementName('FlateDecode');
         $this->assertTrue($element->contains('FlateDecode'));
@@ -153,7 +153,7 @@ class ElementNameTest extends TestCase
         $this->assertFalse($element->contains('Flate-Decode3'));
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $element = new ElementName('FlateDecode');
         $this->assertEquals('FlateDecode', (string) $element);

--- a/tests/Integration/Element/ElementNullTest.php
+++ b/tests/Integration/Element/ElementNullTest.php
@@ -37,7 +37,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementNullTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
         $offset = 0;
@@ -97,13 +97,13 @@ class ElementNullTest extends TestCase
         $this->assertEquals(7, $offset);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new ElementNull();
         $this->assertTrue(null === $element->getContent());
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new ElementNull();
         $this->assertTrue($element->equals(null));
@@ -112,7 +112,7 @@ class ElementNullTest extends TestCase
         $this->assertFalse($element->equals(1));
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new ElementNull();
         $this->assertTrue($element->contains(null));
@@ -120,7 +120,7 @@ class ElementNullTest extends TestCase
         $this->assertFalse($element->contains(0));
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $element = new ElementNull();
         $this->assertEquals('null', (string) $element);

--- a/tests/Integration/Element/ElementNumericTest.php
+++ b/tests/Integration/Element/ElementNumericTest.php
@@ -37,7 +37,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementNumericTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
         $offset = 0;
@@ -97,7 +97,7 @@ class ElementNumericTest extends TestCase
         $this->assertEquals(5, $offset);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new ElementNumeric('B');
         $this->assertEquals(0.0, $element->getContent());
@@ -118,7 +118,7 @@ class ElementNumericTest extends TestCase
         $this->assertEquals(2.0, $element->getContent());
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new ElementNumeric('1');
         $this->assertFalse($element->equals('B'));
@@ -146,7 +146,7 @@ class ElementNumericTest extends TestCase
         $this->assertFalse($element->equals('-3.5'));
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new ElementNumeric('1');
         $this->assertFalse($element->contains('B'));
@@ -174,7 +174,7 @@ class ElementNumericTest extends TestCase
         $this->assertFalse($element->contains('-3.5'));
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $element = new ElementNumeric('B');
         $this->assertEquals('0', (string) $element);

--- a/tests/Integration/Element/ElementStringTest.php
+++ b/tests/Integration/Element/ElementStringTest.php
@@ -37,7 +37,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementStringTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
         $offset = 0;
@@ -130,13 +130,13 @@ class ElementStringTest extends TestCase
         $this->assertEquals(27, $offset);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new ElementString('Copyright');
         $this->assertEquals('Copyright', $element->getContent());
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new ElementString('CopyRight');
         $this->assertTrue($element->equals('CopyRight'));
@@ -151,7 +151,7 @@ class ElementStringTest extends TestCase
         $this->assertFalse($element->equals('Flate-Decode3'));
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new ElementString('CopyRight');
         $this->assertTrue($element->contains('CopyRight'));
@@ -162,7 +162,7 @@ class ElementStringTest extends TestCase
         $this->assertFalse($element->contains('CopyRight3'));
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $element = new ElementString('CopyRight');
         $this->assertEquals('CopyRight', (string) $element);

--- a/tests/Integration/Element/ElementStructTest.php
+++ b/tests/Integration/Element/ElementStructTest.php
@@ -38,7 +38,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementStructTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         $document = $this->getDocumentInstance();
 

--- a/tests/Integration/Element/ElementXRefTest.php
+++ b/tests/Integration/Element/ElementXRefTest.php
@@ -37,7 +37,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementXRefTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         // Skipped.
         $offset = 0;
@@ -97,19 +97,19 @@ class ElementXRefTest extends TestCase
         $this->assertEquals(8, $offset);
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = new ElementXRef('5_0');
         $this->assertEquals('5_0', $element->getContent());
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         $element = new ElementXRef('5_0');
         $this->assertEquals('5_0', $element->getId());
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = new ElementXRef('5_0');
         $this->assertTrue($element->equals(5));
@@ -117,7 +117,7 @@ class ElementXRefTest extends TestCase
         $this->assertTrue($element->equals($element));
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = new ElementXRef('5_0');
         $this->assertTrue($element->contains(5));
@@ -125,7 +125,7 @@ class ElementXRefTest extends TestCase
         $this->assertTrue($element->contains($element));
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $element = new ElementXRef('5_0');
         $this->assertEquals('#Obj#5_0', (string) $element);

--- a/tests/Integration/ElementTest.php
+++ b/tests/Integration/ElementTest.php
@@ -46,7 +46,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class ElementTest extends TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         $document = $this->getDocumentInstance();
 
@@ -120,7 +120,7 @@ class ElementTest extends TestCase
         $this->assertEquals(0, \count($elements));
     }
 
-    public function testGetContent()
+    public function testGetContent(): void
     {
         $element = $this->getElementInstance(42);
         $content = $element->getContent();
@@ -130,14 +130,14 @@ class ElementTest extends TestCase
         $this->assertEquals(2, \count($element->getContent()));
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $element = $this->getElementInstance(2);
 
         $this->assertTrue($element->equals(2));
     }
 
-    public function testContains()
+    public function testContains(): void
     {
         $element = $this->getElementInstance([$this->getElementInstance(4), $this->getElementInstance(2)]);
 
@@ -145,7 +145,7 @@ class ElementTest extends TestCase
         $this->assertFalse($element->contains(8));
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $this->assertEquals((string) $this->getElementInstance('2'), '2');
     }

--- a/tests/Integration/EncodingTest.php
+++ b/tests/Integration/EncodingTest.php
@@ -43,7 +43,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class EncodingTest extends TestCase
 {
-    public function testGetEncodingClass()
+    public function testGetEncodingClass(): void
     {
         $header = new Header(['BaseEncoding' => new Element('StandardEncoding')]);
 
@@ -61,7 +61,7 @@ class EncodingTest extends TestCase
      * Calling init is enough to trigger the exception, but __toString call afterwards
      * makes sure that we don't missing it.
      */
-    public function testInitGetEncodingClassMissingClassException()
+    public function testInitGetEncodingClassMissingClassException(): void
     {
         $this->expectException(EncodingNotFoundException::class);
         $this->expectExceptionMessage('Missing encoding data for: "invalid"');
@@ -80,7 +80,7 @@ class EncodingTest extends TestCase
      * Prior PHP 7.4 we expect an empty string to be returned (based on PHP specification).
      * PHP 7.4+ we expect an exception to be thrown when class is invalid.
      */
-    public function testToStringGetEncodingClassMissingClassException()
+    public function testToStringGetEncodingClassMissingClassException(): void
     {
         // prior to PHP 7.4 toString has to return an empty string.
         if (version_compare(\PHP_VERSION, '7.4.0', '<')) {

--- a/tests/Integration/FontTest.php
+++ b/tests/Integration/FontTest.php
@@ -43,7 +43,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class FontTest extends TestCase
 {
-    public function testGetName()
+    public function testGetName(): void
     {
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
         $parser = $this->getParserInstance();
@@ -54,7 +54,7 @@ class FontTest extends TestCase
         $this->assertEquals('OJHCYD+Cambria,Bold', $font->getName());
     }
 
-    public function testGetType()
+    public function testGetType(): void
     {
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
         $parser = $this->getParserInstance();
@@ -65,7 +65,7 @@ class FontTest extends TestCase
         $this->assertEquals('TrueType', $font->getType());
     }
 
-    public function testGetDetails()
+    public function testGetDetails(): void
     {
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
         $parser = $this->getParserInstance();
@@ -112,7 +112,7 @@ class FontTest extends TestCase
         $this->assertEquals($reference, $font->getDetails());
     }
 
-    public function testTranslateChar()
+    public function testTranslateChar(): void
     {
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
         $parser = $this->getParserInstance();
@@ -136,7 +136,7 @@ class FontTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/issues/364
      */
-    public function testTranslateCharIssue364()
+    public function testTranslateCharIssue364(): void
     {
         /*
          * Approach: we provoke the __toString call with a minimal set of input data.
@@ -155,7 +155,7 @@ class FontTest extends TestCase
         $this->assertEquals('?', $font->translateChar('t'));
     }
 
-    public function testLoadTranslateTable()
+    public function testLoadTranslateTable(): void
     {
         $document = new Document();
 
@@ -235,7 +235,7 @@ end';
         $this->assertEquals('y', $table[92]);
     }
 
-    public function testDecodeHexadecimal()
+    public function testDecodeHexadecimal(): void
     {
         $hexa = '<322041>';
         $this->assertEquals('2 A', Font::decodeHexadecimal($hexa));
@@ -273,25 +273,25 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
         $this->assertEquals("\x0\x27\x0\x4c\x0\x56\x0\x53\x0\x52\x0\x51\x0\x4c\x0\x45\x0\x4c\x0\x4f\x0\x4c\x0\x5d\x0\x44\x0\x6f\x0\x6d\x0\x52\x0\x1d\x0\x3\x0\x56\x0\x48\x0\x5b\x0\x57\x0\x44\x0\x10\x0\x49\x0\x48\x0\x4c\x0\x55\x0\x44\x0\xf\x0\x3\x0\x14\x0\x17\x0\x3\x0\x47\x0\x48\x0\x3\x0\x49\x0\x48\x0\x59\x0\x48\x0\x55\x0\x48\x0\x4c\x0\x55\x0\x52\x0\x3\x0\x47\x0\x48\x0\x3\x0\x15\x0\x13\x0\x15\x0\x13", Font::decodeHexadecimal($hexa));
     }
 
-    public function testDecodeOctal()
+    public function testDecodeOctal(): void
     {
         $this->assertEquals('AB C', Font::decodeOctal('\\101\\102\\040\\103'));
         $this->assertEquals('AB CD', Font::decodeOctal('\\101\\102\\040\\103D'));
         $this->assertEquals('AB \199', Font::decodeOctal('\\101\\102\\040\\199'));
     }
 
-    public function testDecodeEntities()
+    public function testDecodeEntities(): void
     {
         $this->assertEquals('File Type', Font::decodeEntities('File#20Type'));
         $this->assertEquals('File# Ty#pe', Font::decodeEntities('File##20Ty#pe'));
     }
 
-    public function testDecodeUnicode()
+    public function testDecodeUnicode(): void
     {
         $this->assertEquals('AB', Font::decodeUnicode("\xFE\xFF\x00A\x00B"));
     }
 
-    public function testDecodeText()
+    public function testDecodeText(): void
     {
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
         $parser = $this->getParserInstance();
@@ -359,7 +359,7 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
      *
      * @doesNotPerformAssertions
      */
-    public function testTriggerGetFontSpaceLimitOnNull()
+    public function testTriggerGetFontSpaceLimitOnNull(): void
     {
         // error is triggered, if we set the fourth parameter to null
         $font = new Font(new Document(), null, null, new Config());
@@ -369,7 +369,7 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
         $font->getTextArray();
     }
 
-    public function testXmlContent()
+    public function testXmlContent(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue18.pdf';
         $parser = $this->getParserInstance();
@@ -384,7 +384,7 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
      * Create an instance of Header containing an instance of Encoding that doesn't have a BaseEncoding.
      * Test if the Font won't raise a exception because Encoding don't have BaseEncoding.
      */
-    public function testEncodingWithoutBaseEncoding()
+    public function testEncodingWithoutBaseEncoding(): void
     {
         $document = new Document();
         $header = new Header(['Encoding' => new Encoding($document)]);

--- a/tests/Integration/HeaderTest.php
+++ b/tests/Integration/HeaderTest.php
@@ -48,7 +48,7 @@ class HeaderTest extends TestCase
     /**
      * Checks that init function is called for each element.
      */
-    public function testInitHappyPath()
+    public function testInitHappyPath(): void
     {
         $element = $this->createMock(Element::class);
         $element->expects($this->exactly(1))->method('init');
@@ -66,7 +66,7 @@ class HeaderTest extends TestCase
      *
      * @doesNotPerformAssertions
      */
-    public function testInitInvalidElement()
+    public function testInitInvalidElement(): void
     {
         $element = false;
 
@@ -74,7 +74,7 @@ class HeaderTest extends TestCase
         $fixture->init();
     }
 
-    public function testParse()
+    public function testParse(): void
     {
         $document = $this->getDocumentInstance();
 
@@ -108,7 +108,7 @@ class HeaderTest extends TestCase
         $this->assertEquals(1, \count($header->getElements()));
     }
 
-    public function testGetElements()
+    public function testGetElements(): void
     {
         $document = $this->getDocumentInstance();
 
@@ -126,7 +126,7 @@ class HeaderTest extends TestCase
         $this->assertEquals(ElementName::class, $types['Subtype']);
     }
 
-    public function testHas()
+    public function testHas(): void
     {
         $document = $this->getDocumentInstance();
 
@@ -140,7 +140,7 @@ class HeaderTest extends TestCase
         $this->assertFalse($header->has('Text'));
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $document = $this->getDocumentInstance();
 
@@ -157,7 +157,7 @@ class HeaderTest extends TestCase
         $this->assertTrue($header->get('Resources') instanceof ElementMissing);
     }
 
-    public function testResolveXRef()
+    public function testResolveXRef(): void
     {
         $document = $this->getDocumentInstance();
         $content = '<</Type/Page/SubType/Text/Font 5 0 R/Resources 8 0 R>>foo';

--- a/tests/Integration/PDFObjectTest.php
+++ b/tests/Integration/PDFObjectTest.php
@@ -44,12 +44,12 @@ class PDFObjectTest extends TestCase
 
     const COMMAND = 'c';
 
-    protected function getPdfObjectInstance($document)
+    protected function getPdfObjectInstance($document): PDFObject
     {
         return new PDFObject($document);
     }
 
-    public function testGetCommandsText()
+    public function testGetCommandsText(): void
     {
         $content = "/R14 30 Tf 0.999016 0 0 1 137.4
 342.561 Tm
@@ -151,7 +151,7 @@ BI";
         $this->assertEquals(172, $offset);
     }
 
-    public function testCleanContent()
+    public function testCleanContent(): void
     {
         $content = '/Shape <</MCID << /Font<8>>> BT >>BDC
 Q
@@ -196,7 +196,7 @@ q
         $this->assertEquals($cleaned, $expected);
     }
 
-    public function testGetSectionText()
+    public function testGetSectionText(): void
     {
         $content = '/Shape <</MCID 1 >>BDC
 Q
@@ -237,7 +237,7 @@ q'],
      *
      * @see: https://github.com/smalot/pdfparser/issues/398
      */
-    public function testReversedChars()
+    public function testReversedChars(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue398.pdf';
 

--- a/tests/Integration/PageTest.php
+++ b/tests/Integration/PageTest.php
@@ -40,7 +40,7 @@ use Tests\Smalot\PdfParser\TestCase;
 
 class PageTest extends TestCase
 {
-    public function testGetFonts()
+    public function testGetFonts(): void
     {
         // Document with text.
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
@@ -74,7 +74,7 @@ class PageTest extends TestCase
         $this->assertEquals(0, \count($fonts));
     }
 
-    public function testGetFontsElementMissing()
+    public function testGetFontsElementMissing(): void
     {
         $headerResources = $this->getMockBuilder('Smalot\PdfParser\Header')
             ->disableOriginalConstructor()
@@ -103,7 +103,7 @@ class PageTest extends TestCase
         $this->assertEquals([], $fonts);
     }
 
-    public function testGetFont()
+    public function testGetFont(): void
     {
         // Document with text.
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
@@ -120,7 +120,7 @@ class PageTest extends TestCase
         $this->assertTrue($font instanceof Font);
     }
 
-    public function testGetText()
+    public function testGetText(): void
     {
         // Document with text.
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
@@ -146,7 +146,7 @@ class PageTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/pull/457
      */
-    public function testGetTextPullRequest457()
+    public function testGetTextPullRequest457(): void
     {
         // Document with text.
         $filename = $this->rootDir.'/samples/bugs/PullRequest457.pdf';
@@ -166,7 +166,7 @@ class PageTest extends TestCase
         $this->assertStringContainsString('ALL', $text);
     }
 
-    public function testExtractRawData()
+    public function testExtractRawData(): void
     {
         // Document with text.
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
@@ -197,7 +197,7 @@ class PageTest extends TestCase
         $this->assertStringContainsString('0.999429 0 0 1 201.96 720.68', $tmItem['c']);
     }
 
-    public function testExtractDecodedRawData()
+    public function testExtractDecodedRawData(): void
     {
         // Document with text.
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
@@ -232,7 +232,7 @@ class PageTest extends TestCase
         $this->assertStringContainsString('o', $tjItem['c'][2]['c']);
     }
 
-    public function testExtractRawDataWithCorruptedPdf()
+    public function testExtractRawDataWithCorruptedPdf(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Unable to find xref (PDF corrupted?)');
@@ -243,7 +243,7 @@ class PageTest extends TestCase
             ->getPages();
     }
 
-    public function testGetDataCommands()
+    public function testGetDataCommands(): void
     {
         // Document with text.
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
@@ -278,7 +278,7 @@ class PageTest extends TestCase
         $this->assertStringContainsString('o', $tjItem['c'][2]['c']);
     }
 
-    public function testGetDataTm()
+    public function testGetDataTm(): void
     {
         // Document with text.
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
@@ -446,7 +446,7 @@ class PageTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/issues/336
      */
-    public function testGetDataTmIssue336()
+    public function testGetDataTmIssue336(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue336_decode_hexadecimal.pdf';
         $document = $this->getParserInstance()->parseFile($filename);
@@ -480,7 +480,7 @@ class PageTest extends TestCase
      * Sample pdf file provided by @Reqrefusion, see
      * https://github.com/smalot/pdfparser/pull/350#issuecomment-703195220
      */
-    public function testGetPages()
+    public function testGetPages(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue331.pdf';
         $document = $this->getParserInstance()->parseFile($filename);
@@ -503,7 +503,7 @@ class PageTest extends TestCase
         }
     }
 
-    public function testGetTextXY()
+    public function testGetTextXY(): void
     {
         // Document with text.
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
@@ -601,7 +601,7 @@ class PageTest extends TestCase
         $this->assertStringContainsString('Purchase 2', $result[0][1]);
     }
 
-    public function testExtractDecodedRawDataIssue450()
+    public function testExtractDecodedRawDataIssue450(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue450.pdf';
         $parser = $this->getParserInstance();
@@ -619,7 +619,7 @@ class PageTest extends TestCase
         $this->assertEquals('{signature:signer505906:Please+Sign+Here}', $extractedDecodedRawData[3]['c'][0]['c']);
     }
 
-    public function testGetDataTmIssue450()
+    public function testGetDataTmIssue450(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue450.pdf';
         $parser = $this->getParserInstance();

--- a/tests/Integration/ParserTest.php
+++ b/tests/Integration/ParserTest.php
@@ -53,7 +53,7 @@ class ParserTest extends TestCase
      *
      * @group memory-heavy
      */
-    public function testParseFile()
+    public function testParseFile(): void
     {
         $directory = $this->rootDir.'/samples/bugs';
 
@@ -89,7 +89,7 @@ class ParserTest extends TestCase
      *
      * @todo the other languages in the test document need work because of issues with UTF-16 decoding (Chinese, Japanese) and missing right-to-left language support
      */
-    public function testUnicodeDecoding()
+    public function testUnicodeDecoding(): void
     {
         $filename = $this->rootDir.'/samples/InternationalChars.pdf';
 
@@ -115,7 +115,7 @@ class ParserTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/issues/336
      */
-    public function testIssue19()
+    public function testIssue19(): void
     {
         $fixture = new ParserSub();
         $structure = [
@@ -158,7 +158,7 @@ class ParserTest extends TestCase
      * @see https://github.com/smalot/pdfparser/issues/202
      * @see https://github.com/smalot/pdfparser/pull/257
      */
-    public function testIssue202()
+    public function testIssue202(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue202.pdf';
 
@@ -172,7 +172,7 @@ class ParserTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/issues/267
      */
-    public function testIssue267()
+    public function testIssue267(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue267_array_access_on_int.pdf';
 
@@ -189,7 +189,7 @@ class ParserTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/issues/322
      */
-    public function testIssue322()
+    public function testIssue322(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue322.pdf';
 
@@ -208,7 +208,7 @@ class ParserTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/issues/334
      */
-    public function testIssue334()
+    public function testIssue334(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue334.pdf';
 
@@ -223,7 +223,7 @@ class ParserTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/issues/359
      */
-    public function testIssue359()
+    public function testIssue359(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue359.pdf';
 
@@ -250,7 +250,7 @@ class ParserTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/issues/391
      */
-    public function testIssue391()
+    public function testIssue391(): void
     {
         /**
          * PDF provided by @dhildreth for usage in our test environment.
@@ -273,7 +273,7 @@ class ParserTest extends TestCase
      *
      * Test is based on testIssue359 (above).
      */
-    public function testChangedFontSpaceLimit()
+    public function testChangedFontSpaceLimit(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue359.pdf';
 
@@ -290,7 +290,7 @@ class ParserTest extends TestCase
      * Tests if a given Config object is really used.
      * Or if a default one is generated, if null was given.
      */
-    public function testUsageOfConfigObject()
+    public function testUsageOfConfigObject(): void
     {
         // check default
         $this->fixture = new Parser([]);
@@ -314,7 +314,7 @@ class ParserTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/issues/104#issuecomment-883422508
      */
-    public function testRetainImageContentImpact()
+    public function testRetainImageContentImpact(): void
     {
         if (version_compare(\PHP_VERSION, '7.3.0', '<')) {
             $this->markTestSkipped('Garbage collection doesn\'t work reliably enough for this test in PHP < 7.3');
@@ -374,7 +374,7 @@ class ParserSub extends Parser
         return $this->parseObject($id, $structure, $document);
     }
 
-    public function getObjects()
+    public function getObjects(): array
     {
         return $this->objects;
     }

--- a/tests/Integration/RawData/FilterHelperTest.php
+++ b/tests/Integration/RawData/FilterHelperTest.php
@@ -49,7 +49,7 @@ class FilterHelperTest extends TestCase
      * Tests for filter ASCII85Decode
      */
 
-    public function testDecodeFilterASCII85Decode()
+    public function testDecodeFilterASCII85Decode(): void
     {
         $compressed = '6Z6g\Eb0<5ARlp)FE2)5B)'; // = Compressed string
         $result = $this->fixture->decodeFilter('ASCII85Decode', $compressed);
@@ -61,7 +61,7 @@ class FilterHelperTest extends TestCase
      * Tests for filter ASCIIHexDecode
      */
 
-    public function testDecodeFilterASCIIHexDecode()
+    public function testDecodeFilterASCIIHexDecode(): void
     {
         $compressed = '43 6f 6d 70 72 65 73 73 65 64 20 73 74 72 69 6e 67'; // = Compressed string
         $result = $this->fixture->decodeFilter('ASCIIHexDecode', $compressed);
@@ -73,7 +73,7 @@ class FilterHelperTest extends TestCase
      * Tests for filter FlateDecode
      */
 
-    public function testDecodeFilterFlateDecode()
+    public function testDecodeFilterFlateDecode(): void
     {
         $compressed = gzcompress('Compress me', 9);
         $result = $this->fixture->decodeFilter('FlateDecode', $compressed);
@@ -84,7 +84,7 @@ class FilterHelperTest extends TestCase
     /**
      * How does function behave if an empty string was given.
      */
-    public function testDecodeFilterFlateDecodeEmptyString()
+    public function testDecodeFilterFlateDecodeEmptyString(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('gzuncompress(): data error');
@@ -95,7 +95,7 @@ class FilterHelperTest extends TestCase
     /**
      * How does function behave if an uncompressed string was given.
      */
-    public function testDecodeFilterFlateDecodeUncompressedString()
+    public function testDecodeFilterFlateDecodeUncompressedString(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('gzuncompress(): data error');
@@ -106,7 +106,7 @@ class FilterHelperTest extends TestCase
     /**
      * How does function behave if an uncompressed string was given.
      */
-    public function testDecodeFilterUnknownFilter()
+    public function testDecodeFilterUnknownFilter(): void
     {
         $result = $this->fixture->decodeFilter('a string '.rand(), 'something');
         $this->assertEquals('something', $result);
@@ -119,7 +119,7 @@ class FilterHelperTest extends TestCase
     /**
      * CCITTFaxDecode
      */
-    public function testDecodeFilterCCITTFaxDecode()
+    public function testDecodeFilterCCITTFaxDecode(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Decode CCITTFaxDecode not implemented yet.');
@@ -130,7 +130,7 @@ class FilterHelperTest extends TestCase
     /**
      * Crypt
      */
-    public function testDecodeFilterCrypt()
+    public function testDecodeFilterCrypt(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Decode Crypt not implemented yet.');
@@ -141,7 +141,7 @@ class FilterHelperTest extends TestCase
     /**
      * DCTDecode
      */
-    public function testDecodeFilterDCTDecode()
+    public function testDecodeFilterDCTDecode(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Decode DCTDecode not implemented yet.');
@@ -152,7 +152,7 @@ class FilterHelperTest extends TestCase
     /**
      * JBIG2Decode
      */
-    public function testDecodeFilterJBIG2Decode()
+    public function testDecodeFilterJBIG2Decode(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Decode JBIG2Decode not implemented yet.');
@@ -163,7 +163,7 @@ class FilterHelperTest extends TestCase
     /**
      * JPXDecode
      */
-    public function testDecodeFilterJPXDecode()
+    public function testDecodeFilterJPXDecode(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Decode JPXDecode not implemented yet.');

--- a/tests/Integration/RawData/RawDataParserTest.php
+++ b/tests/Integration/RawData/RawDataParserTest.php
@@ -64,7 +64,7 @@ class RawDataParserTest extends TestCase
      * @see https://github.com/smalot/pdfparser/issues/372
      * @see https://github.com/smalot/pdfparser/pull/377
      */
-    public function testGetRawObjectIssue372()
+    public function testGetRawObjectIssue372(): void
     {
         // The following $data content is a minimal example to trigger the infinite loop
         $data = '<</Producer (eDkºãa˜þõ‚LÅòÕ�PïÙ��)©)>>';
@@ -98,7 +98,7 @@ class RawDataParserTest extends TestCase
      * @see https://github.com/smalot/pdfparser/issues/392
      * @see https://github.com/smalot/pdfparser/issues/397
      */
-    public function testDecodeXrefStreamIssue356()
+    public function testDecodeXrefStreamIssue356(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue356.pdf';
 
@@ -109,7 +109,7 @@ class RawDataParserTest extends TestCase
         $this->assertStringContainsString('Ημερήσια έκθεση επιδημιολογικής', $pages[0]->getText());
     }
 
-    public function testDecodeObjectHeaderIssue405()
+    public function testDecodeObjectHeaderIssue405(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue405.pdf';
 
@@ -134,7 +134,7 @@ class RawDataParserTest extends TestCase
      *
      * @see https://github.com/smalot/pdfparser/pull/479
      */
-    public function testDecodeXrefStreamIssue479()
+    public function testDecodeXrefStreamIssue479(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue479.pdf';
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,17 +54,17 @@ abstract class TestCase extends PHPTestCase
         $this->rootDir = __DIR__.'/..';
     }
 
-    protected function getDocumentInstance()
+    protected function getDocumentInstance(): Document
     {
         return new Document();
     }
 
-    protected function getElementInstance($value)
+    protected function getElementInstance($value): Element
     {
         return new Element($value);
     }
 
-    protected function getParserInstance(?Config $config = null)
+    protected function getParserInstance(?Config $config = null): Parser
     {
         return new Parser([], $config);
     }

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -44,7 +44,7 @@ class ConfigTest extends TestCase
     /**
      * Tests setter and getter for font space limit.
      */
-    public function testFontSpaceLimitSetterGetter()
+    public function testFontSpaceLimitSetterGetter(): void
     {
         $this->assertEquals(-50, $this->fixture->getFontSpaceLimit());
 
@@ -66,7 +66,7 @@ class ConfigTest extends TestCase
     /**
      * Tests setter and getter for retaining of raw image data.
      */
-    public function testRetainImageContentSetterGetter()
+    public function testRetainImageContentSetterGetter(): void
     {
         $this->assertTrue($this->fixture->getRetainImageContent());
 


### PR DESCRIPTION
To not mix these changes with https://github.com/smalot/pdfparser/pull/500