### PR TITLE
fix: Undefined array key 65

### DIFF
--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -701,6 +701,11 @@ class Page extends PDFObject
         $extractedTexts = $this->getTextArray();
         $extractedData = [];
         foreach ($dataCommands as $command) {
+
+            if(!isset($extractedTexts[\count($extractedData)])){
+                continue;
+            }
+
             $currentText = $extractedTexts[\count($extractedData)];
             switch ($command['o']) {
                 /*

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -702,7 +702,7 @@ class Page extends PDFObject
         $extractedData = [];
         foreach ($dataCommands as $command) {
 
-            if(!isset($extractedTexts[\count($extractedData)])){
+            if (!isset($extractedTexts[\count($extractedData)])) {
                 continue;
             }
 


### PR DESCRIPTION
# Type of pull request

* [x] Bug fix (involves code and configuration changes)

# About

Recently i found error when i try to read my pdf files. It says "Undefined array key 65" at line 705 of Page.php . So i tried to check whether the key `$extractedTexts[\count($extractedData)]` is exists or not.

# Checklist for code / configuration changes

*In case you changed the code/configuration, please read each of the following checkboxes as they contain valuable information:*

* [ ] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well. By the way, you don't have to provide a full fledged PDF file to demonstrate a fix. Instead a unit test may be sufficient sometimes, please have a look at [FontTest](https://github.com/smalot/pdfparser/blob/master/tests/PHPUnit/Unit/FontTest.php#L40) for example code. Code changes without any tests are likely to be rejected. If you dont know how to write tests, no problem, tell us upfront and we may add them ourselves or discuss other ways.
* [ ] Please run **PHP-CS-Fixer** before committing, to confirm with our coding styles. See https://github.com/smalot/pdfparser/blob/master/.php-cs-fixer.php for more information about our coding styles.

<!--
Pull requests will be declined/rejected if one part of the continuous integration pipeline fails. 
We use the pipeline to make sure no regressions are introduced and existing code still runs as expected.
-->
