### PR TITLE
Usage.md: change example code to avoid PHP notice

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -205,8 +205,9 @@ Characters without width are added to `$missing` array in second parameter.
 ```php
 $parser = new \Smalot\PdfParser\Parser();
 $pdf = $parser->parseFile('document.pdf');
+$fonts = $pdf->getFonts();
 // get first font (we assume here there is at least one)
-$font = reset($pdf->getFonts());
+$font = reset($fonts);
 // get width
 $width = $font->calculateTextWidth('Some text', $missing);
 ```


### PR DESCRIPTION
# Type of pull request

* [x] Documentation update

# About

Usage documentation contains buggy code. The following notice is thrown when used:

> Only variables should be passed by reference

because of the following code part:

> $font = reset($pdf->getFonts());

## Acknowledgement

Reported by @gidzr in #619