### PR TITLE
chore: update phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false" displayDetailsOnTestsThatTriggerWarnings="true">
-  <coverage>
-    <include>
-      <directory>src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false" displayDetailsOnTestsThatTriggerWarnings="true">
   <php>
     <ini name="error_reporting" value="-1"/>
     <ini name="zend.enable_gc" value="0"/>
@@ -18,4 +13,9 @@
       <directory>tests/PHPUnit</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
At newest version of PHPUnit the xml file was changed and the old format started to return a deprecation error.

To solve this was executed the phpunit with the option `--display-phpunit-deprecations`

# Type of pull request

* [x] Bug fix (involves code and configuration changes)
* [ ] New feature (involves code and configuration changes)
* [ ] Documentation update
* [ ] Something else

# About

<!-- Please describe with a few words what this pull request is about -->

# Checklist for code / configuration changes

See [CONTRIBUTING.md] for all essential information about contributing.
