### PR TITLE
Check for wrong line-endings when getting xref

### DIFF
--- a/tests/PHPUnit/Integration/FontTest.php
+++ b/tests/PHPUnit/Integration/FontTest.php
@@ -294,9 +294,6 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
         $this->assertEquals('AB', Font::decodeUnicode("\xFE\xFF\x00A\x00B"));
     }
 
-    /**
-     * @group linux-only
-     */
     public function testDecodeText(): void
     {
         $filename = $this->rootDir.'/samples/Document1_pdfcreator_nocompressed.pdf';


### PR DESCRIPTION
If we didn't find the `xref` command at the offset specified, then replace Windows `\r\n` line endings with Unix style `\n` and try again. If it succeeds, then edit the line-endings and proceed as normal. Otherwise continue on to the `decodeXrefStream()` method.

Fixes parsing of existing test suite file **/samples/bugs/Issue95_ANSI.pdf** the unit test for which would normally be passed over because of the `@group linux-only` flag. Remove this flag, as all assertions in the `testDecodeText()` function now resolve as true in any environment.