### PR TITLE
Extend Github workflow file to run tests in Windows environment

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -225,8 +225,5 @@ jobs:
       - name: Install Composer dependencies (dev-tools)
         run: composer update --working-dir=dev-tools
 
-      - name: Show files and folders
-        run: dir -s
-
       - name: Tests
-        run: dev-tools/vendor/bin/phpunit -c phpunit-windows.xml
+        run: dev-tools/vendor/bin/phpunit -c phpunit-windows.xml --exclude-group linux-only

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -223,4 +223,4 @@ jobs:
         run: composer update --working-dir=dev-tools
 
       - name: Tests
-        run: dev-tools/vendor/bin/phpunit
+        run: dev-tools/vendor/bin/phpunit -c phpunit-windows.xml

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -199,3 +199,28 @@ jobs:
 
       - name: "Run PHPUnit"
         run: "make run-phpunit"
+
+  windows-tests:
+    name: Windows-Tests with PHP ${{ matrix.php-versions }}
+    runs-on: windows-2019
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: Install PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: ${{ matrix.php-versions }}
+            ini-values: memory_limit=1G
+
+        - name: Install Composer dependencies
+          run: "make install-dev-tools"
+
+        - name: Tests
+          run: "make run-phpunit"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -219,7 +219,10 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           ini-values: memory_limit=1G
 
-      - name: Install Composer dependencies
+      - name: Install Composer dependencies (root)
+        run: composer update --no-progress --no-suggest --prefer-dist --optimize-autoloader
+
+      - name: Install Composer dependencies (dev-tools)
         run: composer update --working-dir=dev-tools
 
       - name: Show files and folders

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -220,7 +220,7 @@ jobs:
           ini-values: memory_limit=1G
 
       - name: Install Composer dependencies
-        run: "make install-dev-tools"
+        run: composer update --working-dir=dev-tools
 
       - name: Tests
-        run: "make run-phpunit"
+        run: dev-tools/vendor/bin/phpunit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -209,18 +209,18 @@ jobs:
       matrix:
         php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-        - name: Install PHP
-          uses: shivammathur/setup-php@v2
-          with:
-            php-version: ${{ matrix.php-versions }}
-            ini-values: memory_limit=1G
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          ini-values: memory_limit=1G
 
-        - name: Install Composer dependencies
-          run: "make install-dev-tools"
+      - name: Install Composer dependencies
+        run: "make install-dev-tools"
 
-        - name: Tests
-          run: "make run-phpunit"
+      - name: Tests
+        run: "make run-phpunit"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -222,5 +222,8 @@ jobs:
       - name: Install Composer dependencies
         run: composer update --working-dir=dev-tools
 
+      - name: Show files and folders
+        run: dir -s
+
       - name: Tests
         run: dev-tools/vendor/bin/phpunit -c phpunit-windows.xml

--- a/phpunit-windows.xml
+++ b/phpunit-windows.xml
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="D:\a\pdfparser\pdfparser\vendor\autoload.php"
+         bootstrap="vendor\autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/phpunit-windows.xml
+++ b/phpunit-windows.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Only use this when running in Windows environment! -->
+
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"

--- a/phpunit-windows.xml
+++ b/phpunit-windows.xml
@@ -1,0 +1,36 @@
+<!-- Only use this when running in Windows environment! -->
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor\autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         verbose="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <ini name="zend.enable_gc" value="0"/>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="display_errors" value="On"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="all">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/phpunit-windows.xml
+++ b/phpunit-windows.xml
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="vendor\autoload.php"
+         bootstrap="D:\a\pdfparser\pdfparser\vendor\autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/phpunit-windows.xml
+++ b/phpunit-windows.xml
@@ -1,6 +1,5 @@
-<!-- Only use this when running in Windows environment! -->
 <?xml version="1.0" encoding="UTF-8"?>
-
+<!-- Only use this when running in Windows environment! -->
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"

--- a/tests/Integration/FontTest.php
+++ b/tests/Integration/FontTest.php
@@ -353,6 +353,7 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
      * which would be instance of PDFObject class (but not Encoding or ElementString).
      *
      * @see https://github.com/smalot/pdfparser/pull/500
+     *
      * @group linux-only
      */
     public function testDecodeTextForFontWithIndirectEncodingWithoutTypeEncoding(): void

--- a/tests/Integration/FontTest.php
+++ b/tests/Integration/FontTest.php
@@ -295,7 +295,7 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
     }
 
     /**
-     * @linux-only
+     * @group linux-only
      */
     public function testDecodeText(): void
     {
@@ -353,7 +353,7 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
      * which would be instance of PDFObject class (but not Encoding or ElementString).
      *
      * @see https://github.com/smalot/pdfparser/pull/500
-     * @linux-only
+     * @group linux-only
      */
     public function testDecodeTextForFontWithIndirectEncodingWithoutTypeEncoding(): void
     {

--- a/tests/Integration/FontTest.php
+++ b/tests/Integration/FontTest.php
@@ -294,6 +294,9 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
         $this->assertEquals('AB', Font::decodeUnicode("\xFE\xFF\x00A\x00B"));
     }
 
+    /**
+     * @linux-only
+     */
     public function testDecodeText(): void
     {
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';
@@ -350,6 +353,7 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
      * which would be instance of PDFObject class (but not Encoding or ElementString).
      *
      * @see https://github.com/smalot/pdfparser/pull/500
+     * @linux-only
      */
     public function testDecodeTextForFontWithIndirectEncodingWithoutTypeEncoding(): void
     {

--- a/tests/Integration/PDFObjectTest.php
+++ b/tests/Integration/PDFObjectTest.php
@@ -52,6 +52,9 @@ class PDFObjectTest extends TestCase
         return new PDFObject($document);
     }
 
+    /**
+     * @linux-only
+     */
     public function testGetCommandsText(): void
     {
         $content = "/R14 30 Tf 0.999016 0 0 1 137.4
@@ -199,6 +202,9 @@ q
         $this->assertEquals($cleaned, $expected);
     }
 
+    /**
+     * @linux-only
+     */
     public function testGetSectionText(): void
     {
         $content = '/Shape <</MCID 1 >>BDC

--- a/tests/Integration/PDFObjectTest.php
+++ b/tests/Integration/PDFObjectTest.php
@@ -53,7 +53,7 @@ class PDFObjectTest extends TestCase
     }
 
     /**
-     * @linux-only
+     * @group linux-only
      */
     public function testGetCommandsText(): void
     {
@@ -203,7 +203,7 @@ q
     }
 
     /**
-     * @linux-only
+     * @group linux-only
      */
     public function testGetSectionText(): void
     {


### PR DESCRIPTION
We can run almost all tests in Windows, but a few fail because of different line endings (`\n` in Linux **vs.** `\r\n` in Windows). I marked them with `@group linux-only` so they can be skipped in Windows.

Current state is pretty good for now in my opinion and helps us to catch more (potential) problems beforehand.

What do you guys think?

CC @j0k3r