### PR TITLE
Update PDFObject.php

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -526,6 +526,9 @@ class PDFObject
      */
     private function getTJUsingFontFallback(Font $font, array $command, ?Page $page = null, float $fontFactor = 4): string
     {
+        if (!$font) {
+            return '';
+        }
         $orig_text = $font->decodeText($command, $fontFactor);
         $text = $orig_text;
 


### PR DESCRIPTION
# Type of pull request

[ * ] Bug fix (involves code and configuration changes)


# About

A small number of abnormal PDFs return an empty result when calling the getDefaultFont() method. Therefore, either modify the getDefaultFont() method or check the input before entering the getTJUsingFontFallback() method to prevent the program from crashing due to errors when reaching the $font->decodeText() line. 
小部分异常PDF，调用getDefaultFont()方法返回为空，所以要么去修改getDefaultFont()，要么在进入getTJUsingFontFallback()方法先判错，防止运行到$font->decodeText()报错卡死。

