### PR TITLE
chore: update documentation

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -228,11 +228,22 @@ foreach ($pages as $page) {
     if (!isset($details['MediaBox'])) {
         $pages = $pdf->getObjectsByType('Pages');
         $details = reset($pages)->getHeader()->getDetails();
+        if (!isset($details['MediaBox'])) {
+            $objects = $page->getXObjects();
+            if (isset($objects[0])) {
+                $details = $objects[0]->getHeader()->getDetails();
+                if (isset($details['BBox'])) {
+                    $details['MediaBox'] = $details['BBox'];
+                }
+            }
+        }
     }
-    $mediaBox[] = [
-        'width' => $details['MediaBox'][2],
-        'height' => $details['MediaBox'][3]
-    ];
+    if (isset($details['MediaBox'])) {
+        $mediaBox[] = [
+            'width' => $details['MediaBox'][2],
+            'height' => $details['MediaBox'][3]
+        ];
+    }
 }
 ```
 


### PR DESCRIPTION
Follow up of issue #427 using the suggested code at issue #472.

Notes:
Have PDF files that the pdfparser can't get the MediaBox, as fallback to get the page dimension is possible to use the BBox (Bounding Box).

The Bounding Box could not have the real dimension of a page put is a solution to have a value that could be the page dimension at cases that isn't possible to found the MediaBox.

# Type of pull request

* [ ] Bug fix (involves code and configuration changes)
* [ ] New feature (involves code and configuration changes)
* [x] Documentation update
* [ ] Something else

# About

<!-- Please describe with a few words what this pull request is about -->

# Checklist for code / configuration changes

See [CONTRIBUTING.md] for all essential information about contributing.
