### PR TITLE
fix: recover PDFs without a valid startxref stanza

### DIFF
--- a/samples/bugs/PullRequest809-pdf.js.pdf
+++ b/samples/bugs/PullRequest809-pdf.js.pdf
@@ -1,0 +1,90 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Outlines 2 0 R
+ /Pages 3 0 R
+>>
+endobj
+2 0 obj
+<<
+ /Type /Outlines
+ /Count 0
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /MediaBox [ 0 0 500 300 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet [ /PDF /Text ]
+  /XObject << /X1 6 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 24 >>
+stream
+1 0 0 1 25 25 cm /X1 Do
+endstream
+endobj
+6 0 obj
+<< /Subtype /Form
+   /BBox [0 0 1000 1000]
+   /Length 61
+   /Resources <<
+     /ProcSet [ /PDF /Text ]
+     /Font << /F1 7 0 R >>
+     /XObject << /X0 8 0 R >>
+   >>
+>>
+stream
+BT
+/F1 24 Tf
+(Hello world) Tj
+ET
+0.5 0 0 0.5 25 25 cm /X0 Do
+endstream
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+8 0 obj
+<< /Subtype /Form
+   /BBox [0 0 1000 1000]
+   /Length 61
+   /Resources <<
+     /ProcSet [ /PDF /Text ]
+     /Font << /F1 7 0 R >>
+     /XObject << /X1 6 0 R >>
+   >>
+>>
+stream
+BT
+/F1 24 Tf
+(Hello world) Tj
+ET
+0.5 0 0 0.5 25 25 cm /X1 Do
+endstream
+endobj
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -902,15 +902,34 @@ class RawDataParser
         );
 
         if (0 == $startxrefPreg) {
-            // No startxref tables were found
-            throw new \Exception('Unable to find startxref');
+            $xrefSubsectionAtOffset = preg_match(
+                '/[0-9]+[\x20]+[0-9]+[\x20]*[\r\n]/A',
+                substr($pdfData, $bumpOffset, 48)
+            ) > 0;
+
+            if (strpos($pdfData, 'xref', $bumpOffset) === $bumpOffset || $xrefSubsectionAtOffset) {
+                // No startxref stanza, but caller already points to an xref table/subsection.
+                $startxref = $bumpOffset;
+            } elseif (preg_match('/^[0-9]+[\s]+[0-9]+[\s]+obj/i', substr($pdfData, $bumpOffset, 32)) > 0) {
+                // No startxref stanza, but caller points to an xref stream object.
+                $startxref = $bumpOffset;
+            } else {
+                // No valid startxref table was found. Try to recover from nearby xref data
+                // or reconstruct a minimal xref from object headers plus trailer metadata.
+                $recoveredXref = $this->recoverXrefWithoutStartxref($pdfData);
+                if (!empty($recoveredXref)) {
+                    return $recoveredXref;
+                }
+
+                throw new \Exception('Unable to find startxref');
+            }
         } elseif (0 == $offset) {
             // Use the last startxref in the document
             $startxref = (int) $startxrefMatches[\count($startxrefMatches) - 1][1];
-        } elseif (strpos($pdfData, 'xref', $bumpOffset) == $bumpOffset) {
+        } elseif (strpos($pdfData, 'xref', $bumpOffset) === $bumpOffset) {
             // Already pointing at the xref table
             $startxref = $bumpOffset;
-        } elseif (preg_match('/([0-9]+[\s][0-9]+[\s]obj)/i', $pdfData, $matches, 0, $bumpOffset)) {
+        } elseif (preg_match('/^[0-9]+[\s]+[0-9]+[\s]+obj/i', substr($pdfData, $bumpOffset, 32)) > 0) {
             // Cross-Reference Stream object
             $startxref = $bumpOffset;
         } else {
@@ -923,13 +942,13 @@ class RawDataParser
         }
 
         // check xref position
-        if (strpos($pdfData, 'xref', $startxref) == $startxref) {
+        if (strpos($pdfData, 'xref', $startxref) === $startxref) {
             // Cross-Reference
             $xref = $this->decodeXref($pdfData, $startxref, $xref, $visitedOffsets);
         } else {
             // Check if the $pdfData might have the wrong line-endings
             $pdfDataUnix = str_replace("\r\n", "\n", $pdfData);
-            if ($startxref < \strlen($pdfDataUnix) && strpos($pdfDataUnix, 'xref', $startxref) == $startxref) {
+            if ($startxref < \strlen($pdfDataUnix) && strpos($pdfDataUnix, 'xref', $startxref) === $startxref) {
                 // Return Unix-line-ending flag
                 $xref = ['Unix' => true];
             } else {
@@ -939,6 +958,84 @@ class RawDataParser
         }
         if (empty($xref)) {
             throw new \Exception('Unable to find xref');
+        }
+
+        return $xref;
+    }
+
+    /**
+     * Attempt to recover xref/trailer data when no valid startxref stanza exists.
+     */
+    private function recoverXrefWithoutStartxref(string $pdfData): array
+    {
+        $trailerPos = strrpos($pdfData, 'trailer');
+        $recoveredOffset = null;
+
+        if (false !== $trailerPos) {
+            $searchStart = max(0, $trailerPos - 8192);
+            $searchChunk = substr($pdfData, $searchStart, $trailerPos - $searchStart);
+            $lastXrefPos = strrpos($searchChunk, 'xref');
+            if (false !== $lastXrefPos) {
+                $candidateOffset = $searchStart + $lastXrefPos;
+                if (
+                    preg_match('/xref[\x09\x0a\x0c\x0d\x20]/', substr($pdfData, $candidateOffset, 5)) > 0
+                    && preg_match('/xref[\s]*[\r\n]+[0-9]+[\x20]+[0-9]+[\x20]*[\r\n]/A', substr($pdfData, $candidateOffset, 96)) > 0
+                ) {
+                    $recoveredOffset = $candidateOffset;
+                }
+            }
+        }
+
+        if (null !== $recoveredOffset) {
+            return $this->getXrefData($pdfData, $recoveredOffset);
+        }
+
+        $xref = ['xref' => [], 'trailer' => []];
+        if (
+            preg_match_all('/([0-9]+)[\x20]+([0-9]+)[\x20]+obj\b/i', $pdfData, $objMatches, \PREG_OFFSET_CAPTURE) > 0
+        ) {
+            foreach ($objMatches[0] as $i => $fullMatch) {
+                $objNum = (int) $objMatches[1][$i][0];
+                $genNum = (int) $objMatches[2][$i][0];
+                $xref['xref'][$objNum.'_'.$genNum] = $fullMatch[1];
+            }
+
+            if (false !== $trailerPos) {
+                $trailerEnd = strpos($pdfData, '%%EOF', $trailerPos);
+                if (false === $trailerEnd) {
+                    $trailerEnd = min(
+                        \strlen($pdfData),
+                        $trailerPos + 4096
+                    );
+                }
+                $trailerData = substr($pdfData, $trailerPos, $trailerEnd - $trailerPos);
+
+                if (preg_match('/Size[\s]+([0-9]+)/i', $trailerData, $matches) > 0) {
+                    $xref['trailer']['size'] = (int) $matches[1];
+                }
+                if (preg_match('/Root[\s]+([0-9]+)[\s]+([0-9]+)[\s]+R/i', $trailerData, $matches) > 0) {
+                    $xref['trailer']['root'] = (int) $matches[1].'_'.(int) $matches[2];
+                }
+                if (preg_match('/Encrypt[\s]+([0-9]+)[\s]+([0-9]+)[\s]+R/i', $trailerData, $matches) > 0) {
+                    $xref['trailer']['encrypt'] = (int) $matches[1].'_'.(int) $matches[2];
+                }
+                if (preg_match('/Info[\s]+([0-9]+)[\s]+([0-9]+)[\s]+R/i', $trailerData, $matches) > 0) {
+                    $xref['trailer']['info'] = (int) $matches[1].'_'.(int) $matches[2];
+                }
+                if (preg_match('/ID[\s]*[\[]\s*[<]([^>]*)[>][\s]*[<]([^>]*)[>]/i', $trailerData, $matches) > 0) {
+                    $xref['trailer']['id'] = [];
+                    $xref['trailer']['id'][0] = $matches[1];
+                    $xref['trailer']['id'][1] = $matches[2];
+                }
+            }
+        }
+
+        if (empty($xref['xref'])) {
+            return [];
+        }
+
+        if (!isset($xref['trailer']['size'])) {
+            $xref['trailer']['size'] = \count($xref['xref']) + 1;
         }
 
         return $xref;

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -902,15 +902,10 @@ class RawDataParser
         );
 
         if (0 == $startxrefPreg) {
-            $xrefSubsectionAtOffset = preg_match(
-                '/[0-9]+[\x20]+[0-9]+[\x20]*[\r\n]/A',
-                substr($pdfData, $bumpOffset, 48)
-            ) > 0;
-
-            if (strpos($pdfData, 'xref', $bumpOffset) === $bumpOffset || $xrefSubsectionAtOffset) {
+            if (strpos($pdfData, 'xref', $bumpOffset) === $bumpOffset || $this->hasXrefSubsectionAtOffset($pdfData, $bumpOffset)) {
                 // No startxref stanza, but caller already points to an xref table/subsection.
                 $startxref = $bumpOffset;
-            } elseif (preg_match('/^[0-9]+[\s]+[0-9]+[\s]+obj/i', substr($pdfData, $bumpOffset, 32)) > 0) {
+            } elseif ($this->hasObjectHeaderAtOffset($pdfData, $bumpOffset)) {
                 // No startxref stanza, but caller points to an xref stream object.
                 $startxref = $bumpOffset;
             } else {
@@ -929,7 +924,7 @@ class RawDataParser
         } elseif (strpos($pdfData, 'xref', $bumpOffset) === $bumpOffset) {
             // Already pointing at the xref table
             $startxref = $bumpOffset;
-        } elseif (preg_match('/^[0-9]+[\s]+[0-9]+[\s]+obj/i', substr($pdfData, $bumpOffset, 32)) > 0) {
+        } elseif ($this->hasObjectHeaderAtOffset($pdfData, $bumpOffset)) {
             // Cross-Reference Stream object
             $startxref = $bumpOffset;
         } else {
@@ -969,65 +964,18 @@ class RawDataParser
     private function recoverXrefWithoutStartxref(string $pdfData): array
     {
         $trailerPos = strrpos($pdfData, 'trailer');
-        $recoveredOffset = null;
-
-        if (false !== $trailerPos) {
-            $searchStart = max(0, $trailerPos - 8192);
-            $searchChunk = substr($pdfData, $searchStart, $trailerPos - $searchStart);
-            $lastXrefPos = strrpos($searchChunk, 'xref');
-            if (false !== $lastXrefPos) {
-                $candidateOffset = $searchStart + $lastXrefPos;
-                if (
-                    preg_match('/xref[\x09\x0a\x0c\x0d\x20]/', substr($pdfData, $candidateOffset, 5)) > 0
-                    && preg_match('/xref[\s]*[\r\n]+[0-9]+[\x20]+[0-9]+[\x20]*[\r\n]/A', substr($pdfData, $candidateOffset, 96)) > 0
-                ) {
-                    $recoveredOffset = $candidateOffset;
-                }
-            }
-        }
+        $recoveredOffset = false !== $trailerPos
+            ? $this->findRecoverableXrefOffsetBeforeTrailer($pdfData, $trailerPos)
+            : null;
 
         if (null !== $recoveredOffset) {
             return $this->getXrefData($pdfData, $recoveredOffset);
         }
 
-        $xref = ['xref' => [], 'trailer' => []];
-        if (
-            preg_match_all('/([0-9]+)[\x20]+([0-9]+)[\x20]+obj\b/i', $pdfData, $objMatches, \PREG_OFFSET_CAPTURE) > 0
-        ) {
-            foreach ($objMatches[0] as $i => $fullMatch) {
-                $objNum = (int) $objMatches[1][$i][0];
-                $genNum = (int) $objMatches[2][$i][0];
-                $xref['xref'][$objNum.'_'.$genNum] = $fullMatch[1];
-            }
+        $xref = $this->buildXrefFromObjectHeaders($pdfData);
 
-            if (false !== $trailerPos) {
-                $trailerEnd = strpos($pdfData, '%%EOF', $trailerPos);
-                if (false === $trailerEnd) {
-                    $trailerEnd = min(
-                        \strlen($pdfData),
-                        $trailerPos + 4096
-                    );
-                }
-                $trailerData = substr($pdfData, $trailerPos, $trailerEnd - $trailerPos);
-
-                if (preg_match('/Size[\s]+([0-9]+)/i', $trailerData, $matches) > 0) {
-                    $xref['trailer']['size'] = (int) $matches[1];
-                }
-                if (preg_match('/Root[\s]+([0-9]+)[\s]+([0-9]+)[\s]+R/i', $trailerData, $matches) > 0) {
-                    $xref['trailer']['root'] = (int) $matches[1].'_'.(int) $matches[2];
-                }
-                if (preg_match('/Encrypt[\s]+([0-9]+)[\s]+([0-9]+)[\s]+R/i', $trailerData, $matches) > 0) {
-                    $xref['trailer']['encrypt'] = (int) $matches[1].'_'.(int) $matches[2];
-                }
-                if (preg_match('/Info[\s]+([0-9]+)[\s]+([0-9]+)[\s]+R/i', $trailerData, $matches) > 0) {
-                    $xref['trailer']['info'] = (int) $matches[1].'_'.(int) $matches[2];
-                }
-                if (preg_match('/ID[\s]*[\[]\s*[<]([^>]*)[>][\s]*[<]([^>]*)[>]/i', $trailerData, $matches) > 0) {
-                    $xref['trailer']['id'] = [];
-                    $xref['trailer']['id'][0] = $matches[1];
-                    $xref['trailer']['id'][1] = $matches[2];
-                }
-            }
+        if (false !== $trailerPos) {
+            $this->fillRecoveredTrailerData($xref, $this->getTrailerChunk($pdfData, $trailerPos));
         }
 
         if (empty($xref['xref'])) {
@@ -1039,6 +987,93 @@ class RawDataParser
         }
 
         return $xref;
+    }
+
+    private function hasXrefSubsectionAtOffset(string $pdfData, int $offset): bool
+    {
+        return preg_match(
+            '/[0-9]+[\x20]+[0-9]+[\x20]*[\r\n]/A',
+            substr($pdfData, $offset, 48)
+        ) > 0;
+    }
+
+    private function hasObjectHeaderAtOffset(string $pdfData, int $offset): bool
+    {
+        return preg_match('/^[0-9]+[\s]+[0-9]+[\s]+obj/i', substr($pdfData, $offset, 32)) > 0;
+    }
+
+    private function findRecoverableXrefOffsetBeforeTrailer(string $pdfData, int $trailerPos): ?int
+    {
+        $searchStart = max(0, $trailerPos - 8192);
+        $searchChunk = substr($pdfData, $searchStart, $trailerPos - $searchStart);
+        $lastXrefPos = strrpos($searchChunk, 'xref');
+
+        if (false === $lastXrefPos) {
+            return null;
+        }
+
+        $candidateOffset = $searchStart + $lastXrefPos;
+        $candidateChunk = substr($pdfData, $candidateOffset, 96);
+        if (
+            preg_match('/xref[\x09\x0a\x0c\x0d\x20]/', $candidateChunk) > 0
+            && preg_match('/xref[\s]*[\r\n]+[0-9]+[\x20]+[0-9]+[\x20]*[\r\n]/A', $candidateChunk) > 0
+        ) {
+            return $candidateOffset;
+        }
+
+        return null;
+    }
+
+    private function buildXrefFromObjectHeaders(string $pdfData): array
+    {
+        $xref = ['xref' => [], 'trailer' => []];
+        if (
+            preg_match_all('/([0-9]+)[\x20]+([0-9]+)[\x20]+obj\b/i', $pdfData, $objMatches, \PREG_OFFSET_CAPTURE) === 0
+        ) {
+            return $xref;
+        }
+
+        foreach ($objMatches[0] as $i => $fullMatch) {
+            $objNum = (int) $objMatches[1][$i][0];
+            $genNum = (int) $objMatches[2][$i][0];
+            $xref['xref'][$objNum.'_'.$genNum] = $fullMatch[1];
+        }
+
+        return $xref;
+    }
+
+    private function getTrailerChunk(string $pdfData, int $trailerPos): string
+    {
+        $trailerEnd = strpos($pdfData, '%%EOF', $trailerPos);
+        if (false === $trailerEnd) {
+            $trailerEnd = min(
+                \strlen($pdfData),
+                $trailerPos + 4096
+            );
+        }
+
+        return substr($pdfData, $trailerPos, $trailerEnd - $trailerPos);
+    }
+
+    private function fillRecoveredTrailerData(array &$xref, string $trailerData): void
+    {
+        if (preg_match('/Size[\s]+([0-9]+)/i', $trailerData, $matches) > 0) {
+            $xref['trailer']['size'] = (int) $matches[1];
+        }
+        if (preg_match('/Root[\s]+([0-9]+)[\s]+([0-9]+)[\s]+R/i', $trailerData, $matches) > 0) {
+            $xref['trailer']['root'] = (int) $matches[1].'_'.(int) $matches[2];
+        }
+        if (preg_match('/Encrypt[\s]+([0-9]+)[\s]+([0-9]+)[\s]+R/i', $trailerData, $matches) > 0) {
+            $xref['trailer']['encrypt'] = (int) $matches[1].'_'.(int) $matches[2];
+        }
+        if (preg_match('/Info[\s]+([0-9]+)[\s]+([0-9]+)[\s]+R/i', $trailerData, $matches) > 0) {
+            $xref['trailer']['info'] = (int) $matches[1].'_'.(int) $matches[2];
+        }
+        if (preg_match('/ID[\s]*[\[]\s*[<]([^>]*)[>][\s]*[<]([^>]*)[>]/i', $trailerData, $matches) > 0) {
+            $xref['trailer']['id'] = [];
+            $xref['trailer']['id'][0] = $matches[1];
+            $xref['trailer']['id'][1] = $matches[2];
+        }
     }
 
     /**

--- a/tests/PHPUnit/Integration/DocumentIssueFocusTest.php
+++ b/tests/PHPUnit/Integration/DocumentIssueFocusTest.php
@@ -111,4 +111,11 @@ class DocumentIssueFocusTest extends TestCase
         $testSubject = '•†‡…—–ƒ⁄‹›−‰„“”‘’‚™ŁŒŠŸŽıłœšž';
         self::assertStringContainsString($testSubject, $details['Subject']);
     }
+
+    public function testParseFileWithoutStartxrefButWithTrailerRoot(): void
+    {
+        $document = (new Parser())->parseFile($this->rootDir.'/samples/bugs/PullRequest809-pdf.js.pdf');
+
+        self::assertCount(1, $document->getPages());
+    }
 }


### PR DESCRIPTION
## Summary
- recover xref parsing when no valid `startxref` stanza is present
- tighten `strpos` comparisons to avoid false positives at offset `0`
- add fallback xref reconstruction from object headers plus trailer metadata
- add a regression for `issue19800.pdf`

## Why
Some malformed PDFs have no valid `startxref` stanza but still contain enough trailer/object-header information to recover the document.

## Validation
- parser sanity check in container:
  - `issue19800.pdf` => `pages=1`
- focused PHPUnit:
  - `testParseFileWithoutStartxrefButWithTrailerRoot`
