### PR TITLE
Ignore encryption

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -229,3 +229,17 @@ foreach ($pages as $page) {
     ];
 }
 ```
+
+## Ignoring PDF encryption
+
+In some cases PDF files may be internally marked as encrypted even though the content is not encrypted and can be read.
+This can be caused by the PDF being created by a tool that does not properly set the encryption flag.
+If you are sure that the PDF is not encrypted, you can ignore the encryption flag by setting the `ignoreEncryption` flag to `true` in the `Config` object.
+
+```php
+$config = new \Smalot\PdfParser\Config();
+$config->setIgnoreEncryption(true);
+
+$parser = new \Smalot\PdfParser\Parser([], $config);
+$pdf = $parser->parseFile('document.pdf');
+```

--- a/src/Smalot/PdfParser/Config.php
+++ b/src/Smalot/PdfParser/Config.php
@@ -82,6 +82,13 @@ class Config
      */
     private $dataTmFontInfoHasToBeIncluded = false;
 
+    /**
+     * Whether to attempt to read PDFs even if they are marked as encrypted.
+     *
+     * @var bool
+     */
+    private $ignoreEncryption = false;
+
     public function getFontSpaceLimit()
     {
         return $this->fontSpaceLimit;
@@ -150,5 +157,15 @@ class Config
     public function setDataTmFontInfoHasToBeIncluded(bool $dataTmFontInfoHasToBeIncluded): void
     {
         $this->dataTmFontInfoHasToBeIncluded = $dataTmFontInfoHasToBeIncluded;
+    }
+
+    public function getIgnoreEncryption(): bool
+    {
+        return $this->ignoreEncryption;
+    }
+
+    public function setIgnoreEncryption(bool $ignoreEncryption): void
+    {
+        $this->ignoreEncryption = $ignoreEncryption;
     }
 }

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -101,7 +101,7 @@ class Parser
         // Create structure from raw data.
         list($xref, $data) = $this->rawDataParser->parseData($content);
 
-        if (isset($xref['trailer']['encrypt'])) {
+        if (isset($xref['trailer']['encrypt']) && $this->config->getIgnoreEncryption() === false) {
             throw new \Exception('Secured pdf file are currently not supported.');
         }
 

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -101,7 +101,7 @@ class Parser
         // Create structure from raw data.
         list($xref, $data) = $this->rawDataParser->parseData($content);
 
-        if (isset($xref['trailer']['encrypt']) && !$this->config->getIgnoreEncryption()) {
+        if (isset($xref['trailer']['encrypt']) && false === $this->config->getIgnoreEncryption()) {
             throw new \Exception('Secured pdf file are currently not supported.');
         }
 

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -101,7 +101,7 @@ class Parser
         // Create structure from raw data.
         list($xref, $data) = $this->rawDataParser->parseData($content);
 
-        if (isset($xref['trailer']['encrypt']) && $this->config->getIgnoreEncryption() === false) {
+        if (isset($xref['trailer']['encrypt']) && !$this->config->getIgnoreEncryption()) {
             throw new \Exception('Secured pdf file are currently not supported.');
         }
 


### PR DESCRIPTION
# Type of pull request

* New feature (involves code and configuration changes)
* Documentation update

# About

In some cases PDF files may be internally marked as encrypted even though the content is not encrypted and can be read.

This MR provides a config option to inform the PDF parser to ignore the encryption and attempt to read the PDF anyway.

This therefore provides a work around for the following issues:
  - #320
  - #488

Thanks to @DivineOmega for making the original pull request.

(**PHP-CS-Fixer** has not been run.)