### PR TITLE
Add case for 'endobj' in PDF parsing

### DIFF
--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -320,6 +320,7 @@ class Parser
 
             case 'endstream':
             case 'obj': // I don't know what it means but got my project fixed.
+            case 'endobj': // I don't know what this means either, but it is found in some PDF documents I tried to parse.
             case '':
                 // Nothing to do with.
                 return null;


### PR DESCRIPTION
Fixes an issue with parsing some PDF documents which contain this instruction. I have no idea what it means.

# Type of pull request

* [x] Bug fix (involves code and configuration changes)
* [ ] New feature (involves code and configuration changes)
* [ ] Documentation update
* [ ] Something else

# About

I am working on parsing a HUGE library of PDF files and some of those files contain an `endobj` header element
which isn't handled by the parser, and this results in an exception. The files do parse correctly if this header
element is simply ignored. It doesn't seem to have any practical use.

# Checklist for code / configuration changes

See [CONTRIBUTING.md](./../CONTRIBUTING.md) for all essential information about contributing.
