### PR TITLE
PHP 8.3 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,6 +23,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
 
     steps:
       - name: "Checkout"
@@ -153,6 +154,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
 
     steps:
       - name: "Checkout"
@@ -207,7 +209,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout

--- a/src/Smalot/PdfParser/Encoding.php
+++ b/src/Smalot/PdfParser/Encoding.php
@@ -32,7 +32,6 @@
 
 namespace Smalot\PdfParser;
 
-use Exception;
 use Smalot\PdfParser\Element\ElementNumeric;
 use Smalot\PdfParser\Encoding\EncodingLocator;
 use Smalot\PdfParser\Encoding\PostScriptGlyphs;

--- a/tests/PHPUnit/Integration/EncodingTest.php
+++ b/tests/PHPUnit/Integration/EncodingTest.php
@@ -35,7 +35,6 @@
 
 namespace PHPUnitTests\Integration;
 
-use Exception;
 use PHPUnitTests\TestCase;
 use Smalot\PdfParser\Document;
 use Smalot\PdfParser\Element;


### PR DESCRIPTION
PHP 8.3 is still in alpha, so we don't have to hurry here. I wanted to have it integrated already so we can observe changes and how PDFParser behaves.