### PR TITLE
Implement 'Do' command and support Form referenced by 'Do' commands

### DIFF
--- a/src/Smalot/PdfParser/Page.php
+++ b/src/Smalot/PdfParser/Page.php
@@ -532,6 +532,9 @@ class Page extends PDFObject
                 case 'cm':
                     $extractedData[] = $command;
                     break;
+                case 'Do':
+                    $extractedData[] = $command;
+                    break;
                     /*
                      * ET
                      * End a text object, discarding the text matrix
@@ -733,7 +736,7 @@ class Page extends PDFObject
             // If we've used up all the texts from getTextArray(), exit
             // so we aren't accessing non-existent array indices
             // Fixes 'undefined array key' errors in Issues #575, #576
-            if (\count($extractedTexts) <= \count($extractedData)) {
+            if (\count($extractedTexts) > 0 && \count($extractedTexts) <= \count($extractedData)) {
                 break;
             }
             $currentText = $extractedTexts[\count($extractedData)];
@@ -760,6 +763,16 @@ class Page extends PDFObject
                     $TempMatrix[4] = (float) $concatTm[4] * (float) $newConcatTm[0] + (float) $concatTm[5] * (float) $newConcatTm[2] + (float) $newConcatTm[4];
                     $TempMatrix[5] = (float) $concatTm[4] * (float) $newConcatTm[1] + (float) $concatTm[5] * (float) $newConcatTm[3] + (float) $newConcatTm[5];
                     $concatTm = $TempMatrix;
+                    break;
+                case 'Do':
+                    $args = preg_split('/\s/s', $command[self::COMMAND]);
+                    $id = trim(array_pop($args), '/ ');
+                    $xobject = $this->getXObject($id);
+                    if (\is_object($xobject) && $xobject instanceof self && !\in_array($xobject->getUniqueId(), self::$recursionStack, true)) {
+                        self::$recursionStack[] = $xobject->getUniqueId();
+                        $extractedData = array_merge($xobject->getDataTm(), $extractedData);
+                        $extractedTexts = array_merge($xobject->getTextArray(), $extractedTexts);
+                    }
                     break;
                     /*
                      * ET

--- a/src/Smalot/PdfParser/XObject/Form.php
+++ b/src/Smalot/PdfParser/XObject/Form.php
@@ -48,4 +48,103 @@ class Form extends Page
 
         return $contents->getText($this);
     }
+    public function extractRawData(): array
+    {
+        /*
+         * Now you can get the complete content of the object with the text on it
+         */
+        $extractedData = [];
+
+        //This is the only difference to Page.php
+        $header = new Header([], $this->document);
+        $content = new PDFObject($this->document, $header, $this->content, $this->config);
+
+        $values = $content->getContent();
+        if (isset($values) && \is_array($values)) {
+            $text = '';
+            foreach ($values as $section) {
+                $text .= $section->getContent();
+            }
+            $sectionsText = $this->getSectionsText($text);
+            foreach ($sectionsText as $sectionText) {
+                $commandsText = $this->getCommandsText($sectionText);
+                foreach ($commandsText as $command) {
+                    $extractedData[] = $command;
+                }
+            }
+        } else {
+            if ($this->isFpdf()) {
+                $content = $this->getPDFObjectForFpdf();
+            }
+            $sectionsText = $content->getSectionsText($content->getContent());
+            foreach ($sectionsText as $sectionText) {
+                $commandsText = $content->getCommandsText($sectionText);
+                foreach ($commandsText as $command) {
+                    $extractedData[] = $command;
+                }
+            }
+        }
+
+        return $extractedData;
+    }
+    
+    public function getTextArray(?Page $page = null): array
+    {
+        if ($this->isFpdf()) {
+            $pdfObject = $this->getPDFObjectForFpdf();
+            $newPdfObject = $this->createPDFObjectForFpdf();
+
+            return $newPdfObject->getTextArray($pdfObject);
+        } else {
+            
+            //This is the only difference to Page.php
+            $header = new Header([], $this->document);
+            if ($contents = new PDFObject($this->document, $header, $this->content, $this->config)) {
+                if ($contents instanceof ElementMissing) {
+                    return [];
+                } elseif ($contents instanceof ElementNull) {
+                    return [];
+                } elseif ($contents instanceof PDFObject) {
+                    $elements = $contents->getHeader()->getElements();
+
+                    if (is_numeric(key($elements))) {
+                        $new_content = '';
+
+                        /** @var PDFObject $element */
+                        foreach ($elements as $element) {
+                            if ($element instanceof ElementXRef) {
+                                $new_content .= $element->getObject()->getContent();
+                            } else {
+                                $new_content .= $element->getContent();
+                            }
+                        }
+
+                        $header = new Header([], $this->document);
+                        $contents = new PDFObject($this->document, $header, $new_content, $this->config);
+                    } else {
+                        try {
+                            $contents->getTextArray($this);
+                        } catch (\Throwable $e) {
+                            return $contents->getTextArray();
+                        }
+                    }
+                } elseif ($contents instanceof ElementArray) {
+                    // Create a virtual global content.
+                    $new_content = '';
+
+                    /** @var PDFObject $content */
+                    foreach ($contents->getContent() as $content) {
+                        $new_content .= $content->getContent()."\n";
+                    }
+
+                    $header = new Header([], $this->document);
+                    $contents = new PDFObject($this->document, $header, $new_content, $this->config);
+                }
+
+                return $contents->getTextArray($this);
+            }
+
+            return [];
+        }
+    }
 }


### PR DESCRIPTION
# Type of pull request

* [ ] Bug fix (involves code and configuration changes)
* [x] New feature (involves code and configuration changes)
* [ ] Documentation update
* [ ] Something else

# About

Added support for `Do` command for Issue #802

# Checklist for code / configuration changes

See [CONTRIBUTING.md](./../CONTRIBUTING.md) for all essential information about contributing.


# Discuss the draft

Opened as Draft for now to show how I managed to make it work with my test pdf from #802 

I think it's best to discuss the changes I had to make first, to find out if there is maybe a better way to do it:
1) `$extractedTexts` can be empty if all Text is inside the object referenced by `Do` command
-> Added a check to only skip all next commands if extracted text wasnt empty to begin with
2) `extractRawData` and `getTextArray` takes content from the wrong property for Form objects
Page object gets it with `$content = $this->get('Contents');` which takes it from the `elements` array defined in the Header object
Form object content can be access with:
```
$header = new Header([], $this->document);
$content = new PDFObject($this->document, $header, $this->content, $this->config);
```
I copied this part from another location and found that it worked. Im pretty sure we can create this object somewhere in the constructor of form or the factory, but sadly i didnt manage to find the place where i should do that.
