### PR TITLE
Strengthen check for UTF-8 conformity in formatContent()

### DIFF
--- a/tests/PHPUnit/Integration/PDFObjectTest.php
+++ b/tests/PHPUnit/Integration/PDFObjectTest.php
@@ -284,6 +284,13 @@ q
 
         // Binary check is done before a regexp that causes an error
         $this->assertStringContainsString('Marko Nestorović PR', $pages[0]->getText());
+
+        // mb_check_encoding(..., 'UTF-8') returns true here,
+        // necessitating a test for UTF-8 that's more strict
+        $content = hex2bin('0101010101010101');
+        $cleaned = $formatContent->invoke($this->getPdfObjectInstance(new Document()), $content);
+
+        $this->assertEquals('', $cleaned);
     }
 
     public function testGetSectionsText(): void


### PR DESCRIPTION
# Type of pull request

* [X] Bug fix (involves code and configuration changes)

# About

In some cases a binary string may pass as valid UTF-8 to the `mb_check_encoding(..., 'UTF-8')` function. Use a comprehensive regexp from the W3 group instead to be **certain** we aren't trying to parse binary content in `formatContent()`. In addition to `(strings)`, also check for the beginning of `ID` inline image content sections, which may also contain binary. Resolves #668.

Reference: https://www.w3.org/International/questions/qa-forms-utf-8.en

# Checklist for code / configuration changes

*In case you changed the code/configuration, please read each of the following checkboxes as they contain valuable information:*

* [X] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well.
* [X] Please run **PHP-CS-Fixer** before committing, to confirm with our coding styles. See https://github.com/smalot/pdfparser/blob/master/.php-cs-fixer.php for more information about our coding styles.
* [X] In case you **fix an existing issue**, please do one of the following:
  * [X] Write in this text something like `fixes #1234` to outline that you are providing a fix for the issue `#1234`.