### PR TITLE
fix: Return page width and height from document

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -226,7 +226,8 @@ foreach ($pages as $page) {
     $details = $page->getDetails();
     // The page could haven't the Mediabox, then we get this information from document
     if (!isset($details['MediaBox'])) {
-        $details = reset($pdf->getObjectsByType('Pages'))->getHeader()->getDetails();
+        $pages = $pdf->getObjectsByType('Pages');
+        $details = reset($pages)->getHeader()->getDetails();
     }
     $mediaBox[] = [
         'width' => $details['MediaBox'][2],

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -224,6 +224,10 @@ $pages = $pdf->getPages();
 $mediaBox = [];
 foreach ($pages as $page) {
     $details = $page->getDetails();
+    // The page could haven't the Mediabox, then we get this information from document
+    if (!isset($details['MediaBox'])) {
+        $details = reset($pdf->getObjectsByType('Pages'))->getHeader()->getDetails();
+    }
     $mediaBox[] = [
         'width' => $details['MediaBox'][2],
         'height' => $details['MediaBox'][3]

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -224,7 +224,7 @@ $pages = $pdf->getPages();
 $mediaBox = [];
 foreach ($pages as $page) {
     $details = $page->getDetails();
-    // The page could haven't the Mediabox, then we get this information from document
+    // If Mediabox is not set in details of current $page instance, get details from the header instead
     if (!isset($details['MediaBox'])) {
         $pages = $pdf->getObjectsByType('Pages');
         $details = reset($pages)->getHeader()->getDetails();


### PR DESCRIPTION
# Type of pull request

* [ ] Bug fix (involves code and configuration changes)
* [ ] New feature (involves code and configuration changes)
* [x] Documentation update
* [ ] Something else

# About

Some documents could have pages without MediaBox, at this case we need to get the MediaBox from document and not from a specific page.