### PR TITLE
Reduce excessive substring allocation, using preg_match's offset parameter

### DIFF
--- a/src/Smalot/PdfParser/Element.php
+++ b/src/Smalot/PdfParser/Element.php
@@ -107,7 +107,7 @@ class Element
             $old_position = $position;
 
             if (!$only_values) {
-                if (!preg_match('/\G\s*(?P<name>\/[A-Z0-9\._]+)(?P<value>.*)/si', $content, $match, 0, $position)) {
+                if (false === preg_match('/\G\s*(?P<name>\/[A-Z0-9\._]+)(?P<value>.*)/si', $content, $match, 0, $position)) {
                     break;
                 } else {
                     $name = ltrim($match['name'], '/');

--- a/src/Smalot/PdfParser/Element.php
+++ b/src/Smalot/PdfParser/Element.php
@@ -107,7 +107,7 @@ class Element
             $old_position = $position;
 
             if (!$only_values) {
-                if (!preg_match('/^\s*(?P<name>\/[A-Z0-9\._]+)(?P<value>.*)/si', substr($content, $position), $match)) {
+                if (!preg_match('/\G\s*(?P<name>\/[A-Z0-9\._]+)(?P<value>.*)/si', $content, $match, 0, $position)) {
                     break;
                 } else {
                     $name = ltrim($match['name'], '/');

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -261,8 +261,6 @@ class PDFObject
 
         self::$recursionStack[] = $this->getUniqueId();
 
-        $parts = [];
-
         foreach ($sections as $section) {
             $commands = $this->getCommandsText($section);
             $reverse_text = false;
@@ -450,11 +448,7 @@ class PDFObject
             }
 
             $result .= $text;
-
-            //$parts[] = $text;
         }
-
-        //die(print_r($parts, 1) . "<br>\n<br>\n ->" . gettype($sections[9]). " - ". print_r($sections, 1));
 
         return $result.' ';
     }

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -625,7 +625,14 @@ class PDFObject
                         // get elements
                         $command = $this->getCommandsText($text_part, $offset);
 
-                        if (preg_match('/\G\s*[A-Z]{1,2}\s*/si', $text_part, $matches, 0, $offset)) {
+                        if (preg_match(
+                            '/\G\s*[A-Z]{1,2}\s*/si',
+                            $text_part,
+                            $matches,
+                            0,
+                            $offset
+                        )
+                        ) {
                             $operator = trim($matches[0]);
                             $offset += \strlen($matches[0]);
                         }
@@ -646,7 +653,14 @@ class PDFObject
                         $offset = $strpos + 1;
                     }
 
-                    if (preg_match('/\G\s*[A-Z]{1,2}\s*/si', $text_part, $matches, 0, $offset)) {
+                    if (preg_match(
+                        '/\G\s*[A-Z]{1,2}\s*/si',
+                        $text_part,
+                        $matches,
+                        0,
+                        $offset
+                    )
+                    ) {
                         $operator = trim($matches[0]);
                         $offset += \strlen($matches[0]);
                     }
@@ -686,7 +700,14 @@ class PDFObject
                         $command = substr($text_part, $offset, $strpos - $offset - 1);
                         $offset = $strpos;
 
-                        if (preg_match('/\G\s*([A-Z\']{1,2})\s*/si', $text_part, $matches, 0, $offset)) {
+                        if (preg_match(
+                            '/\G\s*([A-Z\']{1,2})\s*/si',
+                            $text_part,
+                            $matches,
+                            0,
+                            $offset
+                        )
+                        ) {
                             $operator = $matches[1];
                             $offset += \strlen($matches[0]);
                         }
@@ -707,11 +728,25 @@ class PDFObject
                         $operator = trim($matches['id']);
                         $command = trim($matches['data']);
                         $offset += \strlen($matches[0]);
-                    } elseif (preg_match('/\G\s*([0-9\.\-]+\s*?)+\s*/si', $text_part, $matches, 0, $offset)) {
+                    } elseif (preg_match(
+                        '/\G\s*([0-9\.\-]+\s*?)+\s*/si',
+                        $text_part,
+                        $matches,
+                        0,
+                        $offset
+                    )
+                    ) {
                         $type = 'n';
                         $command = trim($matches[0]);
                         $offset += \strlen($matches[0]);
-                    } elseif (preg_match('/\G\s*([A-Z\*]+)\s*/si', $text_part, $matches, 0, $offset)) {
+                    } elseif (preg_match(
+                        '/\G\s*([A-Z\*]+)\s*/si',
+                        $text_part,
+                        $matches,
+                        0,
+                        $offset
+                    )
+                    ) {
                         $type = '';
                         $operator = $matches[1];
                         $command = '';

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -261,6 +261,8 @@ class PDFObject
 
         self::$recursionStack[] = $this->getUniqueId();
 
+        $parts = [];
+
         foreach ($sections as $section) {
             $commands = $this->getCommandsText($section);
             $reverse_text = false;
@@ -448,7 +450,11 @@ class PDFObject
             }
 
             $result .= $text;
+
+            //$parts[] = $text;
         }
+
+        //die(print_r($parts, 1) . "<br>\n<br>\n ->" . gettype($sections[9]). " - ". print_r($sections, 1));
 
         return $result.' ';
     }
@@ -592,18 +598,22 @@ class PDFObject
                 case '/':
                     $type = $char;
                     if (preg_match(
-                        '/^\/([A-Z0-9\._,\+]+\s+[0-9.\-]+)\s+([A-Z]+)\s*/si',
-                        substr($text_part, $offset),
-                        $matches
+                        '/\G\/([A-Z0-9\._,\+]+\s+[0-9.\-]+)\s+([A-Z]+)\s*/si',
+                        $text_part,
+                        $matches,
+                        0,
+                        $offset
                     )
                     ) {
                         $operator = $matches[2];
                         $command = $matches[1];
                         $offset += \strlen($matches[0]);
                     } elseif (preg_match(
-                        '/^\/([A-Z0-9\._,\+]+)\s+([A-Z]+)\s*/si',
-                        substr($text_part, $offset),
-                        $matches
+                        '/\G\/([A-Z0-9\._,\+]+)\s+([A-Z]+)\s*/si',
+                        $text_part,
+                        $matches,
+                        0,
+                        $offset
                     )
                     ) {
                         $operator = $matches[2];
@@ -621,7 +631,7 @@ class PDFObject
                         // get elements
                         $command = $this->getCommandsText($text_part, $offset);
 
-                        if (preg_match('/^\s*[A-Z]{1,2}\s*/si', substr($text_part, $offset), $matches)) {
+                        if (preg_match('/\G\s*[A-Z]{1,2}\s*/si', $text_part, $matches, 0, $offset)) {
                             $operator = trim($matches[0]);
                             $offset += \strlen($matches[0]);
                         }
@@ -642,7 +652,7 @@ class PDFObject
                         $offset = $strpos + 1;
                     }
 
-                    if (preg_match('/^\s*[A-Z]{1,2}\s*/si', substr($text_part, $offset), $matches)) {
+                    if (preg_match('/\G\s*[A-Z]{1,2}\s*/si', $text_part, $matches, 0, $offset)) {
                         $operator = trim($matches[0]);
                         $offset += \strlen($matches[0]);
                     }
@@ -682,7 +692,7 @@ class PDFObject
                         $command = substr($text_part, $offset, $strpos - $offset - 1);
                         $offset = $strpos;
 
-                        if (preg_match('/^\s*([A-Z\']{1,2})\s*/si', substr($text_part, $offset), $matches)) {
+                        if (preg_match('/\G\s*([A-Z\']{1,2})\s*/si', $text_part, $matches, 0, $offset)) {
                             $operator = $matches[1];
                             $offset += \strlen($matches[0]);
                         }
@@ -693,19 +703,21 @@ class PDFObject
                     if ('ET' == substr($text_part, $offset, 2)) {
                         break;
                     } elseif (preg_match(
-                        '/^\s*(?P<data>([0-9\.\-]+\s*?)+)\s+(?P<id>[A-Z]{1,3})\s*/si',
-                        substr($text_part, $offset),
-                        $matches
+                        '/\G\s*(?P<data>([0-9\.\-]+\s*?)+)\s+(?P<id>[A-Z]{1,3})\s*/si',
+                        $text_part,
+                        $matches,
+                        0,
+                        $offset
                     )
                     ) {
                         $operator = trim($matches['id']);
                         $command = trim($matches['data']);
                         $offset += \strlen($matches[0]);
-                    } elseif (preg_match('/^\s*([0-9\.\-]+\s*?)+\s*/si', substr($text_part, $offset), $matches)) {
+                    } elseif (preg_match('/\G\s*([0-9\.\-]+\s*?)+\s*/si', $text_part, $matches, 0, $offset)) {
                         $type = 'n';
                         $command = trim($matches[0]);
                         $offset += \strlen($matches[0]);
-                    } elseif (preg_match('/^\s*([A-Z\*]+)\s*/si', substr($text_part, $offset), $matches)) {
+                    } elseif (preg_match('/\G\s*([A-Z\*]+)\s*/si', $text_part, $matches, 0, $offset)) {
                         $type = '';
                         $operator = $matches[1];
                         $command = '';


### PR DESCRIPTION
This PR proposes to use preg_match's offset parameter instead of preparing special string for it.
This change requires minor changes of regexps: "match start of string" meta-character ^ should be replaced with \G escape sequence https://www.php.net/manual/en/regexp.reference.escape.php

This PR slightly improves memory allocation, achieved with pulls https://github.com/smalot/pdfparser/pull/582, https://github.com/smalot/pdfparser/pull/590, but would be useful for all PDF's and not only image-rich ones.

This PR shows 
42M for the first launch, 18M for the best subsequent vs
43M for the first launch, 18M for the best subsequent for pull 590

https://westra.ru/reports/kavkaz/danilina-1el2-arhyz-2021.pdf
```php
$lim = '128M';
ini_set("memory_limit", $lim);
include 'alt_autoload.php-dist';

$path = 'danilina-1el2-arhyz-2021.pdf';

$config = new \Smalot\PdfParser\Config();
$config->setRetainImageContent(false);
$parser = new \Smalot\PdfParser\Parser([], $config);

$content = file_get_contents($path);
$pdf = $parser->parseContent($content);

$text = $pdf->getText();

echo ini_get("memory_limit")."\n";
echo $text;
```