### PR TITLE
Simplified Coding Style checks: PSR12 replaces Symfony, risky not allowed anymore

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -14,10 +14,8 @@ $finder = Finder::create()
 $config = new Config();
 $config
     ->setFinder($finder)
-    ->setRiskyAllowed(true)
     ->setRules([
-        '@Symfony' => true,
-        '@Symfony:risky' => true,
+        '@PSR12' => true,
         'array_syntax' => ['syntax' => 'short'],
         'no_empty_phpdoc' => true,
         'no_unused_imports' => true,

--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -255,7 +255,7 @@ class Document
                             if ('rdf:li' == $val['tag']) {
                                 $metadata[] = $val['value'];
 
-                            // Else assign a value to this property
+                                // Else assign a value to this property
                             } else {
                                 $metadata[$val['tag']] = $val['value'];
                             }

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -451,7 +451,7 @@ class PDFObject
                 $inTextBlock = true;
                 $sections[] = $line;
 
-            // If an 'ET' is encountered, unset the $inTextBlock flag
+                // If an 'ET' is encountered, unset the $inTextBlock flag
             } elseif ('ET' == $line) {
                 $inTextBlock = false;
                 $sections[] = $line;

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -267,7 +267,8 @@ class RawDataParser
             if (
                 ('/' == $v[0])
                 && ('Type' == $v[1])
-                && (isset($sarr[$k + 1])
+                && (
+                    isset($sarr[$k + 1])
                     && '/' == $sarr[$k + 1][0]
                     && 'XRef' == $sarr[$k + 1][1]
                 )
@@ -293,7 +294,8 @@ class RawDataParser
                     if (
                         '/' == $vdc[0]
                         && 'Columns' == $vdc[1]
-                        && (isset($decpar[$kdc + 1])
+                        && (
+                            isset($decpar[$kdc + 1])
                             && 'numeric' == $decpar[$kdc + 1][0]
                         )
                     ) {
@@ -301,7 +303,8 @@ class RawDataParser
                     } elseif (
                         '/' == $vdc[0]
                         && 'Predictor' == $vdc[1]
-                        && (isset($decpar[$kdc + 1])
+                        && (
+                            isset($decpar[$kdc + 1])
                             && 'numeric' == $decpar[$kdc + 1][0]
                         )
                     ) {
@@ -407,7 +410,7 @@ class RawDataParser
                     }
                     $prev_row = $ddata[$k];
                 } // end for each row
-            // complete decoding
+                // complete decoding
             } else {
                 // number of bytes in a row
                 $rowlen = array_sum($wb);


### PR DESCRIPTION
# Type of pull request

* [x] Something else

# About

Coding style checks are a pain in the butt for a while and are interfering with new pull requests frequently. Recent changes even lead to syntax errors because they are not compatible with older PHP versions ([example](https://github.com/smalot/pdfparser/actions/runs/11046573037/job/30686157896?pr=723)). Investing the time to keep the code up to date with them isn't worth it (at least to me). With this PR a stable and not-ever-changing coding style set is used (`PSR12`). Its also a standard and well documented (https://www.php-fig.org/psr/psr-12/). I hope this eliminates or at least reduces the number of coding style errors in the future while at the same time guarantees some level of consistent coding styles.