### PR TITLE
Fix for adjacent escaped slashes and escaped parentheses in strings

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -251,9 +251,9 @@ class PDFObject
             // actually occured within a (string) using the following
             // steps:
 
-            // Step 1: Remove any escaped parentheses from the alleged
-            // image characteristics data
-            $para = str_replace(['\\(', '\\)'], '', $text[1][0]);
+            // Step 1: Remove any escaped slashes and parentheses from
+            // the alleged image characteristics data
+            $para = str_replace(['\\\\', '\\(', '\\)'], '', $text[1][0]);
 
             // Step 2: Remove all correctly ordered and balanced
             // parentheses from (strings)
@@ -306,13 +306,16 @@ class PDFObject
         // by the next steps
         $pdfstrings = [];
         $attempt = '(';
-        while (preg_match('/'.preg_quote($attempt, '/').'.*?(?<![^\\\\]\\\\)\)/s', $content, $text)) {
+        while (preg_match('/'.preg_quote($attempt, '/').'.*?\)/s', $content, $text)) {
+            // Remove all escaped slashes and parentheses from the target text
+            $para = str_replace(['\\\\', '\\(', '\\)'], '', $text[0]);
+
             // PDF strings can contain unescaped parentheses as long as
             // they're balanced, so check for balanced parentheses
-            $left = preg_match_all('/(?<![^\\\\]\\\\)\(/', $text[0]);
-            $right = preg_match_all('/(?<![^\\\\]\\\\)\)/', $text[0]);
+            $left = preg_match_all('/\(/', $para);
+            $right = preg_match_all('/\)/', $para);
 
-            if ($left == $right) {
+            if (')' == $para[-1] && $left == $right) {
                 // Replace the string with a unique placeholder
                 $id = uniqid('STRING_', true);
                 $pdfstrings[$id] = $text[0];

--- a/tests/PHPUnit/Integration/PDFObjectTest.php
+++ b/tests/PHPUnit/Integration/PDFObjectTest.php
@@ -291,6 +291,14 @@ q
         $cleaned = $formatContent->invoke($this->getPdfObjectInstance(new Document()), $content);
 
         $this->assertEquals('', $cleaned);
+
+        // Check that escaped slashes and parentheses are accounted for;
+        // formatContent would emit a PHP Warning for "regular expression
+        // is too large" here without fix for Issue #709
+        $content = '(String \\\\\\(string)Tj '.str_repeat('(Test)Tj ', 4500);
+        $cleaned = $formatContent->invoke($this->getPdfObjectInstance(new Document()), $content);
+
+        $this->assertStringContainsString('(String \\\\\\(string)Tj'."\r\n", $cleaned);
     }
 
     /**

--- a/tests/PHPUnit/Integration/PDFObjectTest.php
+++ b/tests/PHPUnit/Integration/PDFObjectTest.php
@@ -291,10 +291,20 @@ q
         $cleaned = $formatContent->invoke($this->getPdfObjectInstance(new Document()), $content);
 
         $this->assertEquals('', $cleaned);
+    }
 
-        // Check that escaped slashes and parentheses are accounted for;
-        // formatContent would emit a PHP Warning for "regular expression
-        // is too large" here without fix for Issue #709
+    /**
+     * Check that escaped slashes and parentheses are accounted for,
+     * formatContent would emit a PHP Warning for "regular expression
+     * is too large" here without fix for issue #709
+     *
+     * @see https://github.com/smalot/pdfparser/issues/709
+     */
+    public function testFormatContentIssue709()
+    {
+        $formatContent = new \ReflectionMethod('Smalot\PdfParser\PDFObject', 'formatContent');
+        $formatContent->setAccessible(true);
+
         $content = '(String \\\\\\(string)Tj '.str_repeat('(Test)Tj ', 4500);
         $cleaned = $formatContent->invoke($this->getPdfObjectInstance(new Document()), $content);
 


### PR DESCRIPTION
# Type of pull request

* [X] Bug fix (involves code and configuration changes)

# About

The current `(string)` replacement regexp in `formatContent()` only backchecked two characters for escaped slashes, so if an escaped slash immediately preceded an escaped parenthesis, the script would incorrectly interpret it as an escaped slash and an unescaped parenthesis. This would lead to the loop never finding the "end" of the string (for an open parenthesis) or finding the end of the string prematurely (for a close parenthesis).

Perform a string replace to get rid of all escaped slashes and then escaped parentheses; they aren't needed when just checking for balanced, unescaped parentheses. Also add removing slashes to the inline images section above for the same reason.

Resolves #709.

# Checklist for code / configuration changes

*In case you changed the code/configuration, please read each of the following checkboxes as they contain valuable information:*

* [X] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well.
* [X] Please run **PHP-CS-Fixer** before committing, to confirm with our coding styles. See https://github.com/smalot/pdfparser/blob/master/.php-cs-fixer.php for more information about our coding styles.
* [X] In case you **fix an existing issue**, please do one of the following:
  * [X] Write in this text something like `fixes #1234` to outline that you are providing a fix for the issue `#1234`.