### PR TITLE
Fixes text decoding error when Tf command appears before BT. (#542)

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -191,8 +191,8 @@ class PDFObject
         $textCleaned = $this->cleanContent($content, '_');
 
         // Extract text blocks.
-        if (preg_match_all('/(\sQ)?\s+BT[\s|\(|\[]+(.*?)\s*ET(\sq)?/s', $textCleaned, $matches, \PREG_OFFSET_CAPTURE)) {
-            foreach ($matches[2] as $pos => $part) {
+        if (preg_match_all('/(\sQ)?\s+((?:[^\n]*\sT[a-z]\s+)*)BT[\s|\(|\[]+(.*?)\s*ET(\sq)?/s', $textCleaned, $matches, \PREG_OFFSET_CAPTURE)) {
+            foreach ($matches[3] as $pos => $part) {
                 $text = $part[0];
                 if ('' === $text) {
                     continue;
@@ -202,6 +202,10 @@ class PDFObject
 
                 // Removes BDC and EMC markup.
                 $section = preg_replace('/(\/[A-Za-z0-9]+\s*<<.*?)(>>\s*BDC)(.*?)(EMC\s+)/s', '${3}', $section.' ');
+
+                // Add Tx commands which before BT.
+                // @see: https://github.com/smalot/pdfparser/issues/542
+                $section = trim((!empty($matches[2][$pos][0]) ? $matches[2][$pos][0] : '').$section);
 
                 // Add Q and q flags if detected around BT/ET.
                 // @see: https://github.com/smalot/pdfparser/issues/387


### PR DESCRIPTION
### Issue Description
The [#Issue 542](https://github.com/smalot/pdfparser/issues/542) caused by the Tf command appears before the text block. And the method PDFObject::getSectionText only extracts command within BT & ET.

```pdf
Q
0.18 Tc
/F1 3.05 Tf
BT
0 0 0 sc
5.66929 7.65354 Td
<007D00F0010900C5012B00D0000300F001090128012B00F0010900D10003012E0137012B0003010300AD0128010F012E013400D0021800E5012B> Tj
ET
```

### Solution
```php
public function getSectionsText(?string $content): array
{
    ...
    if (preg_match_all('/(\sQ)?\s+((?:[^\n]*\sT[a-z]\s+)*)BT[\s|\(|\[]+(.*?)\s*ET(\sq)?/s', $textCleaned, $matches, \PREG_OFFSET_CAPTURE)) {
        foreach ($matches[3] as $pos => $part) {
            ...

            // Add Tx commands which before BT.
            $section = trim((!empty($matches[2][$pos][0]) ? $matches[2][$pos][0] : '').$section);

            ...
        }
    }
    ...
    return $sections;
}
```