### PR TITLE
Revise maintenance status and contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,24 @@
 
 **Please read the following text before creating a pull request.**
 
-This project is organized and supported by contributions from the community. Maintenance is done in our limited time.
-We welcome any pull request that contributes to PDFParser (code, documentation, ...).
-However, we would like to point out that you are initially responsible for a contribution.
-If you are new to dealing with pull requests, you can find more information at [Github documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+This project is maintained by the community in very limited time.
+**At this point, contributions are effectively limited to small, well-scoped**
+- bug fixes
+- PHP compatibility updates
+- documentation improvements and
+- related tests.
+
+**Do not** open pull requests for new features, larger refactorings, deep parser changes, performance projects, or broader behavior changes.
+Such contributions are unlikely to be reviewed, merged, or maintained responsibly in the current state of the project.
+
+If you are unsure whether a change is small enough in scope, please open an [issue](https://github.com/smalot/pdfparser/issues) first and ask before investing significant time.
+
+If you are new to pull requests, you can find more information in the [GitHub documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+
 Please don't just throw code at us and expect us to handle it.
-Nevertheless, we will support you and give you feedback.
+We will try to give feedback where possible, but contributor support is also limited by time and available project knowledge.
+
+## CI
 
 To make life easier for you and us, there is a Continuous Integration (CI) system that carries out software tests and performs a number of other tasks.
 The following points describe the relevant preparations/inputs for the CI system.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,11 @@
 **Please read the following text before creating a pull request.**
 
 This project is maintained by the community in very limited time.
-**At this point, contributions are effectively limited to small, well-scoped**
-- bug fixes
+**At this point, contributions are effectively limited to:**
+- small, well-scoped bug fixes
 - PHP compatibility updates
-- documentation improvements and
-- related tests.
+- documentation improvements
+- related tests
 
 **Do not** open pull requests for new features, larger refactorings, deep parser changes, performance projects, or broader behavior changes.
 Such contributions are unlikely to be reviewed, merged, or maintained responsibly in the current state of the project.
@@ -24,8 +24,8 @@ We will try to give feedback where possible, but contributor support is also lim
 To make life easier for you and us, there is a Continuous Integration (CI) system that carries out software tests and performs a number of other tasks.
 The following points describe the relevant preparations/inputs for the CI system.
 All checks must be green, otherwise a pull request will not be accepted.
-* Please create an [issue](https://github.com/smalot/pdfparser/issues) before starting work on any significant changes.
-* We only accept code that is bundled with tests, regardless of whether it is a new function or a bug fix. This strengthens the code base and avoids later regressions. :exclamation: **If you don't know how to write a test, tell us upfront when you open the pull request and we might add them ourselves or discuss other ways**. This [Medium article](https://pguso.medium.com/a-beginners-guide-to-phpunit-writing-and-running-unit-tests-in-php-d0b23b96749f) might be a good starting point. Code changes without tests are very likely to be rejected.
+* If your change goes beyond a small, well-scoped bug fix, please open an [issue](https://github.com/smalot/pdfparser/issues) first to clarify whether it is within the current maintenance scope of this project.
+* We only accept code that is bundled with tests. This applies to bug fixes as well as compatibility-related changes. This strengthens the code base and avoids later regressions. :exclamation: **If you don't know how to write a test, tell us upfront when you open the pull request and we might add them ourselves or discuss other ways**. This [Medium article](https://pguso.medium.com/a-beginners-guide-to-phpunit-writing-and-running-unit-tests-in-php-d0b23b96749f) might be a good starting point. Code changes without tests are very likely to be rejected.
 * Fix reported issues with the coding style. We use **PHP-CS-Fixer** for this. See [.php-cs-fixer.php](./.php-cs-fixer.php) for more information about our coding styles. [Developer.md](./doc/Developer.md) contains more information about this topic.
 * If you are fixing an **existing error**, refer to it in the introduction text of the pull request. For example, if you created a fix for issue `#1234` write the following Markdown: `fixes #1234`.
-* In case you have changed **internal behavior/functionality**, check our documentation to make sure these changes are **correctly documented**: https://github.com/smalot/pdfparser/tree/master/doc
+* If your bug fix or compatibility change affects documented behavior, please update the documentation accordingly: https://github.com/smalot/pdfparser/tree/master/doc

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 
 The `smalot/pdfparser` is a standalone PHP package that provides various tools to extract data from PDF files.
 
-This library is under **active maintenance**.
-There is no active development by the author of this library (at the moment), but we welcome any pull request adding/extending functionality!
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for further information about how to contribute.
+### Maintenance status
+
+This library is under **limited maintenance**.
+It is still kept compatible with supported PHP versions, and community contributions may be accepted. However, there is currently **no active feature development** and **no guarantee** that pull requests will be reviewed or merged in a timely manner. 
+If you plan to contribute anything beyond a small, well-scoped fix, please read [CONTRIBUTING.md](./CONTRIBUTING.md) first.
 
 ## Features
 


### PR DESCRIPTION
# Type of pull request

* [x] Documentation update

# About

This PR updates the project documentation to better reflect the current maintenance reality of this repository.

In recent discussions around larger contribution proposals (#820, #795), it became clear to me that the expectations currently set by `README.md` and `CONTRIBUTING.md` are too optimistic and no longer match what we can realistically review, merge, and maintain.

The goal of this change is therefore not to discourage contributions in general, but to set clearer expectations upfront:
- this project is under limited maintenance
- small, well-scoped fixes are still welcome
- broader feature work or deeper parser changes are currently outside the scope we can maintain responsibly

I would rather communicate that clearly in the documentation than leave contributors with expectations that we may not be able to meet.