### PR TITLE
Absorb spaces after 'stream' declarations

### DIFF
--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -756,7 +756,7 @@ class RawDataParser
                     // start stream object
                     $objtype = 'stream';
                     $offset += 6;
-                    if (1 == preg_match('/^([\r]?[\n])/isU', substr($pdfData, $offset, 4), $matches)) {
+                    if (1 == preg_match('/^( *[\r]?[\n])/isU', substr($pdfData, $offset, 4), $matches)) {
                         $offset += \strlen($matches[0]);
 
                         // we get stream length here to later help preg_match test less data

--- a/tests/PHPUnit/Integration/RawData/RawDataParserTest.php
+++ b/tests/PHPUnit/Integration/RawData/RawDataParserTest.php
@@ -87,6 +87,25 @@ class RawDataParserTest extends TestCase
             ],
             $result
         );
+
+        // Test that spaces after a 'stream' declaration are absorbed
+        // See: https://github.com/smalot/pdfparser/issues/641
+        $data = 'stream '."\n";
+        $data .= 'streamdata'."\n";
+        $data .= 'endstream'."\n";
+        $data .= 'endobj';
+
+        $result = $this->fixture->exposeGetRawObject($data);
+
+        // Value 'streamdata'."\n" would be empty string without the fix
+        $this->assertEquals(
+            [
+                'stream',
+                'streamdata'."\n",
+                19,
+            ],
+            $result
+        );
     }
 
     /**


### PR DESCRIPTION
# Type of pull request

* [x] Bug fix (involves code and configuration changes)

# About

<!-- Please describe with a few words what this pull request is about -->

When detecting the start of a `stream`, PdfParser currently expects the next character to be either a carriage-return (`\r`) or a newline (`\n`). If there is a space in between the `stream` and either the `\r` or the `\n`, it is not detected as a stream of data and is discarded.

Adjust the regexp in **RawDataParser.php** to absorb spaces after `stream`.

Resolves #641. Note that in the sample files provided by the original reporter of **641** there are remaining font decoding issues with the output that are outside the scope of this fix.

# Checklist for code / configuration changes

* [x] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well.
* [x] Please run **PHP-CS-Fixer** before committing, to confirm with our coding styles. See https://github.com/smalot/pdfparser/blob/master/.php-cs-fixer.php for more information about our coding styles.
* [x] In case you **fix an existing issue**, please do one of the following:
  * [x] Write in this text something like `fixes #1234` to outline that you are providing a fix for the issue `#1234`.