### PR TITLE
Attempt to fix #659 (gzuncompress(): data error)

### DIFF
--- a/tests/PHPUnit/Integration/RawData/FilterHelperTest.php
+++ b/tests/PHPUnit/Integration/RawData/FilterHelperTest.php
@@ -142,6 +142,29 @@ class FilterHelperTest extends TestCase
     }
 
     /**
+     * Check if function runs into a "gzuncompress(): data error".
+     *
+     * @see https://github.com/smalot/pdfparser/issues/659
+     */
+    public function testDecodeFilterFlateDecodeGzUncompressDataErrorIssue659(): void
+    {
+        $data = '�s��8�S4z�2A�ٮ�������n�O��)q,�ӕ�ik�7l�B:��<Lgz?��C�/�UL�"XZ�@���ui~-�����٥~�&K��"&8_�E����A�f
+
+        ***@***.***�Kj��s����!3�Q�<�������#
+
+        ŀ>�����3�|�L';
+
+        $subjectUnderTest = new FilterHelper();
+
+        //                 ,--- currently throws exception: decodeFilterFlateDecode: invalid data
+        //                 ,
+        //                 ,
+        $subjectUnderTest->decodeFilter('FlateDecode', $data, 1000000);
+
+        // we expect an error with "gzuncompress(): data error" here
+    }
+
+    /**
      * How does function behave if an unknown filter name was given.
      */
     public function testDecodeFilterUnknownFilter(): void


### PR DESCRIPTION
# Type of pull request

* [x] Bug fix (involves code and configuration changes)

# About

This PR is about the error in #659 (`gzuncompress(): data error`). Will fix #659 

@NickHahac Currently I try to exploit the error, but your test data is not working (binary?). Could help me with the [unit test](https://github.com/smalot/pdfparser/pull/690/files#diff-235727ecb69058b18625467133a4011eedea250a8842a96ae4c6e9c1b4f372cdR149-R165)?

# Checklist for code / configuration changes

*In case you changed the code/configuration, please read each of the following checkboxes as they contain valuable information:*

* [ ] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well.