### PR TITLE
Fixes Scrutinizer integration (mostly failing tests)

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,14 +5,10 @@ build:
                 override:
                     - php-scrutinizer-run
                     -
-                        # Forces a certain PHPUnit version (=7.5.x), otherwise some tests fail due
-                        # to not enough memory.
-                        # @https://github.com/smalot/pdfparser/issues/410
-                        # @https://github.com/smalot/pdfparser/pull/412
-                        command: make prepare-for-scrutinizer && make install-dev-tools && make run-phpunit ARGS="--exclude-group memory-heavy --coverage-clover coverage/clover.xml"
+                        command: make install-dev-tools && make run-phpunit ARGS="--exclude-group memory-heavy --coverage-clover coverage/clover.xml"
                         coverage:
                             file: coverage/clover.xml
                             format: clover
             environment:
                 php:
-                    version: 7.4
+                    version: 8.2

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,14 +1,14 @@
 build:
     cache:
         directories:
-            - vendor        # Cache for already installed composer package -> speed up composer install
-            - bin           # As vendor directory is cached, bin directory must be also cached (as some dependency will not installed if they are already present and so, related binary will not be linked)
-            - ~/.composer   # Composer home directory (avoid fetching already fetched packages)
+            - vendor # Cache for already installed composer package -> speed up composer install
     nodes:
         analysis:
             environment:
                 php:
                     version: 8.2
+                    ini:
+                        memory_limit: "-1"
                 variables:
                     XDEBUG_MODE: 'coverage'
             tests:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,14 +1,21 @@
 build:
+    cache:
+        directories:
+            - vendor        # Cache for already installed composer package -> speed up composer install
+            - bin           # As vendor directory is cached, bin directory must be also cached (as some dependency will not installed if they are already present and so, related binary will not be linked)
+            - ~/.composer   # Composer home directory (avoid fetching already fetched packages)
     nodes:
         analysis:
+            environment:
+                php:
+                    version: 8.2
+                variables:
+                    XDEBUG_MODE: 'coverage'
             tests:
                 override:
                     - php-scrutinizer-run
                     -
-                        command: make install-dev-tools && make run-phpunit ARGS="--exclude-group memory-heavy --coverage-clover coverage/clover.xml"
+                        command: make install-dev-tools && make run-phpunit ARGS="--migrate-configuration" && make run-phpunit ARGS="--exclude-group memory-heavy --coverage-clover coverage/clover.xml"
                         coverage:
                             file: coverage/clover.xml
                             format: clover
-            environment:
-                php:
-                    version: 8.2

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,6 @@
 install-dev-tools:
 	composer update --working-dir=dev-tools
 
-# Workaround to force PHPUnit 7.5.x when running Scrutinizer.
-# Scrutinizer fails due to not enough memory when using a newer PHPUnit version (tested with 9.5).
-# @see: https://github.com/smalot/pdfparser/issues/410
-# @see: https://github.com/smalot/pdfparser/pull/412
-prepare-for-scrutinizer:
-	cd dev-tools && sed -e 's/>=7.5/^7.5/g' composer.json > composer.json2 && rm composer.json && mv composer.json2 composer.json
-
 run-php-cs-fixer:
 	dev-tools/vendor/bin/php-cs-fixer fix $(ARGS)
 

--- a/tests/PHPUnit/Integration/RawData/RawDataParserTest.php
+++ b/tests/PHPUnit/Integration/RawData/RawDataParserTest.php
@@ -119,6 +119,8 @@ class RawDataParserTest extends TestCase
      * @see https://github.com/smalot/pdfparser/issues/373
      * @see https://github.com/smalot/pdfparser/issues/392
      * @see https://github.com/smalot/pdfparser/issues/397
+     *
+     * @group memory-heavy
      */
     public function testDecodeXrefStreamIssue356(): void
     {

--- a/tests/PHPUnit/Integration/RawData/RawDataParserTest.php
+++ b/tests/PHPUnit/Integration/RawData/RawDataParserTest.php
@@ -119,8 +119,6 @@ class RawDataParserTest extends TestCase
      * @see https://github.com/smalot/pdfparser/issues/373
      * @see https://github.com/smalot/pdfparser/issues/392
      * @see https://github.com/smalot/pdfparser/issues/397
-     *
-     * @group memory-heavy
      */
     public function testDecodeXrefStreamIssue356(): void
     {


### PR DESCRIPTION
# Type of pull request

* [x] Bug fix (involves code and configuration changes)

# About

This PR is the successor of #412 and re-establishes Scrutinizer integration. Our tests were failing because of insufficient memory. I changed configuration file to provide test process more memory. Nice side effect, because of additional changes Scrutinizer runs faster now :rocket:.

**Scrutinizer build reference:** https://scrutinizer-ci.com/docs/configuration/build_reference

**Latest working Scrutinizer test**: https://scrutinizer-ci.com/g/smalot/pdfparser/inspections/eed3683a-fc39-4819-90a2-3e626479062b