### PR TITLE
Account for inline images in formatContent()

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -233,31 +233,32 @@ class PDFObject
             // actually occured within a (string) using the following
             // steps:
 
-            // Remove any escaped parentheses from the alleged image
-            // characteristics data
+            // Step 1: Remove any escaped parentheses from the alleged
+            // image characteristics data
             $para = str_replace(['\\(', '\\)'], '', $text[1][0]);
 
-            // Remove all correctly ordered and balanced parentheses
-            // from (strings)
+            // Step 2: Remove all correctly ordered and balanced
+            // parentheses from (strings)
             do {
                 $paraTest = $para;
-                $para = preg_replace('/\(([^)]*)\)/', '$1', $paraTest);
+                $para = preg_replace('/\(([^()]*)\)/', '$1', $paraTest);
             } while ($para != $paraTest);
 
             $paraOpen = strpos($para, '(');
             $paraClose = strpos($para, ')');
 
-            // If the remaining text contains a close parenthesis ')'
-            // AND it occurs before any open parenthesis, then we are
-            // almost certain to be inside a (string)
+            // Check: If the remaining text contains a close parenthesis
+            // ')' AND it occurs before any open parenthesis, then we
+            // are almost certain to be inside a (string)
             if (0 < $paraClose && (false === $paraOpen || $paraClose < $paraOpen)) {
                 // Bump the search offset forward and match again
                 $offsetBI = (int) $text[1][1];
                 continue;
             }
 
-            // Double check that this is actually inline image data by
-            // parsing the alleged image characteristics as a dictionary
+            // Step 3: Double check that this is actually inline image
+            // data by parsing the alleged image characteristics as a
+            // dictionary
             $dict = $this->parseDictionary('<<'.$text[1][0].'>>');
 
             // Check if an image Width and Height are set in the dict

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -274,6 +274,12 @@ class PDFObject
                     $content,
                     1
                 );
+            } else {
+                // If there was no valid dictionary, or a height and width
+                // weren't specified, then we don't know what this is, so
+                // just leave it alone; bump the search offset forward and
+                // match again
+                $offsetBI = (int) $text[1][1];
             }
         }
 

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -214,20 +214,6 @@ class PDFObject
             return '';
         }
 
-        // Find all inline image content and replace them so they aren't
-        // affected by the next steps
-        $pdfInlineImages = [];
-        while (preg_match('/\sID\s(.+?)\sEI(?=\s|$)/', $content, $text)) {
-            $id = uniqid('IMAGE_', true);
-            $pdfInlineImages[$id] = $text[1];
-            $content = preg_replace(
-                '/'.preg_quote($text[0], '/').'/',
-                '^^^'.$id.'^^^',
-                $content,
-                1
-            );
-        }
-
         // Outside of (String) content in PDF document streams, all
         // text should conform to UTF-8. Test for binary content by
         // deleting everything after the first open-parenthesis ( which
@@ -266,6 +252,20 @@ class PDFObject
                 // match as a base to find a longer string
                 $attempt = $text[0];
             }
+        }
+
+        // Find all inline image content and replace them so they aren't
+        // affected by the next steps
+        $pdfInlineImages = [];
+        while (preg_match('/\sBI(.+?)\sID\s(.+?)\sEI(?=\s|$)/', $content, $text)) {
+            $id = uniqid('IMAGE_', true);
+            $pdfInlineImages[$id] = [$text[1], $text[2]];
+            $content = preg_replace(
+                '/'.preg_quote($text[0], '/').'/',
+                '^^^'.$id.'^^^',
+                $content,
+                1
+            );
         }
 
         // Remove all carriage returns and line-feeds from the document stream
@@ -317,6 +317,16 @@ class PDFObject
             $content = str_replace('###'.$id.'###', $dict, $content);
         }
 
+        // Restore the original content of any inline images
+        $pdfInlineImages = array_reverse($pdfInlineImages, true);
+        foreach ($pdfInlineImages as $id => $image) {
+            $content = str_replace(
+                '^^^'.$id.'^^^',
+                "\r\nBI\r\n".$image[0]."\r\nID\r\n".$image[1]."\r\nEI\r\n",
+                $content
+            );
+        }
+
         // Restore the original string content
         $pdfstrings = array_reverse($pdfstrings, true);
         foreach ($pdfstrings as $id => $text) {
@@ -331,16 +341,6 @@ class PDFObject
             );
 
             $content = str_replace('@@@'.$id.'@@@', $text, $content);
-        }
-
-        // Restore the original content of any inline images
-        $pdfInlineImages = array_reverse($pdfInlineImages, true);
-        foreach ($pdfInlineImages as $id => $image) {
-            $content = str_replace(
-                '^^^'.$id.'^^^',
-                "\r\nID\r\n".$image."\r\nEI\r\n",
-                $content
-            );
         }
 
         $content = trim(preg_replace(['/(\r\n){2,}/', '/\r\n +/'], "\r\n", $content));

--- a/tests/PHPUnit/Integration/PDFObjectTest.php
+++ b/tests/PHPUnit/Integration/PDFObjectTest.php
@@ -284,12 +284,22 @@ q
 
         // Binary check is done before a regexp that causes an error
         $this->assertStringContainsString('Marko Nestorović PR', $pages[0]->getText());
+    }
 
-        // Check that inline image data does not corrupt the stream
-        // See: https://github.com/smalot/pdfparser/issues/691
+    /**
+     * Check that inline image data does not corrupt the stream
+     *
+     * @see: https://github.com/smalot/pdfparser/issues/691
+     */
+    public function testFormatContentInlineImages(): void
+    {
+        $formatContent = new \ReflectionMethod('Smalot\PdfParser\PDFObject', 'formatContent');
+        $formatContent->setAccessible(true);
+
         $cleaned = $formatContent->invoke(
             $this->getPdfObjectInstance(new Document()),
-            'q 65.30 0 0 18.00 412 707 cm BI /W 544 /H 150 /BPC 1 /IM true /F [/A85 /Fl] ID Gb"0F_$L6!$j/a\$:ma&h\'JnJJ9S?O_EA-W+%D^ClCH=FP3s5M-gStQm\'5/hc`C?<Q)riWgtEe:Po0dY_-er6$jM@#?n`E+#(sa"0Gk3&K>CqL(^pV$_-er6Ik`"-1]Q ;~> EI Q /F002 10.00 Tf 0.00 Tw 0 g'
+            'q 65.30 0 0 18.00 412 707 cm BI /W 544 /H 150
+/BPC 1 /IM true /F [/A85 /Fl] ID Gb"0F_$L6!$j/a\$:ma&h\'JnJJ9S?O_EA-W+%D^ClCH=FP3s5M-gStQm\'5/hc`C?<Q)riWgtEe:Po0dY_-er6$jM@#?n`E+#(sa"0Gk3&K>CqL(^pV$_-er6Ik`"-1]Q ;~> EI Q /F002 10.00 Tf 0.00 Tw 0 g'
         );
 
         // PdfParser should not be fooled by Q's in inline image data;

--- a/tests/PHPUnit/Integration/PDFObjectTest.php
+++ b/tests/PHPUnit/Integration/PDFObjectTest.php
@@ -284,6 +284,19 @@ q
 
         // Binary check is done before a regexp that causes an error
         $this->assertStringContainsString('Marko Nestorović PR', $pages[0]->getText());
+
+        // Check that inline image data does not corrupt the stream
+        // See: https://github.com/smalot/pdfparser/issues/691
+        $cleaned = $formatContent->invoke(
+            $this->getPdfObjectInstance(new Document()),
+            'q 65.30 0 0 18.00 412 707 cm BI /W 544 /H 150 /BPC 1 /IM true /F [/A85 /Fl] ID Gb"0F_$L6!$j/a\$:ma&h\'JnJJ9S?O_EA-W+%D^ClCH=FP3s5M-gStQm\'5/hc`C?<Q)riWgtEe:Po0dY_-er6$jM@#?n`E+#(sa"0Gk3&K>CqL(^pV$_-er6Ik`"-1]Q ;~> EI Q /F002 10.00 Tf 0.00 Tw 0 g'
+        );
+
+        // PdfParser should not be fooled by Q's in inline image data;
+        // Only one 'Q' command should be found
+        $commandQ = preg_match_all('/Q\r\n/', $cleaned);
+
+        $this->assertEquals(1, $commandQ);
     }
 
     public function testGetSectionsText(): void

--- a/tests/PHPUnit/Integration/PDFObjectTest.php
+++ b/tests/PHPUnit/Integration/PDFObjectTest.php
@@ -298,15 +298,29 @@ q
 
         $cleaned = $formatContent->invoke(
             $this->getPdfObjectInstance(new Document()),
-            'q 65.30 0 0 18.00 412 707 cm BI /W 544 /H 150
+            'BT (This BI /W 258 /H 51 /should not trigger /as a /PDF command) TD ET q 65.30 0 0 18.00 412 707 cm BI /W 544 /H 150
 /BPC 1 /IM true /F [/A85 /Fl] ID Gb"0F_$L6!$j/a\$:ma&h\'JnJJ9S?O_EA-W+%D^ClCH=FP3s5M-gStQm\'5/hc`C?<Q)riWgtEe:Po0dY_-er6$jM@#?n`E+#(sa"0Gk3&K>CqL(^pV$_-er6Ik`"-1]Q ;~> EI Q /F002 10.00 Tf 0.00 Tw 0 g'
         );
 
         // PdfParser should not be fooled by Q's in inline image data;
         // Only one 'Q' command should be found
         $commandQ = preg_match_all('/Q\r\n/', $cleaned);
-
         $this->assertEquals(1, $commandQ);
+
+        // The 'BI' inside a string should not be interpreted as the
+        // beginning of an inline image command
+        $this->assertStringContainsString('(This BI /W 258 /H 51 /should not trigger /as a /PDF command) TD', $cleaned);
+
+        $cleaned = $formatContent->invoke(
+            $this->getPdfObjectInstance(new Document()),
+            'BT (This BI /W 258 /H 51 /should not () \) trigger /as a /PDF command) TD (There is no ID inline image in this data) TD (Nothing but text EI should be found) TD ET'
+        );
+
+        $this->assertEquals('BT'."\r\n".
+'(This BI /W 258 /H 51 /should not () \) trigger /as a /PDF command) TD'."\r\n".
+'(There is no ID inline image in this data) TD'."\r\n".
+'(Nothing but text EI should be found) TD'."\r\n".
+'ET', $cleaned);
     }
 
     public function testGetSectionsText(): void


### PR DESCRIPTION
# Type of pull request

* [X] Bug fix (involves code and configuration changes)

# About

`formatContent()` now accounts for inline image `BI ... ID ... EI` commands in document streams. Resolves #691.

# Checklist for code / configuration changes

*In case you changed the code/configuration, please read each of the following checkboxes as they contain valuable information:*

* [X] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well.
* [X] Please run **PHP-CS-Fixer** before committing, to confirm with our coding styles. See https://github.com/smalot/pdfparser/blob/master/.php-cs-fixer.php for more information about our coding styles.
* [X] In case you **fix an existing issue**, please do one of the following:
  * [X] Write in this text something like `fixes #1234` to outline that you are providing a fix for the issue `#1234`.