### PR TITLE
Fix Font::getDetails() TypeError when Encoding is indirect reference to PDFObject

### DIFF
--- a/samples/bugs/EncodingAsIndirectPDFObject.pdf
+++ b/samples/bugs/EncodingAsIndirectPDFObject.pdf
@@ -1,0 +1,48 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+
+3 0 obj
+<< /Type /Page /Parent 2 0 R
+   /MediaBox [0 0 612 792]
+   /Resources << /Font << /F1 4 0 R >> >>
+   /Contents 6 0 R >>
+endobj
+
+4 0 obj
+<< /Type /Font
+   /Subtype /Type1
+   /BaseFont /Helvetica
+   /Encoding 5 0 R >>
+endobj
+
+5 0 obj
+<< /Differences [32 /space 65 /A /B /C /D /E /F /G /H /I /J] >>
+endobj
+
+6 0 obj
+<< /Length 37 >>
+stream
+BT /F1 12 Tf 100 700 Td (Hello) Tj ET
+endstream
+endobj
+
+xref
+0 7
+0000000000 65535 f 
+0000000009 00000 n 
+0000000059 00000 n 
+0000000117 00000 n 
+0000000253 00000 n 
+0000000349 00000 n 
+0000000429 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+517
+%%EOF

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -94,7 +94,19 @@ class Font extends PDFObject
 
         $details['Name'] = $this->getName();
         $details['Type'] = $this->getType();
-        $details['Encoding'] = ($this->has('Encoding') ? (string) $this->get('Encoding') : 'Ansi');
+        $encoding = $this->has('Encoding') ? $this->get('Encoding') : null;
+        if ($encoding instanceof PDFObject) {
+            // Encoding is an indirect reference to an encoding dictionary (PDF spec Table 5.11).
+            // Encoding extends PDFObject, so this branch handles both cases.
+            // Extract BaseEncoding name; absent means the font's built-in encoding is the base.
+            $baseEncoding = $encoding->getHeader()->get('BaseEncoding');
+            $baseEncodingStr = ($baseEncoding instanceof Element) ? (string) $baseEncoding : '';
+            $details['Encoding'] = $baseEncodingStr !== '' ? $baseEncodingStr : 'Ansi';
+        } elseif ($encoding instanceof Element) {
+            $details['Encoding'] = (string) $encoding;
+        } else {
+            $details['Encoding'] = 'Ansi';
+        }
 
         $details += parent::getDetails($deep);
 

--- a/tests/PHPUnit/Integration/FontTest.php
+++ b/tests/PHPUnit/Integration/FontTest.php
@@ -593,4 +593,35 @@ al;font-family:Helvetica,sans-serif;font-stretch:normal"><p><span style="font-fa
         // check result
         $this->assertEquals('foobar-', $font->decodeContent("foobar-\x8D"));
     }
+
+    /**
+     * Font::getDetails() must not throw when a font's Encoding entry is an
+     * indirect object reference that resolves to a plain PDFObject instead of
+     * an Element — i.e. an encoding dictionary that lacks /Type /Encoding.
+     *
+     * This is a valid PDF structure per PDF spec Table 5.11: the dictionary
+     * may carry only a /Differences array and omit /Type and /BaseEncoding.
+     * Without the fix, PHP throws:
+     *   "Object of class PDFObject could not be converted to string"
+     *
+     * @see https://github.com/smalot/pdfparser/issues/822
+     */
+    public function testGetDetailsWithEncodingAsIndirectPDFObject(): void
+    {
+        $filename = $this->rootDir.'/samples/bugs/EncodingAsIndirectPDFObject.pdf';
+        $parser = $this->getParserInstance();
+        $document = $parser->parseFile($filename);
+
+        foreach ($document->getPages() as $page) {
+            foreach ($page->getFonts() as $font) {
+                // Must not throw "PDFObject could not be converted to string"
+                $details = $font->getDetails();
+                $this->assertIsString($details['Encoding']);
+                $this->assertNotEmpty($details['Encoding']);
+            }
+        }
+
+        // Text extraction must still work correctly
+        $this->assertSame('Hello', trim($document->getText()));
+    }
 }

--- a/tests/PHPUnit/Unit/FontTest.php
+++ b/tests/PHPUnit/Unit/FontTest.php
@@ -34,11 +34,102 @@ namespace PHPUnitTests\Unit;
 use PHPUnitTests\TestCase;
 use Smalot\PdfParser\Config;
 use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Element;
+use Smalot\PdfParser\Encoding;
 use Smalot\PdfParser\Font;
+use Smalot\PdfParser\Header;
 use Smalot\PdfParser\PDFObject;
 
 class FontTest extends TestCase
 {
+    /**
+     * Font::getDetails() must not throw when Encoding is an indirect reference
+     * that resolves to a PDFObject instead of an Element.
+     *
+     * Such PDFs store the Encoding as an object reference (e.g. "12 0 R") whose
+     * resolved target is a plain PDFObject without /Type /Encoding — a valid
+     * structure per PDF spec Table 5.11 (encoding dictionary with /Differences).
+     *
+     * @see https://github.com/smalot/pdfparser/issues/822
+     */
+    public function testGetDetailsEncodingAsPDFObjectWithBaseEncoding(): void
+    {
+        $document = new Document();
+        $encodingObj = new PDFObject(
+            $document,
+            new Header(['BaseEncoding' => new Element('WinAnsiEncoding')])
+        );
+        $font = new Font($document, new Header(['Encoding' => $encodingObj]));
+
+        $details = $font->getDetails(false);
+
+        self::assertSame('WinAnsiEncoding', $details['Encoding']);
+    }
+
+    /**
+     * When Encoding is a PDFObject without a BaseEncoding entry the font uses
+     * its built-in encoding as base (PDF spec §5.5.5). getDetails() must return
+     * 'Ansi' as fallback, consistent with Encoding::getDetails()['BaseEncoding'].
+     */
+    public function testGetDetailsEncodingAsPDFObjectWithoutBaseEncoding(): void
+    {
+        $document = new Document();
+        $encodingObj = new PDFObject($document, new Header([]));
+        $font = new Font($document, new Header(['Encoding' => $encodingObj]));
+
+        $details = $font->getDetails(false);
+
+        self::assertSame('Ansi', $details['Encoding']);
+    }
+
+    /**
+     * When Encoding is an Encoding instance (PDFObject subclass, /Type /Encoding
+     * present) the BaseEncoding name must be returned.
+     */
+    public function testGetDetailsEncodingAsEncodingInstance(): void
+    {
+        $document = new Document();
+        $encodingObj = new Encoding(
+            $document,
+            new Header(['BaseEncoding' => new Element('MacRomanEncoding')])
+        );
+        $font = new Font($document, new Header(['Encoding' => $encodingObj]));
+
+        $details = $font->getDetails(false);
+
+        self::assertSame('MacRomanEncoding', $details['Encoding']);
+    }
+
+    /**
+     * When Encoding is a direct name element (e.g. /WinAnsiEncoding) the name
+     * is returned as-is — the original pre-fix behaviour must be preserved.
+     */
+    public function testGetDetailsEncodingAsDirectElement(): void
+    {
+        $document = new Document();
+        $font = new Font(
+            $document,
+            new Header(['Encoding' => new Element('WinAnsiEncoding')])
+        );
+
+        $details = $font->getDetails(false);
+
+        self::assertSame('WinAnsiEncoding', $details['Encoding']);
+    }
+
+    /**
+     * When no Encoding entry is present getDetails() must return 'Ansi'.
+     */
+    public function testGetDetailsEncodingMissingDefaultsToAnsi(): void
+    {
+        $document = new Document();
+        $font = new Font($document, new Header([]));
+
+        $details = $font->getDetails(false);
+
+        self::assertSame('Ansi', $details['Encoding']);
+    }
+
     /**
      * decodeText must decode \b.
      *


### PR DESCRIPTION
# Type of pull request

* [x] Bug fix (involves code and configuration changes)
* [ ] New feature (involves code and configuration changes)
* [ ] Documentation update
* [ ] Something else

# About

fixes #822

`Font::getDetails()` threw `"PDFObject could not be converted to string"` when a font's `/Encoding` entry was an indirect reference resolving to a plain `PDFObject` (encoding dictionary without `/Type /Encoding`). This is a valid PDF structure per spec Table 5.11.

**Root cause:** `Font::getDetails()` applied an unconditional `(string)` cast to the result of `$this->get('Encoding')`. `Header::resolveXRef()` can return a `PDFObject` (which has no `__toString()`), causing a `TypeError` in PHP 8+.

**Fix:** Check the type before casting:
- `PDFObject` (covers both `Encoding` subclass and plain encoding dictionaries): extract `BaseEncoding` name; fall back to `'Ansi'` if absent — consistent with `Encoding::getDetails()['BaseEncoding']`.
- `Element` (direct name like `/WinAnsiEncoding`): cast as before.
- `null` (no entry): return `'Ansi'` as before.

**Changes:**
- `src/Smalot/PdfParser/Font.php` — fix in `getDetails()`
- `tests/PHPUnit/Unit/FontTest.php` — 5 unit tests covering all branches
- `tests/PHPUnit/Integration/FontTest.php` — integration test with sample PDF
- `samples/bugs/EncodingAsIndirectPDFObject.pdf` — minimal reproducer (720 B)

**AI disclosure**
This PR was developed with Claude Code assistance. All code has been reviewed as best I can. I tested the code in my local installation.