### PR TITLE
Fix hexadecimal decoding (fixes #715)

### DIFF
--- a/samples/bugs/Issue715.pdf
+++ b/samples/bugs/Issue715.pdf
@@ -4,6 +4,7 @@
 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
 3 0 obj<</Type/Page/MediaBox[0 0 3 3]>>endobj
 4 0 obj<</Type/Sig/Contents<28295C>>>endobj
+5 0 obj<</Producer (x(y))/Creator (a(b))>>endobj
 
 xref
 0 4
@@ -12,9 +13,10 @@ xref
 0000000053 00000 n
 0000000102 00000 n
 0000000148 00000 n
+0000000192 00000 n
 
 trailer
-<</Size 5 /Root 1 0 R>>
+<</Size 5 /Root 1 0 R /Info 5 0 R>>
 startxref
-193
+242
 %%EOF

--- a/samples/bugs/Issue715.pdf
+++ b/samples/bugs/Issue715.pdf
@@ -1,0 +1,20 @@
+%PDF-1.0
+
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 3 3]>>endobj
+4 0 obj<</Type/Sig/Contents<28295C>>>endobj
+
+xref
+0 4
+0000000000 65535 f
+0000000010 00000 n
+0000000053 00000 n
+0000000102 00000 n
+0000000148 00000 n
+
+trailer
+<</Size 5 /Root 1 0 R>>
+startxref
+193
+%%EOF

--- a/src/Smalot/PdfParser/Element/ElementHexa.php
+++ b/src/Smalot/PdfParser/Element/ElementHexa.php
@@ -47,12 +47,11 @@ class ElementHexa extends ElementString
         if (preg_match('/^\s*\<(?P<name>[A-F0-9]+)\>/is', $content, $match)) {
             $name = $match['name'];
             $offset += strpos($content, '<'.$name) + \strlen($name) + 2; // 1 for '>'
-            // repackage string as standard
-            $name = '('.self::decode($name).')';
-            $element = ElementDate::parse($name, $document);
+            $name = self::decode($name);
+            $element = ElementDate::parse('('.$name.')', $document);
 
             if (!$element) {
-                $element = ElementString::parse($name, $document);
+                $element = new self($name);
             }
 
             return $element;

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -296,7 +296,7 @@ class Parser
                 return ElementString::parse('('.$value.')', $document);
 
             case '<':
-                return $this->parseHeaderElement('(', ElementHexa::decode($value), $document);
+                return ElementHexa::parse('<'.$value.'>', $document);
 
             case '/':
                 return ElementName::parse('/'.$value, $document);

--- a/tests/PHPUnit/Integration/Element/ElementHexaTest.php
+++ b/tests/PHPUnit/Integration/Element/ElementHexaTest.php
@@ -130,5 +130,9 @@ class ElementHexaTest extends TestCase
 007000610  073007100750061002c0020> ');
 
         $this->assertEquals('pasqua, primavera, resurrezione, festa cristiana, gesù, uova di cioccolata, coniglietti, pulcini, pasquale, campane, dina rebucci, uova di pasqua, ', $element);
+
+        $testString = '()\\';
+        $element = ElementHexa::parse('<'.bin2hex($testString).'>', null, $offset);
+        $this->assertEquals($testString, (string) $element);
     }
 }

--- a/tests/PHPUnit/Integration/Element/ElementHexaTest.php
+++ b/tests/PHPUnit/Integration/Element/ElementHexaTest.php
@@ -130,7 +130,16 @@ class ElementHexaTest extends TestCase
 007000610  073007100750061002c0020> ');
 
         $this->assertEquals('pasqua, primavera, resurrezione, festa cristiana, gesù, uova di cioccolata, coniglietti, pulcini, pasquale, campane, dina rebucci, uova di pasqua, ', $element);
+    }
 
+    /**
+     * Closing round bracket encoded in hexadecimal format breaks parsing - string is truncated.
+     *
+     * @see https://github.com/smalot/pdfparser/issues/715
+     */
+    public function testIssue715(): void
+    {
+        $offset = 0;
         $testString = '()\\';
         $element = ElementHexa::parse('<'.bin2hex($testString).'>', null, $offset);
         $this->assertEquals($testString, (string) $element);

--- a/tests/PHPUnit/Integration/Element/ElementStringTest.php
+++ b/tests/PHPUnit/Integration/Element/ElementStringTest.php
@@ -131,6 +131,9 @@ class ElementStringTest extends TestCase
         $element = ElementString::parse('(Gutter\\ console\\ assembly)', null, $offset);
         $this->assertEquals('Gutter console assembly', $element->getContent());
         $this->assertEquals(27, $offset);
+
+        $element = ElementString::parse('(())');
+        $this->assertEquals('()', $element->getContent());
     }
 
     public function testGetContent(): void

--- a/tests/PHPUnit/Integration/Element/ElementStringTest.php
+++ b/tests/PHPUnit/Integration/Element/ElementStringTest.php
@@ -140,6 +140,29 @@ class ElementStringTest extends TestCase
     {
         $element = ElementString::parse('(())');
         $this->assertEquals('()', $element->getContent());
+
+        // source: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf
+        // page 54
+        $string = '(Strings may contain balanced parentheses ( ) and
+special characters (*!&}^% and so on).)';
+        $element = ElementString::parse($string);
+        $this->assertEquals('Strings may contain balanced parentheses ( ) and
+special characters (*!&}^% and so on).', $element->getContent());
+
+        // source: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf
+        // page 55
+        $string = '( This string has an end−of−line at the end of it.
+)';
+        $element = ElementString::parse($string);
+        $this->assertEquals(' This string has an end−of−line at the end of it.'.\PHP_EOL, $element->getContent());
+
+        // source: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf
+        // page 55
+        $string = '( These \
+two strings \
+are the same.)';
+        $element = ElementString::parse($string);
+        $this->assertEquals(' These two strings are the same.', $element->getContent());
     }
 
     public function testGetContent(): void

--- a/tests/PHPUnit/Integration/Element/ElementStringTest.php
+++ b/tests/PHPUnit/Integration/Element/ElementStringTest.php
@@ -131,7 +131,13 @@ class ElementStringTest extends TestCase
         $element = ElementString::parse('(Gutter\\ console\\ assembly)', null, $offset);
         $this->assertEquals('Gutter console assembly', $element->getContent());
         $this->assertEquals(27, $offset);
+    }
 
+    /**
+     * @see https://github.com/smalot/pdfparser/issues/715
+     */
+    public function testParseIssue715(): void
+    {
         $element = ElementString::parse('(())');
         $this->assertEquals('()', $element->getContent());
     }

--- a/tests/PHPUnit/Integration/ParserTest.php
+++ b/tests/PHPUnit/Integration/ParserTest.php
@@ -441,19 +441,20 @@ class ParserTest extends TestCase
 
     /**
      * Tests special chars encoded as hex.
+     *
+     * @see https://github.com/smalot/pdfparser/issues/715
      */
-    public function testSpecialCharsEncodedAsHex(): void
+    public function testIssue715SpecialCharsEncodedAsHex(): void
     {
         $filename = $this->rootDir.'/samples/bugs/Issue715.pdf';
 
         $this->fixture = new Parser();
         $document = $this->fixture->parseFile($filename);
         $sigObject = $document->getObjectsByType('Sig');
-        $result = null;
-        if (isset($sigObject['4_0'])) {
-            $result = (string) $sigObject['4_0']->getHeader()->get('Contents');
-        }
-        $this->assertEquals('()\\', $result);
+
+        $this->assertTrue(isset($sigObject['4_0']));
+        $this->assertEquals('()\\', (string) $sigObject['4_0']->getHeader()->get('Contents'));
+
         $details = $document->getDetails();
         $this->assertEquals('x(y)', $details['Producer'] ?? null);
         $this->assertEquals('a(b)', $details['Creator'] ?? null);

--- a/tests/PHPUnit/Integration/ParserTest.php
+++ b/tests/PHPUnit/Integration/ParserTest.php
@@ -449,8 +449,10 @@ class ParserTest extends TestCase
         $this->fixture = new Parser();
         $document = $this->fixture->parseFile($filename);
         $result = (string) ($document->getObjectsByType('Sig')['4_0'] ?? null)?->getHeader()->get('Contents');
-
         $this->assertEquals('()\\', $result);
+        $details = $document->getDetails();
+        $this->assertEquals('x(y)', $details['Producer'] ?? null);
+        $this->assertEquals('a(b)', $details['Creator'] ?? null);
     }
 }
 

--- a/tests/PHPUnit/Integration/ParserTest.php
+++ b/tests/PHPUnit/Integration/ParserTest.php
@@ -438,6 +438,20 @@ class ParserTest extends TestCase
 
         // without the configuration option set, an exception would be thrown.
     }
+
+    /**
+     * Tests special chars encoded as hex.
+     */
+    public function testSpecialCharsEncodedAsHex(): void
+    {
+        $filename = $this->rootDir.'/samples/bugs/Issue715.pdf';
+
+        $this->fixture = new Parser();
+        $document = $this->fixture->parseFile($filename);
+        $result = (string) ($document->getObjectsByType('Sig')['4_0'] ?? null)?->getHeader()->get('Contents');
+
+        $this->assertEquals('()\\', $result);
+    }
 }
 
 class ParserSub extends Parser

--- a/tests/PHPUnit/Integration/ParserTest.php
+++ b/tests/PHPUnit/Integration/ParserTest.php
@@ -448,7 +448,11 @@ class ParserTest extends TestCase
 
         $this->fixture = new Parser();
         $document = $this->fixture->parseFile($filename);
-        $result = (string) ($document->getObjectsByType('Sig')['4_0'] ?? null)?->getHeader()->get('Contents');
+        $sigObject = $document->getObjectsByType('Sig');
+        $result = null;
+        if (isset($sigObject['4_0'])) {
+            $result = (string) $sigObject['4_0']->getHeader()->get('Contents');
+        }
         $this->assertEquals('()\\', $result);
         $details = $document->getDetails();
         $this->assertEquals('x(y)', $details['Producer'] ?? null);


### PR DESCRIPTION
# Type of pull request

* [X] Bug fix (involves code and configuration changes)

# About

Fix for #715 as requested by @k00ni. Tests are passing but I am not confident that this will not break pdfparser because I lack knowledge of internal work of library and PDF format.