### PR TITLE
Prevent zero from being passed to array_chunk()

### DIFF
--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -408,10 +408,15 @@ class RawDataParser
             } else {
                 // number of bytes in a row
                 $rowlen = array_sum($wb);
-                // convert the stream into an array of integers
-                $sdata = unpack('C*', $xrefcrs[1][3][0]);
-                // split the rows
-                $ddata = array_chunk($sdata, $rowlen);
+                if (0 < $rowlen) {
+                    // convert the stream into an array of integers
+                    $sdata = unpack('C*', $xrefcrs[1][3][0]);
+                    // split the rows
+                    $ddata = array_chunk($sdata, $rowlen);
+                } else {
+                    // if the row length is zero, $ddata should be an empty array as well
+                    $ddata = [];
+                }
             }
 
             $sdata = [];


### PR DESCRIPTION
# Type of pull request

* [X] Bug fix (involves code and configuration changes)

# About

Passing a zero (0) value to the `array_chunk()` function causes an error, and in rare cases, a PDF XRef object may be added to a document with an "empty" `/W [0 0 0]` command. In **RawDataParser.php** this would cause the `$rowlen` variable to be set to zero and cause an error.

Add a simple check to return an empty array in this case. Resolves #679.

It is very difficult to create a unit test for this error as it requires a PDF to be generated with "empty" sections with the specific `/W [0 0 0]` command. As the error occurs at a point when the *entire* document is being considered, we can't just feed PdfParser some test PDF code that's a subsection of a full document. The sample PDF given by the reporter of issue #679 contained personal info that we cannot include in PdfParser and they did not know how to generate a similar file. It is hoped we can merge this PR without a unit test added, since it is, at it's core, just a check for a zero value which should have been in the code already. :)

Thanks to @KeanuTang for the initial analysis and provided code solution, with which I built this PR.

# Checklist for code / configuration changes

*In case you changed the code/configuration, please read each of the following checkboxes as they contain valuable information:*

* [ ] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well.
     Code changes without any tests are likely to be rejected. If you dont know how to write tests, no problem, tell us upfront and we may add them ourselves or discuss other ways.
* [X] Please run **PHP-CS-Fixer** before committing, to confirm with our coding styles. See https://github.com/smalot/pdfparser/blob/master/.php-cs-fixer.php for more information about our coding styles.
* [X] In case you **fix an existing issue**, please do one of the following:
  * [X] Write in this text something like `fixes #1234` to outline that you are providing a fix for the issue `#1234`.