### PR TITLE
str_replace in Font.php now seems to work as expected

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -435,7 +435,7 @@ class Font extends PDFObject
             // replace escaped chars
             $text = str_replace(
                 ['\\\\', '\(', '\)', '\n', '\r', '\t', '\f', '\ ', '\b'],
-                [chr(92), chr(40),chr(41), chr(10), chr(13), chr(9), chr(12), chr(32), chr(8)],
+                [\chr(92), \chr(40), \chr(41), \chr(10), \chr(13), \chr(9), \chr(12), \chr(32), \chr(8)],
                 $text
             );
 

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -434,8 +434,8 @@ class Font extends PDFObject
 
             // replace escaped chars
             $text = str_replace(
-                ['\\\\', '\(', '\)', '\n', '\r', '\t', '\f', '\ '],
-                ['\\', '(', ')', "\n", "\r", "\t", "\f", ' '],
+                ['\\\\', '\(', '\)', '\n', '\r', '\t', '\f', '\ ', '\b'],
+                [chr(92), chr(40),chr(41), chr(10), chr(13), chr(9), chr(12), chr(32), chr(8)],
                 $text
             );
 

--- a/tests/PHPUnit/Unit/FontTest.php
+++ b/tests/PHPUnit/Unit/FontTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @file This file is part of the PdfParser library.
+ *
+ * @author  Konrad Abicht <k.abicht@gmail.com>
+ *
+ * @date    2023-07-19
+ *
+ * @license LGPLv3
+ *
+ * @url     <https://github.com/smalot/pdfparser>
+ *
+ *  PdfParser is a pdf library written in PHP, extraction oriented.
+ *  Copyright (C) 2017 - Sébastien MALOT <sebastien@malot.fr>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.
+ *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
+ */
+
+namespace PHPUnitTests\Unit;
+
+use PHPUnitTests\TestCase;
+use Smalot\PdfParser\Config;
+use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Font;
+use Smalot\PdfParser\PDFObject;
+
+class FontTest extends TestCase
+{
+    /**
+     * decodeText must decode \b.
+     *
+     * @see https://github.com/smalot/pdfparser/pull/597
+     */
+    public function testDecodeTextIssue597(): void
+    {
+        $config = $this->createMock(Config::class);
+        $config->method('getFontSpaceLimit')->willReturn(1);
+
+        $document = $this->createMock(Document::class);
+        $sut = new Font($document, null, null, $config);
+
+        $commands = [
+            [
+                PDFObject::TYPE => '<',
+                PDFObject::COMMAND => "<ab>\b",
+            ]
+        ];
+
+        // result is a binary string and looks like: 0x3cc2ab083e
+        $result = $sut->decodeText($commands);
+
+        // check that \b is not part of the result anymore
+        self::assertFalse(strpos($result, "\b>"));
+
+        // compare result with expected value
+        self::assertEquals('3cc2ab083e', bin2hex($result));
+    }
+}

--- a/tests/PHPUnit/Unit/FontTest.php
+++ b/tests/PHPUnit/Unit/FontTest.php
@@ -56,7 +56,7 @@ class FontTest extends TestCase
             [
                 PDFObject::TYPE => '<',
                 PDFObject::COMMAND => "<ab>\b",
-            ]
+            ],
         ];
 
         // result is a binary string and looks like: 0x3cc2ab083e


### PR DESCRIPTION
Hi,
I ran into an issue while text has been decoded using /ToUnicode and a CMap 

I used a PDF file which was read correctly by Acrobat Reader, and showed the text. It has been created by a third hand with setasign/SetaFPDF.
Because of privacy issues I can't provide it :-( nor can I reproduce such PDF, I don't know what they have done.
nevertheless the thing was: (all takes place in Font.php)

decodeContentByToUnicodeCMapOrDescendantFonts(465) with translateChar(107)
did sometimes not find the character, which should be there and also was obviously in the $this->table as well had some offset-issues.
The CMap mapped like 67 characters .. 
A while of digging showed me, that in decimals my 2 bytes encoded string has been in decimals something like this:

00|47|00|50|00|03|00|92|98
the error came with 00|92 -> which obviously has not been in the table
further debugging showed me, that my desired letter has been in 3 bytes there 00|92|98

the original decompressed string had character combinations of '\b' '\r' '\f' in it. So they were not the "special characters" but always backslash and the letter.

which should have been replaced to the one byte long special character with str_replace in line 436.
While debugging I found out that was not the case resulting in 92|98 for \b
the special character for \b would have been decimal 8 which is what was the right letter in the table. I played around with escaping etc. finally I just used chr(92) chr(98) etc.  (see commit)
php version has been 8.1.6 for windows 
I don't now why it did not replace the strings as intended and expected ...

Perhaps - if you have time - and the issue is known - you could look into the matter and perhaps the chr(92) etc.  approach helps. 

Best Regards

---

fixes #160 