### PR TITLE
Font.php: hot fix for calculateTextWidth in case Widths key is not set

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -283,7 +283,9 @@ class Font extends PDFObject
     {
         $index_map = array_flip($this->table);
         $details = $this->getDetails();
-        $widths = $details['Widths'];
+
+        // TODO: Temporary fix, in the rare case the Widths-key is not set in $details array.
+        $widths = $details['Widths'] ?? [];
 
         // Widths array is zero indexed but table is not. We must map them based on FirstChar and LastChar
         $width_map = array_flip(range($details['FirstChar'], $details['LastChar']));

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -284,7 +284,7 @@ class Font extends PDFObject
         $index_map = array_flip($this->table);
         $details = $this->getDetails();
 
-        // TODO: Temporary fix, in the rare case the Widths-key is not set in $details array.
+        // Usually, Widths key is set in $details array, but if it isn't use an empty array instead.
         $widths = $details['Widths'] ?? [];
 
         // Widths array is zero indexed but table is not. We must map them based on FirstChar and LastChar

--- a/tests/PHPUnit/Integration/FontTest.php
+++ b/tests/PHPUnit/Integration/FontTest.php
@@ -455,6 +455,29 @@ TEXT;
     }
 
     /**
+     * Check behavior if getDetails() does return an array without a Widths-key.
+     *
+     * @see https://github.com/smalot/pdfparser/issues/619
+     */
+    public function testCalculateTextWidthNoWidthsKey(): void
+    {
+        $document = $this->createMock(Document::class);
+
+        $header = $this->createMock(Header::class);
+        $header->method('getDetails')->willReturn([
+            'FirstChar' => '',
+            'LastChar' => '',
+            // 'Widths' key is not set, so without the fix in Font.php a warning would be thrown.
+        ]);
+
+        $font = new Font($document, $header);
+        $font->setTable([]);
+        $width = $font->calculateTextWidth('foo');
+
+        $this->assertNull($width);
+    }
+
+    /**
      * Check behavior if iconv function gets input which contains illegal characters.
      *
      * In this test we create a CP1252-encoded string, which contains a character that has no counterpart in UTF-8.


### PR DESCRIPTION
# Type of pull request

* [x] Bug fix (involves code and configuration changes)

# About

Hot fix for Font.php to avoid PHP warning in case the Widths-key is not set in `$details`.

# Checklist for code / configuration changes

*In case you changed the code/configuration, please read each of the following checkboxes as they contain valuable information:*

* [x] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well.
     By the way, you don't have to provide a full fledged PDF file to demonstrate a fix. Instead a unit test may be sufficient sometimes,
     please have a look at [FontTest](https://github.com/smalot/pdfparser/blob/master/tests/PHPUnit/Unit/FontTest.php#L40) for example code.
     Code changes without any tests are likely to be rejected. If you dont know how to write tests, no problem, tell us upfront and we may add them ourselves or discuss other ways.
* [x] Please run **PHP-CS-Fixer** before committing, to confirm with our coding styles. See https://github.com/smalot/pdfparser/blob/master/.php-cs-fixer.php for more information about our coding styles.

### Acknowledgement

Bug reported in #619 by @gidzr.