### PR TITLE
Stop Image XObjects being included as empty strings in PDFObject::getTextArray().

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -775,16 +775,27 @@ class PDFObject
                         break;
 
                     case 'Do':
-                        if (null !== $page) {
-                            $args = preg_split('/\s/s', $command[self::COMMAND]);
-                            $id = trim(array_pop($args), '/ ');
-                            $xobject = $page->getXObject($id);
+                        if (is_null($page)) {
+                          break;
+                        }
 
-                            // @todo $xobject could be a ElementXRef object, which would then throw an error
-                            if (\is_object($xobject) && $xobject instanceof self && !\in_array($xobject->getUniqueId(), self::$recursionStack, true)) {
-                                // Not a circular reference.
-                                $text[] = $xobject->getText($page);
-                            }
+                        $args = preg_split('/\s/s', $command[self::COMMAND]);
+                        $id = trim(array_pop($args), '/ ');
+                        $xobject = $page->getXObject($id);
+
+                        // Check we got a PDFObject back.
+                        if (!$xobject instanceof self) {
+                          break;
+                        }
+
+                        // If the PDFObject is an image, do nothing, as images aren't text.
+                        if ($xobject instanceof Image) {
+                          break;
+                        }
+
+                        // Check this is not a circular reference.
+                        if (!\in_array($xobject->getUniqueId(), self::$recursionStack, true)) {
+                            $text[] = $xobject->getText($page);
                         }
                         break;
 


### PR DESCRIPTION
Fix for #733 and #767.

This PR stops Image XObjects being included in the results of PDFObject:: getTextArray() as empty strings.