### PR TITLE
FIX % *** pgformat breaks parsing 

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -709,6 +709,9 @@ class PDFObject
                         $operator = $matches[1];
                         $command = '';
                         $offset += \strlen($matches[0]);
+                    } elseif (preg_match('/^\s*([% \*]+.*[\*]{3})/si', substr($text_part, $offset), $matches)) {
+                        $command = '';
+                        $offset += \strlen($matches[0]);
                     }
             }
 


### PR DESCRIPTION
`% *** pgformat 'PAGEFORMAT 01' = 1 ***` in BT / ET will break parsing