### PR TITLE
Fix memory exhaustion caused by circular references in PDF xref chains

### DIFF
--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -880,7 +880,7 @@ class RawDataParser
             // We've already processed this offset, skip to avoid infinite loop
             return $xref;
         }
-        
+
         // Track this offset as visited
         $visitedOffsets[] = $offset;
         // If the $offset is currently pointed at whitespace, bump it

--- a/tests/PHPUnit/Integration/RawData/RawDataParserTest.php
+++ b/tests/PHPUnit/Integration/RawData/RawDataParserTest.php
@@ -310,7 +310,7 @@ class RawDataParserTest extends TestCase
 
         // Call with offset 50 already in visitedOffsets - should return immediately
         $result = $this->fixture->exposeGetXrefData($pdfData, 50, [], [50]);
-        
+
         // Should return empty array without processing
         $this->assertIsArray($result);
         $this->assertEmpty($result);


### PR DESCRIPTION
# Type of pull request

* [x] Bug fix (involves code and configuration changes)

# About

This PR fixes xref-handling when it comes to circular references. A malformed PDF can lead to memory exhaustion because PDFParser enters an endless loop at some point. These fixes should prevent that.

It allows me to work with a bunch of "broken" PDFs, but I might have overlook some things. It would be great if someone else could have a look. Any feedback is appreciated (maybe @GreyWyvern @j0k3r?) :rocket:
