### PR TITLE
Fix Parsing Header Element with null value

### DIFF
--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -263,6 +263,10 @@ class Parser
         switch ($type) {
             case '<<':
             case '>>':
+                
+                if(empty($value))
+                    return null;
+                
                 $header = $this->parseHeader($value, $document);
                 PDFObject::factory($document, $header, null, $this->config);
 


### PR DESCRIPTION
`Parser::parseHeader` needs an array at first argument. When $value is null an exception is thrown.