### PR TITLE
Bugfix for "Unable to find startxref" exception

### DIFF
--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -883,7 +883,7 @@ class RawDataParser
 
         // Find all startxref tables from this $offset forward
         $startxrefPreg = preg_match_all(
-            '/(?<=[\r\n])startxref(?:[\s]*[\r\n]+|\s+)([0-9]+)[\s]*[\r\n]+%%EOF/i',
+            '/(?<=[\r\n])startxref(?:[\s]*[\r\n]+[\s]*|\s+)([0-9]+)[\s]*[\r\n]+%%EOF/i',
             $pdfData,
             $startxrefMatches,
             \PREG_SET_ORDER,

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -883,7 +883,7 @@ class RawDataParser
 
         // Find all startxref tables from this $offset forward
         $startxrefPreg = preg_match_all(
-            '/(?<=[\r\n])startxref[\s]*[\r\n]+([0-9]+)[\s]*[\r\n]+%%EOF/i',
+            '/(?<=[\r\n])startxref(?:[\s]*[\r\n]+|\s+)([0-9]+)[\s]*[\r\n]+%%EOF/i',
             $pdfData,
             $startxrefMatches,
             \PREG_SET_ORDER,


### PR DESCRIPTION
# Type of pull request

* [Y] Bug fix (involves code and configuration changes)
* [ ] New feature (involves code and configuration changes)
* [ ] Documentation update
* [ ] Something else

# About

Addresses inadequacies in handling startxref statement before EOF marker. 

Currently, getXrefData() uses a regex that requires a newline before the offset value.

This fix allows:

- space before the reference offset.
- keyword and offset on the same line (e.g. containing "startxref 1746580").

For more detail see #756 

# TO DO

- tests 
- example files