### PR TITLE
Fix failing Scrutinizer CI tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,4 +18,9 @@
       <directory>tests/PHPUnit</directory>
     </testsuite>
   </testsuites>
+  <filter>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
 </phpunit>


### PR DESCRIPTION
Fix Scrutinizer 'Incorrect whitelist config' error.

Fixes https://github.com/smalot/pdfparser/issues/591.

Note: I tested this out on a branch in my fork, setting up scrutinizer to run on a test branch in my repo.  Initially the scrutinize run failed with the same error as you received in your runs on master.  Then I added the "filter" section to the php config as suggested by others in google/stackoverflow and re-ran it, and it passed in scrutinize:

<img width="1116" alt="image" src="https://github.com/smalot/pdfparser/assets/1637133/53af1c90-b8b3-4e00-a804-368335670b91">

Link to the issues: https://scrutinizer-ci.com/g/jzohrab/pdfparser/issues

