### PR TITLE
Continuous-integration.yml: let workflow run on each push event

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,8 +3,6 @@ name: "CI"
 on:
   pull_request:
   push:
-    branches:
-      - master
 
 env:
   fail-fast: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,8 +1,6 @@
 name: "CI"
 
-on:
-  pull_request:
-  push:
+on: [push, pull_request]
 
 env:
   fail-fast: true


### PR DESCRIPTION
# Type of pull request

* [x] Something else

# About

Our current CI workflow only runs when a commit was pushed to the master branch or in a PR. This change lets it run every time something was committed, regardless which branch was used. It also allows us to create side branches and test things online, eliminating the need to do that locally. Before the change, CI workflow didn't trigger when a commit was added to a side-branch.