### PR TITLE
Improve performance by not extracting compressed image data if retainImageContent was set to false

### DIFF
--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -805,20 +805,25 @@ class RawDataParser
     }
 
     /**
+     * Get value of an object header's section
+     *
      * @param array|null $header obj's header, parsed by getRawObject
-     * @param string $key Header's section
+     * @param string $key header's section name
      * @param string $type type of the section (ie 'numeric', '/', '<<', etc.)
      * @param string|null $default default value for header's section
-     * @return string|null value of obj header's section, or default value if none found
+     *
+     * returns string|array|null value of obj header's section, or default value if none found, or its type doesn't match $type param
      */
-    protected function getHeaderValue(?array $headerDic, string $key, string $type, ?string $default = ''): ?string
+    protected function getHeaderValue(?array $headerDic, string $key, string $type, $default = '')
     {
-        if (!is_array($headerDic))
+        if (!is_array($headerDic)) {
             return $default;
+        }
 
         foreach ($headerDic as $i => $val) {
-            if (is_array($val) && 3 == count($val) && '/' == $val[0] && $val[1] == $key && isset($headerDic[$i + 1]))
-                return is_array($headerDic[$i + 1]) && 1 < count($headerDic[$i + 1]) && $type == $headerDic[$i+1][0] ? $headerDic[$i + 1][1] : $default;
+            if (is_array($val) && 3 == count($val) && '/' == $val[0] && $val[1] == $key && isset($headerDic[$i + 1])) {
+                return is_array($headerDic[$i + 1]) && 1 < count($headerDic[$i + 1]) && $type == $headerDic[$i + 1][0] ? $headerDic[$i + 1][1] : $default;
+            }
         }
 
         return $default;

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -557,7 +557,7 @@ class RawDataParser
         do {
             $oldOffset = $offset;
             // get element
-            $element = $this->getRawObject($pdfData, $offset, $header[1]);
+            $element = $this->getRawObject($pdfData, $offset, $header != null ? $header[1] : null);
             $offset = $element[2];
             // decode stream using stream's dictionary information
             if ($decoding && ('stream' === $element[0]) && $header != null) {

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -763,7 +763,7 @@ class RawDataParser
                         $offset += \strlen($matches[0]);
 
                         $streamLen = (int) $this->getHeaderValue($headerDic, 'Length', 'numeric', 0);
-                        $skip = !$this->config->getRetainImageContent() && 'XObject' == $this->getHeaderValue($headerDic, 'Type', '/') && 'Image' == $this->getHeaderValue($headerDic, 'Subtype', '/');
+                        $skip = false === $this->config->getRetainImageContent() && 'XObject' == $this->getHeaderValue($headerDic, 'Type', '/') && 'Image' == $this->getHeaderValue($headerDic, 'Subtype', '/');
 
                         $pregResult = preg_match(
                             '/(endstream)[\x09\x0a\x0c\x0d\x20]/isU',
@@ -807,9 +807,9 @@ class RawDataParser
     /**
      * Get value of an object header's section
      *
-     * @param string      $key     header's section name
-     * @param string      $type    type of the section (i.e. 'numeric', '/', '<<', etc.)
-     * @param string|null $default default value for header's section
+     * @param string            $key     header's section name
+     * @param string            $type    type of the section (i.e. 'numeric', '/', '<<', etc.)
+     * @param string|array|null $default default value for header's section
      *
      * @return string|array|null value of obj header's section, or default value if none found, or its type doesn't match $type param
      */
@@ -820,14 +820,14 @@ class RawDataParser
         }
 
         foreach ($headerDic as $i => $val) {
+            $isSectionName = \is_array($val) && 3 == \count($val) && '/' == $val[0];
             if (
-                \is_array($val)
-                && 3 == \count($val)
-                && '/' == $val[0]
+                $isSectionName
                 && $val[1] == $key
                 && isset($headerDic[$i + 1])
             ) {
-                return \is_array($headerDic[$i + 1]) && 1 < \count($headerDic[$i + 1]) && $type == $headerDic[$i + 1][0]
+                $isSectionValue = \is_array($headerDic[$i + 1]) && 1 < \count($headerDic[$i + 1]);
+                return $isSectionValue && $type == $headerDic[$i + 1][0]
                     ? $headerDic[$i + 1][1]
                     : $default;
             }

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -807,7 +807,7 @@ class RawDataParser
 
     /**
      * Get value of an object header's section (obj << YYY >> part ).
-     * 
+     *
      * It is similar to Header::get('...')->getContent(), the only difference is it can be used during the parsing process,
      * when no Smalot\PdfParser\Header objects are created yet.
      *

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -262,8 +262,7 @@ class RawDataParser
             if (
                 ('/' == $v[0])
                 && ('Type' == $v[1])
-                && (
-                    isset($sarr[$k + 1])
+                && (isset($sarr[$k + 1])
                     && '/' == $sarr[$k + 1][0]
                     && 'XRef' == $sarr[$k + 1][1]
                 )
@@ -289,8 +288,7 @@ class RawDataParser
                     if (
                         '/' == $vdc[0]
                         && 'Columns' == $vdc[1]
-                        && (
-                            isset($decpar[$kdc + 1])
+                        && (isset($decpar[$kdc + 1])
                             && 'numeric' == $decpar[$kdc + 1][0]
                         )
                     ) {
@@ -298,8 +296,7 @@ class RawDataParser
                     } elseif (
                         '/' == $vdc[0]
                         && 'Predictor' == $vdc[1]
-                        && (
-                            isset($decpar[$kdc + 1])
+                        && (isset($decpar[$kdc + 1])
                             && 'numeric' == $decpar[$kdc + 1][0]
                         )
                     ) {
@@ -647,7 +644,7 @@ class RawDataParser
 
             case '(':   // \x28 LEFT PARENTHESIS
             case ')':  // \x29 RIGHT PARENTHESIS
-                    // literal string object
+                // literal string object
                 $objtype = $char;
                 ++$offset;
                 $strpos = $offset;
@@ -872,7 +869,8 @@ class RawDataParser
             // find last startxref
             $pregResult = preg_match_all(
                 '/[\r\n]startxref[\s]*[\r\n]+([0-9]+)[\s]*[\r\n]+%%EOF/i',
-                $pdfData, $matches,
+                $pdfData,
+                $matches,
                 \PREG_SET_ORDER,
                 $offset
             );

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -557,10 +557,10 @@ class RawDataParser
         do {
             $oldOffset = $offset;
             // get element
-            $element = $this->getRawObject($pdfData, $offset, $header != null ? $header[1] : null);
+            $element = $this->getRawObject($pdfData, $offset, null != $header ? $header[1] : null);
             $offset = $element[2];
             // decode stream using stream's dictionary information
-            if ($decoding && ('stream' === $element[0]) && $header != null) {
+            if ($decoding && ('stream' === $element[0]) && null != $header) {
                 $element[3] = $this->decodeStream($pdfData, $xref, $header[1], $element[1]);
             }
             $objContentArr[$i] = $element;
@@ -607,7 +607,7 @@ class RawDataParser
     /**
      * Get object type, raw value and offset to next object
      *
-     * @param int $offset Object offset
+     * @param int        $offset    Object offset
      * @param array|null $headerDic obj header's dictionary, parsed by getRawObject. Used for stream parsing optimization
      *
      * @return array containing object type, raw value and offset to next object
@@ -762,7 +762,7 @@ class RawDataParser
                     if (1 == preg_match('/^([\r]?[\n])/isU', substr($pdfData, $offset, 4), $matches)) {
                         $offset += \strlen($matches[0]);
 
-                        $streamLen = intval($this->getHeaderValue($headerDic, 'Length', 'numeric', 0));
+                        $streamLen = (int) $this->getHeaderValue($headerDic, 'Length', 'numeric', 0);
                         $skip = !$this->config->getRetainImageContent() && 'XObject' == $this->getHeaderValue($headerDic, 'Type', '/') && 'Image' == $this->getHeaderValue($headerDic, 'Subtype', '/');
 
                         $pregResult = preg_match(
@@ -774,7 +774,7 @@ class RawDataParser
                         );
 
                         if (1 == $pregResult) {
-                            $objval = $skip ? '' : substr($pdfData, $offset,  $matches[0][1] - $offset);
+                            $objval = $skip ? '' : substr($pdfData, $offset, $matches[0][1] - $offset);
                             $offset = $matches[1][1];
                         }
                     }
@@ -807,22 +807,29 @@ class RawDataParser
     /**
      * Get value of an object header's section
      *
-     * @param array|null $header obj's header, parsed by getRawObject
-     * @param string $key header's section name
-     * @param string $type type of the section (ie 'numeric', '/', '<<', etc.)
+     * @param string      $key     header's section name
+     * @param string      $type    type of the section (i.e. 'numeric', '/', '<<', etc.)
      * @param string|null $default default value for header's section
      *
-     * returns string|array|null value of obj header's section, or default value if none found, or its type doesn't match $type param
+     * @return string|array|null value of obj header's section, or default value if none found, or its type doesn't match $type param
      */
-    protected function getHeaderValue(?array $headerDic, string $key, string $type, $default = '')
+    private function getHeaderValue(?array $headerDic, string $key, string $type, $default = '')
     {
-        if (!is_array($headerDic)) {
+        if (!\is_array($headerDic)) {
             return $default;
         }
 
         foreach ($headerDic as $i => $val) {
-            if (is_array($val) && 3 == count($val) && '/' == $val[0] && $val[1] == $key && isset($headerDic[$i + 1])) {
-                return is_array($headerDic[$i + 1]) && 1 < count($headerDic[$i + 1]) && $type == $headerDic[$i + 1][0] ? $headerDic[$i + 1][1] : $default;
+            if (
+                \is_array($val)
+                && 3 == \count($val)
+                && '/' == $val[0]
+                && $val[1] == $key
+                && isset($headerDic[$i + 1])
+            ) {
+                return \is_array($headerDic[$i + 1]) && 1 < \count($headerDic[$i + 1]) && $type == $headerDic[$i + 1][0]
+                    ? $headerDic[$i + 1][1]
+                    : $default;
             }
         }
 

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -815,7 +815,7 @@ class RawDataParser
      */
     private function getHeaderValue(?array $headerDic, string $key, string $type, $default = '')
     {
-        if (!\is_array($headerDic)) {
+        if (false === \is_array($headerDic)) {
             return $default;
         }
 

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -827,6 +827,7 @@ class RawDataParser
                 && isset($headerDic[$i + 1])
             ) {
                 $isSectionValue = \is_array($headerDic[$i + 1]) && 1 < \count($headerDic[$i + 1]);
+
                 return $isSectionValue && $type == $headerDic[$i + 1][0]
                     ? $headerDic[$i + 1][1]
                     : $default;

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -761,13 +761,16 @@ class RawDataParser
                     $offset += 6;
                     if (1 == preg_match('/^([\r]?[\n])/isU', substr($pdfData, $offset, 4), $matches)) {
                         $offset += \strlen($matches[0]);
-                        $skip = !$this->config->getRetainImageContent() && 'XObject' == $this->getHeaderValue($headerDic, 'Type') && 'Image' == $this->getHeaderValue($headerDic, 'Subtype');
+
+                        $streamLen = intval($this->getHeaderValue($headerDic, 'Length', 'numeric', 0));
+                        $skip = !$this->config->getRetainImageContent() && 'XObject' == $this->getHeaderValue($headerDic, 'Type', '/') && 'Image' == $this->getHeaderValue($headerDic, 'Subtype', '/');
+
                         $pregResult = preg_match(
                             '/(endstream)[\x09\x0a\x0c\x0d\x20]/isU',
                             $pdfData,
                             $matches,
                             \PREG_OFFSET_CAPTURE,
-                            $offset
+                            $offset + $streamLen
                         );
 
                         if (1 == $pregResult) {


### PR DESCRIPTION
One of previous pull requests allowed not to decompress image data, if the user has set retainImageContent flag to false.
This pull request suggests even not to extract compressed image data, if this flag was set to false.

Minor optimization: extracting stream data tries to use header information about stream's length to speed preg_match up.

This PR improves memory allocation, achieved with [pull 582](https://github.com/smalot/pdfparser/pull/582),
from 45M for the first launch, 25M for the best subsequent one 
to 43M for the first launch, 18M for the best subsequent.


https://westra.ru/reports/kavkaz/danilina-1el2-arhyz-2021.pdf
```php
$lim = '128M';
ini_set("memory_limit", $lim);
include 'alt_autoload.php-dist';

$path = 'danilina-1el2-arhyz-2021.pdf';

$config = new \Smalot\PdfParser\Config();
$config->setRetainImageContent(false);
$parser = new \Smalot\PdfParser\Parser([], $config);

$content = file_get_contents($path);
$pdf = $parser->parseContent($content);

$text = $pdf->getText();

echo ini_get("memory_limit")."\n";
echo $text;
```