### PR TITLE
Support metadata element names containing spaces

### DIFF
--- a/src/Smalot/PdfParser/Element.php
+++ b/src/Smalot/PdfParser/Element.php
@@ -111,7 +111,7 @@ class Element
                     break;
                 } else {
                     $name = preg_replace_callback(
-                        '/#(\d\d)/',
+                        '/#([0-9a-f]{2})/i',
                         function($m) {
                             return \chr(base_convert($m[1], 16, 10));
                         },

--- a/src/Smalot/PdfParser/Element.php
+++ b/src/Smalot/PdfParser/Element.php
@@ -107,10 +107,16 @@ class Element
             $old_position = $position;
 
             if (!$only_values) {
-                if (!preg_match('/\G\s*(?P<name>\/[A-Z0-9\._]+)(?P<value>.*)/si', $content, $match, 0, $position)) {
+                if (!preg_match('/\G\s*(?P<name>\/[A-Z#0-9\._]+)(?P<value>.*)/si', $content, $match, 0, $position)) {
                     break;
                 } else {
-                    $name = ltrim($match['name'], '/');
+                    $name = preg_replace_callback(
+                        '/#(\d\d)/',
+                        function($m) {
+                            return \chr(base_convert($m[1], 16, 10));
+                        },
+                        ltrim($match['name'], '/')
+                    );
                     $value = $match['value'];
                     $position = strpos($content, $value, $position + \strlen($match['name']));
                 }

--- a/src/Smalot/PdfParser/Element.php
+++ b/src/Smalot/PdfParser/Element.php
@@ -112,7 +112,7 @@ class Element
                 } else {
                     $name = preg_replace_callback(
                         '/#([0-9a-f]{2})/i',
-                        function($m) {
+                        function ($m) {
                             return \chr(base_convert($m[1], 16, 10));
                         },
                         ltrim($match['name'], '/')

--- a/tests/PHPUnit/Integration/ElementTest.php
+++ b/tests/PHPUnit/Integration/ElementTest.php
@@ -58,7 +58,7 @@ class ElementTest extends TestCase
         /Contents[4 0 R 42]/Fonts<</F1 41/F2 43>>/NullType
         null/StringType(hello)/DateType(D:20130901235555+02\'00\')/XRefType 2 0 R
         /NumericType 8/HexaType<0020>/BooleanType false
-        /Document#20Type(Templates)';
+        /Space#20Test(Templates)/Hyphen#2DTest(Templates)';
         $offset = 0;
 
         $elements = Element::parse($content, $document, $offset, false);
@@ -101,7 +101,9 @@ class ElementTest extends TestCase
         $this->assertTrue($elements['BooleanType'] instanceof ElementBoolean);
         $this->assertFalse($elements['BooleanType']->getContent());
 
-        $this->assertTrue(\array_key_exists('Document Type', $elements));
+        $this->assertTrue(\array_key_exists('Space Test', $elements));
+
+        $this->assertTrue(\array_key_exists('Hyphen-Test', $elements));
 
         // Only_values = true.
         $content = '/NameType /FlateDecode';

--- a/tests/PHPUnit/Integration/ElementTest.php
+++ b/tests/PHPUnit/Integration/ElementTest.php
@@ -57,7 +57,8 @@ class ElementTest extends TestCase
         $content = '/NameType /FlateDecode
         /Contents[4 0 R 42]/Fonts<</F1 41/F2 43>>/NullType
         null/StringType(hello)/DateType(D:20130901235555+02\'00\')/XRefType 2 0 R
-        /NumericType 8/HexaType<0020>/BooleanType false';
+        /NumericType 8/HexaType<0020>/BooleanType false
+        /Document#20Type(Templates)';
         $offset = 0;
 
         $elements = Element::parse($content, $document, $offset, false);
@@ -99,6 +100,8 @@ class ElementTest extends TestCase
         $this->assertTrue(\array_key_exists('BooleanType', $elements));
         $this->assertTrue($elements['BooleanType'] instanceof ElementBoolean);
         $this->assertFalse($elements['BooleanType']->getContent());
+
+        $this->assertTrue(\array_key_exists('Document Type', $elements));
 
         // Only_values = true.
         $content = '/NameType /FlateDecode';


### PR DESCRIPTION
Add ability for PdfParser to parse metadata names with hexadecimal encoded characters such as "Document#20Type" where `#20` is a space.

See PDF Reference 1.7 Section H.3 Implementation Notes, Subsection 3.2.4,3 (page 1099)
https://ia801001.us.archive.org/1/items/pdf1.7/pdf_reference_1-7.pdf

Fixes #529