### PR TITLE
Account for empty arrays in XMP data

### DIFF
--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -271,7 +271,6 @@ class Document
                             // value for this property
                             if (1 == \count($metadata) && isset($metadata[0]) && \is_string($metadata[0])) {
                                 $metadata = $metadata[0];
-
                             } elseif (0 == \count($metadata)) {
                                 // if the value is an empty array, set
                                 // the value of this property to the empty

--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -272,10 +272,10 @@ class Document
                             if (1 == \count($metadata) && isset($metadata[0]) && \is_string($metadata[0])) {
                                 $metadata = $metadata[0];
 
-                                // else if the value is an empty array, set
+                            } elseif (0 == \count($metadata)) {
+                                // if the value is an empty array, set
                                 // the value of this property to the empty
                                 // string
-                            } elseif (0 == \count($metadata)) {
                                 $metadata = '';
                             }
                         }

--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -263,12 +263,21 @@ class Document
                         break;
 
                     case 'close':
-                        // If the value of this property is a single-
-                        // element array where the element is of type
-                        // string, use the value of the first list item
-                        // as the value for this property
-                        if (\is_array($metadata) && isset($metadata[0]) && 1 == \count($metadata) && \is_string($metadata[0])) {
-                            $metadata = $metadata[0];
+                        // If the value of this property is an array
+                        if (\is_array($metadata)) {
+                            // If the value is a single element array
+                            // where the element is of type string, use
+                            // the value of the first list item as the
+                            // value for this property
+                            if (1 == \count($metadata) && isset($metadata[0]) && \is_string($metadata[0])) {
+                                $metadata = $metadata[0];
+
+                                // else if the value is an empty array, set
+                                // the value of this property to the empty
+                                // string
+                            } elseif (0 == \count($metadata)) {
+                                $metadata = '';
+                            }
                         }
 
                         // Move down one level in the stack


### PR DESCRIPTION
The previous version of Document::extractXMPMetadata() did not account for empty arrays as values. When encountered, use the empty string as a value for this property.

There is no test, because in the future this behaviour might change based on the outcome of #617.

Sorry, I am trying to commit all my small changes before any big ones. :)