### PR TITLE
Merge XMP Metadata if dc:format tag not found

### DIFF
--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -287,7 +287,7 @@ class Document
             }
 
             // Only use this metadata if it's referring to a PDF
-            if (isset($metadata['dc:format']) && 'application/pdf' == $metadata['dc:format']) {
+            if (!isset($metadata['dc:format']) || 'application/pdf' == $metadata['dc:format']) {
                 // According to the XMP specifications: 'Conflict resolution
                 // for separate packets that describe the same resource is
                 // beyond the scope of this document.' - Section 6.1

--- a/tests/PHPUnit/Integration/DocumentTest.php
+++ b/tests/PHPUnit/Integration/DocumentTest.php
@@ -232,4 +232,35 @@ class DocumentTest extends TestCase
         $document = $this->getDocumentInstance();
         $document->getPages();
     }
+
+    public function testExtractXMPMetadata(): void
+    {
+        $document = $this->getDocumentInstance();
+
+        // Check that XMP metadata is parsed even if missing a
+        // dc:format tag
+        // See: https://github.com/smalot/pdfparser/issues/721
+        $content = '<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c015 84.159810, 2016/09/10-02:41:30">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description>
+         <dc:creator>
+            <rdf:Seq>
+               <rdf:li>PdfParser</rdf:li>
+            </rdf:Seq>
+         </dc:creator>
+         <xmp:CreateDate>2018-02-07T11:51:44-05:00</xmp:CreateDate>
+         <xmp:ModifyDate>2019-10-23T09:56:01-04:00</xmp:ModifyDate>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>';
+
+        $document->extractXMPMetadata($content);
+        $document->init();
+        $details = $document->getDetails();
+
+        $this->assertEquals(4, \count($details));
+        $this->assertEquals('PdfParser', $details['dc:creator']);
+        $this->assertEquals('2019-10-23T09:56:01-04:00', $details['xmp:modifydate']);
+    }
 }

--- a/tests/PHPUnit/Integration/DocumentTest.php
+++ b/tests/PHPUnit/Integration/DocumentTest.php
@@ -233,13 +233,14 @@ class DocumentTest extends TestCase
         $document->getPages();
     }
 
-    public function testExtractXMPMetadata(): void
+    /**
+     * @see https://github.com/smalot/pdfparser/issues/721
+     */
+    public function testExtractXMPMetadataIssue721(): void
     {
         $document = $this->getDocumentInstance();
 
-        // Check that XMP metadata is parsed even if missing a
-        // dc:format tag
-        // See: https://github.com/smalot/pdfparser/issues/721
+        // Check that XMP metadata is parsed even if missing a dc:format tag
         $content = '<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
 <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c015 84.159810, 2016/09/10-02:41:30">
    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">


### PR DESCRIPTION
# Type of pull request

* [X] Bug fix (involves code and configuration changes)

# About

Previously `extractXMPMetadata()` would check for the existence of a `dc:format` tag with an `application/pdf` MIME-type value before allowing found XMP metadata to be merged with the other document details.

If the tag doesn't exist, merge the metadata anyway. If it _does_ exist, only _then_ check to see if it has the `application/pdf` MIME-type. Resolves #721.

# Checklist for code / configuration changes

*In case you changed the code/configuration, please read each of the following checkboxes as they contain valuable information:*

* [X] Please add at least **one test case** (unit test, system test, ...) to demonstrate that the change is working. If existing code was changed, your tests cover these code parts as well.
* [X] Please run **PHP-CS-Fixer** before committing, to confirm with our coding styles. See https://github.com/smalot/pdfparser/blob/master/.php-cs-fixer.php for more information about our coding styles.
* [X] In case you **fix an existing issue**, please do one of the following:
  * [X] Write in this text something like `fixes #1234` to outline that you are providing a fix for the issue `#1234`.
