### PR TITLE
Fix ASCII85 decoding in a specific case

### DIFF
--- a/src/Smalot/PdfParser/RawData/FilterHelper.php
+++ b/src/Smalot/PdfParser/RawData/FilterHelper.php
@@ -150,13 +150,13 @@ class FilterHelper
         // all white-space characters shall be ignored
         $data = preg_replace('/[\s]/', '', $data);
         // remove start sequence 2-character sequence <~ (3Ch)(7Eh)
-        if (false !== strpos($data, '<~')) {
+        if (0 === strpos($data, '<~')) {
             // remove EOD and extra data (if any)
             $data = substr($data, 2);
         }
         // check for EOD: 2-character sequence ~> (7Eh)(3Eh)
         $eod = strpos($data, '~>');
-        if (false !== $eod) {
+        if (\strlen($data) - 2 === $eod) {
             // remove EOD and extra data (if any)
             $data = substr($data, 0, $eod);
         }

--- a/tests/PHPUnit/Integration/RawData/FilterHelperTest.php
+++ b/tests/PHPUnit/Integration/RawData/FilterHelperTest.php
@@ -59,6 +59,30 @@ class FilterHelperTest extends TestCase
         $this->assertEquals('Compressed string', $result);
     }
 
+    public function testDecodeFilterASCII85DecodeInitSequence(): void
+    {
+        $compressed = '<~6Z6g\Eb0<5ARlp)FE2)5B)'; // = Compressed string
+        $result = $this->fixture->decodeFilter('ASCII85Decode', $compressed);
+
+        $this->assertEquals('Compressed string', $result);
+    }
+
+    public function testDecodeFilterASCII85DecodeEndSequence(): void
+    {
+        $compressed = '6Z6g\Eb0<5ARlp)FE2)5B)~>'; // = Compressed string
+        $result = $this->fixture->decodeFilter('ASCII85Decode', $compressed);
+
+        $this->assertEquals('Compressed string', $result);
+    }
+
+    public function testDecodeFilterASCII85DecodeSpecificEndSequence(): void
+    {
+        $compressed = '+^6b<~>'; // = 0x215B33C0 = "![3\xC0"
+        $result = $this->fixture->decodeFilter('ASCII85Decode', $compressed);
+
+        $this->assertEquals("\x21\x5B\x33\xC0", $result);
+    }
+
     /*
      * Tests for filter ASCIIHexDecode
      */


### PR DESCRIPTION
When the start or the end of the string is `<~>`. In this case we must be sure of the exact position of this substring: e.g. when there is no `<~` header but `<~>` at the end, we must not remove the first two characters even if `<~` is found somewhere.

Issue: #599