### PR TITLE
Handle null Header and falsy header elements

### DIFF
--- a/src/Smalot/PdfParser/Header.php
+++ b/src/Smalot/PdfParser/Header.php
@@ -132,8 +132,8 @@ class Header
      */
     public function get(string $name)
     {
-        if (\array_key_exists($name, $this->elements)) {
-            return $this->resolveXRef($name);
+        if (\array_key_exists($name, $this->elements) && $element = $this->resolveXRef($name)) {
+            return $element;
         }
 
         return new ElementMissing();

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -78,7 +78,7 @@ class PDFObject
         ?Config $config = null
     ) {
         $this->document = $document;
-        $this->header = null !== $header ? $header : new Header();
+        $this->header = $header ?? new Header();
         $this->content = $content;
         $this->config = $config;
     }

--- a/tests/Integration/HeaderTest.php
+++ b/tests/Integration/HeaderTest.php
@@ -155,6 +155,18 @@ class HeaderTest extends TestCase
         $this->assertTrue($header->get('Font') instanceof Page);
         $this->assertTrue($header->get('Image') instanceof ElementMissing);
         $this->assertTrue($header->get('Resources') instanceof ElementMissing);
+
+        /**
+         * A double forward slash in the header's content results in a falsy element
+         * that should be parsed to ElementMissing instead.
+         *
+         * @see https://github.com/smalot/pdfparser/pull/525
+         */
+        $content = '<</Type/Page/SubType//Text>>foo';
+        $position = 0;
+        $header = Header::parse($content, $document, $position);
+
+        $this->assertTrue($header->get('SubType') instanceof ElementMissing);
     }
 
     public function testResolveXRef(): void


### PR DESCRIPTION
**Document.php**
`$object->getHeader()` can be `null` but that is never checked before calling `->get(...)` methods on it. Fixed by adding a `continue` if `getHeader()` returns `null`.

**Header.php**
Header elements may resolve to have `false` as a value (in `ElementDate::parse`, `ElementString::parse` and `ElementName::parse`). Another solution would be to change those `bool` returns to i.e. `ElementNull` or `ElementMissing`, but that seemed too big of a change, so instead I added a check to `Header->get(...)` that returns `ElementMissing` if the value of the Element is falsy (i.e. `null, false, 0, ''` )

This should fix #514 .