### PR TITLE
Fix chr() deprecation in ASCII85 last-tuple decoding

### DIFF
--- a/samples/bugs/PullRequest793.pdf
+++ b/samples/bugs/PullRequest793.pdf
@@ -1,0 +1,34 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]
+   /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Filter /ASCII85Decode /Length 81 >>
+stream
+6<#'\7PQ#?1*BP.+>khq2_Zp.<+I+"5uU-B8N8RMCghC,/Tc,SCh4`-G%G]+Ci=M?FCfN8.3MT)+@T6~>
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000250 00000 n 
+0000000404 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/src/Smalot/PdfParser/RawData/FilterHelper.php
+++ b/src/Smalot/PdfParser/RawData/FilterHelper.php
@@ -209,7 +209,7 @@ class FilterHelper
                     if (255 < $tuple >> 24) {
                         $chr24Part = \chr(($tuple >> 24) % 256);
                     } else {
-                        $chr24Part = \chr($tuple >> 24);
+                        $chr24Part = \chr(($tuple >> 24) & 0xFF);
                     }
 
                     if (255 < $tuple) {
@@ -232,15 +232,15 @@ class FilterHelper
         // last tuple (if any)
         switch ($group_pos) {
             case 4:
-                $decoded .= \chr($tuple >> 24).\chr($tuple >> 16).\chr($tuple >> 8);
+                $decoded .= \chr(($tuple >> 24) & 0xFF).\chr(($tuple >> 16) & 0xFF).\chr(($tuple >> 8) & 0xFF);
                 break;
 
             case 3:
-                $decoded .= \chr($tuple >> 24).\chr($tuple >> 16);
+                $decoded .= \chr(($tuple >> 24) & 0xFF).\chr(($tuple >> 16) & 0xFF);
                 break;
 
             case 2:
-                $decoded .= \chr($tuple >> 24);
+                $decoded .= \chr(($tuple >> 24) & 0xFF);
                 break;
 
             case 1:

--- a/tests/PHPUnit/Integration/ParserTest.php
+++ b/tests/PHPUnit/Integration/ParserTest.php
@@ -438,6 +438,18 @@ class ParserTest extends TestCase
 
         // without the configuration option set, an exception would be thrown.
     }
+
+    /**
+     * Tests a fix for chr() which threw deprecations when running PHP 8.5
+     *
+     * @see https://github.com/smalot/pdfparser/pull/793
+     */
+    public function testPullRequest793ChrDeprecationFix(): void
+    {
+        $document = (new Parser())->parseFile($this->rootDir.'/samples/bugs/PullRequest793.pdf');
+
+        $this->assertEquals('ASCII85 last-tuple overflow test', $document->getText());
+    }
 }
 
 class ParserSub extends Parser


### PR DESCRIPTION
## Problem

PR #779 fixed the `chr()` deprecation warning in the main ASCII85 decoding loop but missed the **"last tuple" switch/case block** (handling incomplete groups at the end of encoded data).

The same issue applies — bit-shifted values (`$tuple >> 16`, `$tuple >> 8`) can exceed 255, triggering:

```
chr(): Providing a value not in-between 0 and 255 is deprecated, this is because a byte value must be in the [0, 255] interval.
```

Observed in production when parsing PDFs with ASCII85-encoded streams that have a partial trailing group.

## Fix

Apply `& 0xFF` bitmask to extract individual bytes before passing to `chr()`, consistent with the approach used in the main loop fix from #779.

`& 0xFF` is the standard bitwise idiom for extracting a single byte from a multi-byte integer (equivalent to `% 256` but more idiomatic).

## Changes

```php
// Before
$decoded .= \chr($tuple >> 24).\chr($tuple >> 16).\chr($tuple >> 8);

// After
$decoded .= \chr(($tuple >> 24) & 0xFF).\chr(($tuple >> 16) & 0xFF).\chr(($tuple >> 8) & 0xFF);
```

Same pattern applied to `case 3` and `case 2`.