### PR TITLE
Better octal and hex-entity decode

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -358,11 +358,11 @@ class Font extends PDFObject
             return \chr(octdec($m[1]));
         }, $text);
 
-        // Replace instances of the special string with a single backslash
-        $text = str_replace('[**pdfparserdblslsh**]', '\\', $text);
-
         // Unescape any parentheses
         $text = str_replace(['\\(', '\\)'], ['(', ')'], $text);
+
+        // Replace instances of the special string with a single backslash
+        $text = str_replace('[**pdfparserdblslsh**]', '\\', $text);
 
         return $text;
     }

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -362,9 +362,7 @@ class Font extends PDFObject
         $text = str_replace(['\\(', '\\)'], ['(', ')'], $text);
 
         // Replace instances of the special string with a single backslash
-        $text = str_replace('[**pdfparserdblslsh**]', '\\', $text);
-
-        return $text;
+        return str_replace('[**pdfparserdblslsh**]', '\\', $text);
     }
 
     /**
@@ -372,11 +370,9 @@ class Font extends PDFObject
      */
     public static function decodeEntities(string $text): string
     {
-        $text = preg_replace_callback('/#([0-9a-f]{2})/i', function ($m) {
+        return preg_replace_callback('/#([0-9a-f]{2})/i', function ($m) {
             return \chr(hexdec($m[1]));
         }, $text);
-
-        return $text;
     }
 
     /**

--- a/tests/PHPUnit/Integration/FontTest.php
+++ b/tests/PHPUnit/Integration/FontTest.php
@@ -290,6 +290,13 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
         $this->assertEquals('\\\\-', Font::decodeOctal('\\\\\\\\\\055')); // \\\\\055
         $this->assertEquals('\\\\\\055', Font::decodeOctal('\\\\\\\\\\\\055')); // \\\\\\055
         $this->assertEquals('\\\\\\-', Font::decodeOctal('\\\\\\\\\\\\\\055')); // \\\\\\\055
+
+        // Make sure we're unescaping ( and ) before returning the escaped
+        // backslashes to the string
+        $this->assertEquals('\\(', Font::decodeOctal('\\\\(')); // \\( - nothing to unescape
+        $this->assertEquals('\\(', Font::decodeOctal('\\\\\\(')); // \\\( - parenthesis unescaped
+        $this->assertEquals('\\\\(', Font::decodeOctal('\\\\\\\\(')); // \\\\( - nothing to unescape
+        $this->assertEquals('\\\\(', Font::decodeOctal('\\\\\\\\\\(')); // \\\\\( - parenthesis unescaped
     }
 
     public function testDecodeEntities(): void

--- a/tests/PHPUnit/Integration/FontTest.php
+++ b/tests/PHPUnit/Integration/FontTest.php
@@ -296,7 +296,7 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
     {
         $this->assertEquals('File Type', Font::decodeEntities('File#20Type'));
         $this->assertEquals('File# Ty#pe', Font::decodeEntities('File##20Ty#pe'));
-        $this->assertEquals('Fi#le# Ty#p#e ', Font::decodeEntities('Fi#23le##20Ty#p#e '));
+        $this->assertEquals('Fi#le#-Ty#p#e ', Font::decodeEntities('Fi#23le##2DTy#p#e '));
     }
 
     public function testDecodeUnicode(): void

--- a/tests/PHPUnit/Integration/FontTest.php
+++ b/tests/PHPUnit/Integration/FontTest.php
@@ -281,12 +281,22 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
         $this->assertEquals('AB C', Font::decodeOctal('\\101\\102\\040\\103'));
         $this->assertEquals('AB CD', Font::decodeOctal('\\101\\102\\040\\103D'));
         $this->assertEquals('AB \199', Font::decodeOctal('\\101\\102\\040\\\\199'));
+
+        // Test that series of backslashes of arbitrary length are decoded properly
+        $this->assertEquals('-', Font::decodeOctal('\\055')); // \055
+        $this->assertEquals('\\055', Font::decodeOctal('\\\\055')); // \\055
+        $this->assertEquals('\\-', Font::decodeOctal('\\\\\\055')); // \\\055
+        $this->assertEquals('\\\\055', Font::decodeOctal('\\\\\\\\055')); // \\\\055
+        $this->assertEquals('\\\\-', Font::decodeOctal('\\\\\\\\\\055')); // \\\\\055
+        $this->assertEquals('\\\\\\055', Font::decodeOctal('\\\\\\\\\\\\055')); // \\\\\\055
+        $this->assertEquals('\\\\\\-', Font::decodeOctal('\\\\\\\\\\\\\\055')); // \\\\\\\055
     }
 
     public function testDecodeEntities(): void
     {
         $this->assertEquals('File Type', Font::decodeEntities('File#20Type'));
         $this->assertEquals('File# Ty#pe', Font::decodeEntities('File##20Ty#pe'));
+        $this->assertEquals('Fi#le# Ty#p#e ', Font::decodeEntities('Fi#23le##20Ty#p#e '));
     }
 
     public function testDecodeUnicode(): void


### PR DESCRIPTION
# Type of pull request

* [x] Bug fix (involves code and configuration changes)
* [ ] New feature (involves code and configuration changes)
* [ ] Documentation update
* [ ] Something else

# About

A follow-up and improvement over #627.

Octal strings can include series of backslashes of arbitrary length. If there is an odd number of backslashes, a following octal code is valid, but if there's an even number, the following octal code should not be translated.

Previously PdfParser would only account for two backslashes directly preceding an octal code. A commit from in-progress PR #634 extended this to three which probably covers 99.99% of all cases. This change ups that to 100% in that there could be a string with any number of backslashes in a row, and codes will be correctly translated.

Also update decodeEntities() to use a preg_replace_callback() instead of the bulkier preg_split() + foreach loop. Make sure it matches all hexadecimal digits including a-f.

Add new tests for both of these.

# Checklist for code / configuration changes

*In case you changed the code/configuration, please read each of the following checkboxes as they contain valuable information:*

* [x] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well.
     By the way, you don't have to provide a full fledged PDF file to demonstrate a fix. Instead a unit test may be sufficient sometimes, please have a look at [FontTest](https://github.com/smalot/pdfparser/blob/master/tests/PHPUnit/Unit/FontTest.php#L40) for example code.
     Code changes without any tests are likely to be rejected. If you dont know how to write tests, no problem, tell us upfront and we may add them ourselves or discuss other ways.
* [x] Please run **PHP-CS-Fixer** before committing, to confirm with our coding styles. See https://github.com/smalot/pdfparser/blob/master/.php-cs-fixer.php for more information about our coding styles.