### PR TITLE
Fix for two bugs related to Unicode translation support by Font objects

### DIFF
--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -191,7 +191,7 @@ class Font extends PDFObject
             // Support for multiple bfchar sections
             if (preg_match_all('/beginbfchar(?P<sections>.*?)endbfchar/s', $content, $matches)) {
                 foreach ($matches['sections'] as $section) {
-                    $regexp = '/<(?P<from>[0-9A-F]+)> +<(?P<to>[0-9A-F]+)>[ \r\n]+/is';
+                    $regexp = '/<(?P<from>[0-9A-F]+)> *<(?P<to>[0-9A-F]+)>[ \r\n]+/is';
 
                     preg_match_all($regexp, $section, $matches);
 

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -56,6 +56,8 @@ class Page extends PDFObject
 
     /**
      * @param array<\Smalot\PdfParser\Font> $fonts
+     *
+     * @internal
      */
     public function setFonts($fonts)
     {

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -54,6 +54,9 @@ class Page extends PDFObject
      */
     protected $dataTm;
 
+    /**
+     * @param array<\Smalot\PdfParser\Font> $fonts
+     */
     public function setFonts($fonts)
     {
         if (empty($this->fonts)) {

--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -54,6 +54,13 @@ class Page extends PDFObject
      */
     protected $dataTm;
 
+    public function setFonts($fonts)
+    {
+        if (empty($this->fonts)) {
+            $this->fonts = $fonts;
+        }
+    }
+
     /**
      * @return Font[]
      */

--- a/src/Smalot/PdfParser/Pages.php
+++ b/src/Smalot/PdfParser/Pages.php
@@ -40,6 +40,11 @@ use Smalot\PdfParser\Element\ElementArray;
 class Pages extends PDFObject
 {
     /**
+     * @var Font[]
+     */
+    protected $fonts;
+
+    /**
      * @todo Objects other than Pages or Page might need to be treated specifically in order to get Page objects out of them,
      *
      * @see https://github.com/smalot/pdfparser/issues/331
@@ -57,6 +62,9 @@ class Pages extends PDFObject
             return $kidsElement->getContent();
         }
 
+        // Prepare to apply the Pages' object's fonts to each page
+        $fonts = $this->getFonts();
+
         $kids = $kidsElement->getContent();
         $pages = [];
 
@@ -64,10 +72,55 @@ class Pages extends PDFObject
             if ($kid instanceof self) {
                 $pages = array_merge($pages, $kid->getPages(true));
             } elseif ($kid instanceof Page) {
+                if (!empty($this->fonts)) {
+                    $kid->setFonts($fonts);
+                }
                 $pages[] = $kid;
             }
         }
 
         return $pages;
+    }
+
+    /**
+     * @return Font[]
+     */
+    public function getFonts()
+    {
+        if (null !== $this->fonts) {
+            return $this->fonts;
+        }
+
+        $resources = $this->get('Resources');
+
+        if (method_exists($resources, 'has') && $resources->has('Font')) {
+            if ($resources->get('Font') instanceof ElementMissing) {
+                return [];
+            }
+
+            if ($resources->get('Font') instanceof Header) {
+                $fonts = $resources->get('Font')->getElements();
+            } else {
+                $fonts = $resources->get('Font')->getHeader()->getElements();
+            }
+
+            $table = [];
+
+            foreach ($fonts as $id => $font) {
+                if ($font instanceof Font) {
+                    $table[$id] = $font;
+
+                    // Store too on cleaned id value (only numeric)
+                    $id = preg_replace('/[^0-9\.\-_]/', '', $id);
+                    if ('' != $id) {
+                        $table[$id] = $font;
+                    }
+                }
+            }
+
+            return $this->fonts = $table;
+        }
+
+        return [];
     }
 }

--- a/src/Smalot/PdfParser/Pages.php
+++ b/src/Smalot/PdfParser/Pages.php
@@ -45,7 +45,8 @@ class Pages extends PDFObject
     protected $fonts;
 
     /**
-     * @todo Objects other than Pages or Page might need to be treated specifically in order to get Page objects out of them,
+     * @todo Objects other than Pages or Page might need to be treated specifically
+     *       in order to get Page objects out of them.
      *
      * @see https://github.com/smalot/pdfparser/issues/331
      */
@@ -89,6 +90,8 @@ class Pages extends PDFObject
      * Gathers information about fonts and collects them in a list.
      *
      * @return void
+     *
+     * @internal
      */
     protected function setupFonts()
     {

--- a/src/Smalot/PdfParser/Pages.php
+++ b/src/Smalot/PdfParser/Pages.php
@@ -85,7 +85,7 @@ class Pages extends PDFObject
     /**
      * @return Font[]
      */
-    public function getFonts()
+    protected function getFonts()
     {
         if (null !== $this->fonts) {
             return $this->fonts;

--- a/src/Smalot/PdfParser/Pages.php
+++ b/src/Smalot/PdfParser/Pages.php
@@ -94,7 +94,7 @@ class Pages extends PDFObject
         $resources = $this->get('Resources');
 
         if (method_exists($resources, 'has') && $resources->has('Font')) {
-            if ($resources->get('Font') instanceof ElementMissing) {
+            if ($resources->get('Font') instanceof Element\ElementMissing) {
                 return [];
             }
 

--- a/src/Smalot/PdfParser/Pages.php
+++ b/src/Smalot/PdfParser/Pages.php
@@ -42,7 +42,7 @@ class Pages extends PDFObject
     /**
      * @var array<\Smalot\PdfParser\Font>|null
      */
-    protected $fonts;
+    protected $fonts = null;
 
     /**
      * @todo Objects other than Pages or Page might need to be treated specifically in order to get Page objects out of them,

--- a/src/Smalot/PdfParser/Pages.php
+++ b/src/Smalot/PdfParser/Pages.php
@@ -42,7 +42,7 @@ class Pages extends PDFObject
     /**
      * @var array<\Smalot\PdfParser\Font>|null
      */
-    protected $fonts = null;
+    protected $fonts;
 
     /**
      * @todo Objects other than Pages or Page might need to be treated specifically in order to get Page objects out of them,

--- a/tests/PHPUnit/Integration/PagesTest.php
+++ b/tests/PHPUnit/Integration/PagesTest.php
@@ -118,8 +118,8 @@ class PagesTest extends TestCase
     {
         $document = $this->createMock(Document::class);
 
-        // create a Page mock and tell PHPUnit that its setFonts has to be called once
-        // otherwise an error is raised
+        // Setup an empty Page instance and insert a Font instance.
+        // We wanna see later on, if $font2 is overwritten by $font1.
         $font2 = new Font($document);
         $page1 = new Page($document);
         $page1->setFonts([$font2]);

--- a/tests/PHPUnit/Integration/PagesTest.php
+++ b/tests/PHPUnit/Integration/PagesTest.php
@@ -45,6 +45,9 @@ use Smalot\PdfParser\Pages;
 class PagesDummy extends Pages
 {
     /**
+     * The purpose of this function is to bypass the tedious
+     * work to setup instances which lead to a valid $fonts variable.
+     *
      * @param array<\Smalot\PdfParser\Font> $fonts
      *
      * @return void
@@ -60,13 +63,20 @@ class PagesTest extends TestCase
     /**
      * If fonts are not stored in Page instances but in the Pages instance.
      *
+     *      Pages
+     *        |   `--- Font[]
+     *        |
+     *        |
+     *        `--+ Page1 (no fonts)
+     *        `--+ ...
+     *
      * @see https://github.com/smalot/pdfparser/pull/698
      */
     public function testPullRequest698NoFontsSet(): void
     {
         $document = $this->createMock(Document::class);
 
-        // create a Page mock and tell PHPUnit that its setFonts has to be called once
+        // Create a Page mock and tell PHPUnit that its setFonts has to be called once
         // otherwise an error is raised
         $page1 = $this->createMock(Page::class);
         $page1->expects($this->once())->method('setFonts');
@@ -80,15 +90,26 @@ class PagesTest extends TestCase
 
         $font1 = $this->createMock(Font::class);
 
+        // Preset fonts variable so we don't have to prepare all the
+        // prerequisites manually (like creating a Ressources instance
+        // with Font instances, see Pages::setupFonts())
         $pages = new PagesDummy($document, $header);
         $pages->setFonts([$font1]);
 
-        // we expect setFonts is called on $page1
+        // We expect setFonts is called on $page1, therefore no assertion here
         $pages->getPages(true);
     }
 
     /**
-     * Dont override fonts list in Page, if available.
+     * Dont override fonts list in a Page instance, if available.
+     *
+     *      Pages
+     *        |   `--- Font[]           <=== less important than fonts in Page instance
+     *        |
+     *        |
+     *        `--+ Page1
+     *                  `--- Font[]     <=== must be kept
+     *        `--+ ...
      *
      * @see https://github.com/smalot/pdfparser/pull/698
      */

--- a/tests/PHPUnit/Integration/PagesTest.php
+++ b/tests/PHPUnit/Integration/PagesTest.php
@@ -139,7 +139,7 @@ class PagesTest extends TestCase
         // Trigger setupFonts method in $pages
         $pages->getPages(true);
 
-        // Note: 
+        // Note:
         // $font1 and $font2 are intenionally not both of the same type.
         // One is a mock and the other one a real instance of Font.
         // This way we can simply check the return value of getFonts here.

--- a/tests/PHPUnit/Integration/PagesTest.php
+++ b/tests/PHPUnit/Integration/PagesTest.php
@@ -182,7 +182,7 @@ class PagesTest extends TestCase
         // check if font names are equal
         $this->assertEquals(
             array_keys($fonts),
-            array_keys($fontsToCompareAgainst),
+            array_keys($fontsToCompareAgainst)
         );
     }
 }

--- a/tests/PHPUnit/Integration/PagesTest.php
+++ b/tests/PHPUnit/Integration/PagesTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * @file This file is part of the PdfParser library.
+ *
+ * @author  Konrad Abicht <k.abicht@gmail.com>
+ *
+ * @date    2024-04-19
+ *
+ * @license LGPLv3
+ *
+ * @url     <https://github.com/smalot/pdfparser>
+ *
+ * PdfParser is a pdf library written in PHP, extraction oriented.
+ * Copyright (C) 2017 - Sébastien MALOT <sebastien@malot.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.
+ * If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
+ */
+
+namespace PHPUnitTests\Integration;
+
+use PHPUnitTests\TestCase;
+use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element\ElementArray;
+use Smalot\PdfParser\Font;
+use Smalot\PdfParser\Header;
+use Smalot\PdfParser\Page;
+use Smalot\PdfParser\Pages;
+
+/**
+ * @internal only for test purposes
+ */
+class PagesDummy extends Pages
+{
+    /**
+     * @param array<\Smalot\PdfParser\Font> $fonts
+     *
+     * @return void
+     */
+    public function setFonts($fonts)
+    {
+        $this->fonts = $fonts;
+    }
+}
+
+class PagesTest extends TestCase
+{
+    /**
+     * If fonts are not stored in Page instances but in the Pages instance.
+     *
+     * @see https://github.com/smalot/pdfparser/pull/698
+     */
+    public function testPullRequest698NoFontsSet(): void
+    {
+        $document = $this->createMock(Document::class);
+
+        // create a Page mock and tell PHPUnit that its setFonts has to be called once
+        // otherwise an error is raised
+        $page1 = $this->createMock(Page::class);
+        $page1->expects($this->once())->method('setFonts');
+
+        // setup header
+        $header = new Header([
+            'Kids' => new ElementArray([
+                $page1,
+            ]),
+        ], $document);
+
+        $font1 = $this->createMock(Font::class);
+
+        $pages = new PagesDummy($document, $header);
+        $pages->setFonts([$font1]);
+
+        // we expect setFonts is called on $page1
+        $pages->getPages(true);
+    }
+
+    /**
+     * Dont override fonts list in Page, if available.
+     *
+     * @see https://github.com/smalot/pdfparser/pull/698
+     */
+    public function testPullRequest698DontOverride(): void
+    {
+        $document = $this->createMock(Document::class);
+
+        // create a Page mock and tell PHPUnit that its setFonts has to be called once
+        // otherwise an error is raised
+        $font2 = new Font($document);
+        $page1 = new Page($document);
+        $page1->setFonts([$font2]);
+
+        // setup header
+        $header = new Header([
+            'Kids' => new ElementArray([
+                $page1,
+            ]),
+        ], $document);
+
+        $font1 = $this->createMock(Font::class);
+
+        $pages = new PagesDummy($document, $header);
+        $pages->setFonts([$font1]);
+
+        $pages->getPages(true);
+
+        // note: $font1 and $font2 are intenionally not both of the same type.
+        // one is a mock and the other one a real instance of Font.
+        // this way we can simply check the return value of getFonts here.
+        // if both were one of the other, we had to use a different assertation approach.
+        $this->assertEquals([$font2], $page1->getFonts());
+    }
+}

--- a/tests/PHPUnit/Integration/PagesTest.php
+++ b/tests/PHPUnit/Integration/PagesTest.php
@@ -135,12 +135,14 @@ class PagesTest extends TestCase
         $pages = new PagesDummy($document, $header);
         $pages->setFonts([$font1]);
 
+        // Trigger setupFonts method in $pages
         $pages->getPages(true);
 
-        // note: $font1 and $font2 are intenionally not both of the same type.
-        // one is a mock and the other one a real instance of Font.
-        // this way we can simply check the return value of getFonts here.
-        // if both were one of the other, we had to use a different assertation approach.
+        // Note: 
+        // $font1 and $font2 are intenionally not both of the same type.
+        // One is a mock and the other one a real instance of Font.
+        // This way we can simply check the return value of getFonts here.
+        // If both were one of the other, we had to use a different assertation approach.
         $this->assertEquals([$font2], $page1->getFonts());
     }
 }

--- a/tests/PHPUnit/Integration/PagesTest.php
+++ b/tests/PHPUnit/Integration/PagesTest.php
@@ -64,10 +64,11 @@ class PagesTest extends TestCase
      * If fonts are not stored in Page instances but in the Pages instance.
      *
      *      Pages
-     *        |   `--- Font[]
+     *        |   `--- fonts = Font[]           <=== will be used to override fonts in Page1 ...
      *        |
      *        |
-     *        `--+ Page1 (no fonts)
+     *        `--+ Page1
+     *        |         `--- fonts = null       <=== Will be overwritten with the content of Pages.fonts
      *        `--+ ...
      *
      * @see https://github.com/smalot/pdfparser/pull/698
@@ -104,11 +105,11 @@ class PagesTest extends TestCase
      * Dont override fonts list in a Page instance, if available.
      *
      *      Pages
-     *        |   `--- Font[]           <=== less important than fonts in Page instance
+     *        |   `--- fonts = Font[]           <=== Has to be ignored because fonts in Page1 is set
      *        |
      *        |
      *        `--+ Page1
-     *                  `--- Font[]     <=== must be kept
+     *        |         `--- fonts = Font[]     <=== must not be overwritten
      *        `--+ ...
      *
      * @see https://github.com/smalot/pdfparser/pull/698

--- a/tests/PHPUnit/Integration/PagesTest.php
+++ b/tests/PHPUnit/Integration/PagesTest.php
@@ -38,6 +38,7 @@ use Smalot\PdfParser\Font;
 use Smalot\PdfParser\Header;
 use Smalot\PdfParser\Page;
 use Smalot\PdfParser\Pages;
+use Smalot\PdfParser\Parser;
 
 /**
  * @internal only for test purposes

--- a/tests/PHPUnit/Integration/PagesTest.php
+++ b/tests/PHPUnit/Integration/PagesTest.php
@@ -160,7 +160,7 @@ class PagesTest extends TestCase
 
         // get Pages instance from generated Document instance
         $objectsOfTypePages = $document->getObjectsByType('Pages');
-        $this->assertEquals(1, count($objectsOfTypePages));
+        $this->assertEquals(1, \count($objectsOfTypePages));
 
         $pagesInstance = array_values($objectsOfTypePages)[0];
 


### PR DESCRIPTION
Symptom was that some documents' contents was rendering as a bunch of control characters.  These are the untranslated strings.  This was happening because for two different reasons, these strings weren't being translated \Smalot\PdfParser\Font::decodeContent() in some circumstances.

First fix is to \Smalot\PdfParser\Font::loadTranslateTable():

  - Fixed bug where bfchar sections weren't loaded due to mistake in regexp.
  - It now uses `*` instead of `+` and thus supports translation tables with lines like `<0000><0000>`.  (Required `<0000> <0000>` before.)

Second fix is for documents that attach their Font objects to the Pages object instead of each Page object:

  - \Smalot\PdfParser\Page now has a setFonts() method
  - \Smalot\PdfParser\Pages now declares its $fonts variable
  - \Smalot\PdfParser\Pages::getPages() now applies the object's fonts to each child Page
  - \Smalot\PdfParser\Pages::getFonts() copied from Page class

# Type of pull request

* [x] Bug fix (involves code and configuration changes)

# About

<!-- Please describe with a few words what this pull request is about -->

# Checklist for code / configuration changes

*In case you changed the code/configuration, please read each of the following checkboxes as they contain valuable information:*

* [x] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well. [...]
* [x] Please run **PHP-CS-Fixer** before committing, to confirm with our coding styles. See https://github.com/smalot/pdfparser/blob/master/.php-cs-fixer.php for more information about our coding styles.