### PR TITLE
Build PDF objects incrementally to lower peak memory

### DIFF
--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -99,24 +99,36 @@ class Parser
      */
     public function parseContent(string $content): Document
     {
-        // Create structure from raw data.
-        list($xref, $data) = $this->rawDataParser->parseData($content);
+        // Normalize the raw data and decode the cross-reference/trailer table.
+        list($xref, $pdfData) = $this->rawDataParser->parseHeaderAndXref($content);
+
+        // The original (possibly un-trimmed) input is no longer needed; drop it
+        // so it can be freed once the normalized $pdfData copy is also released.
+        unset($content);
 
         if (isset($xref['trailer']['encrypt']) && false === $this->config->getIgnoreEncryption()) {
             throw new \Exception('Secured pdf file are currently not supported.');
-        }
-
-        if (empty($data)) {
-            throw new \Exception('Object list not found. Possible secured file.');
         }
 
         // Create destination object.
         $document = new Document();
         $this->objects = [];
 
-        foreach ($data as $id => $structure) {
+        // Stream the raw objects one at a time instead of building the whole
+        // raw object graph up front. Each structure is turned into a PDFObject
+        // and then goes out of scope before the next is parsed, so the largest
+        // transient structure - the full raw object array - is never held,
+        // which markedly lowers peak memory on large documents.
+        foreach ($this->rawDataParser->getObjectsStream($pdfData, $xref) as $id => $structure) {
             $this->parseObject($id, $structure, $document);
-            unset($data[$id]);
+        }
+
+        // Object parsing is done; the raw PDF string is no longer needed and
+        // can be released before text extraction is performed by the caller.
+        unset($pdfData);
+
+        if (empty($this->objects)) {
+            throw new \Exception('Object list not found. Possible secured file.');
         }
 
         $document->setTrailer($this->parseTrailer($xref['trailer'], $document));

--- a/src/Smalot/PdfParser/RawData/RawDataParser.php
+++ b/src/Smalot/PdfParser/RawData/RawDataParser.php
@@ -945,16 +945,21 @@ class RawDataParser
     }
 
     /**
-     * Parses PDF data and returns extracted data as array.
+     * Normalize the raw PDF data and decode the cross-reference/trailer data.
+     *
+     * Returns the xref/trailer data together with the normalized PDF data so
+     * callers (e.g. Parser) can inspect the trailer (for instance to detect
+     * encryption) and then stream the objects one at a time via
+     * getObjectsStream() instead of materializing them all at once.
      *
      * @param string $data PDF data to parse
      *
-     * @return array array of parsed PDF document objects
+     * @return array{0: array, 1: string} [$xref, $pdfData]
      *
      * @throws EmptyPdfException if empty PDF data given
      * @throws MissingPdfHeaderException if PDF data missing `%PDF-` header
      */
-    public function parseData(string $data): array
+    public function parseHeaderAndXref(string $data): array
     {
         if (empty($data)) {
             throw new EmptyPdfException('Empty PDF data given.');
@@ -976,15 +981,31 @@ class RawDataParser
             $xref = $this->getXrefData($pdfData);
         }
 
-        // parse all document objects
-        $objects = [];
+        return [$xref, $pdfData];
+    }
+
+    /**
+     * Yield each indirect object's raw structure one at a time.
+     *
+     * Yielding (rather than returning a fully built array) lets the consumer
+     * build its own representation of an object and discard the raw structure
+     * before the next one is parsed, so the complete raw object graph - by far
+     * the largest transient structure when parsing a document - never has to be
+     * held in memory at once.
+     *
+     * @param string $pdfData normalized PDF data, as returned by parseHeaderAndXref()
+     * @param array  $xref    xref/trailer data, as returned by parseHeaderAndXref()
+     *
+     * @return \Generator<string, array> raw object structure keyed by object reference
+     */
+    public function getObjectsStream(string $pdfData, array $xref): \Generator
+    {
         foreach ($xref['xref'] as $obj => $offset) {
-            if (!isset($objects[$obj]) && ($offset > 0)) {
-                // decode objects with positive offset
-                $objects[$obj] = $this->getIndirectObject($pdfData, $xref, $obj, $offset, true);
+            // decode objects with positive offset; xref is keyed by object
+            // reference so every $obj is unique and decoded exactly once
+            if ($offset > 0) {
+                yield $obj => $this->getIndirectObject($pdfData, $xref, $obj, $offset, true);
             }
         }
-
-        return [$xref, $objects];
     }
 }


### PR DESCRIPTION
Part 1 of #824 

parseData() used to decode every indirect object into a fully built raw object graph - deeply nested arrays that inflate the source roughly 8-10x - and return the whole thing before Parser turned any of it into PDFObjects. At that moment the entire raw graph and the PDF string were held simultaneously, which is the peak for most documents.

Replace parseData() with parseHeaderAndXref() plus a getObjectsStream() generator. Parser now builds each PDFObject and releases the raw structure before pulling the next one, so the full raw graph is never materialized, and the PDF string is freed before text extraction.

Backward compatibility note: the public RawDataParser::parseData() method is removed (it had no remaining callers). Third party consumers (I don't think there are any) that called it directly should switch to parseHeaderAndXref() + getObjectsStream(), or iterate the latter into an array for the old [$xref, $objects] return shape.

Measured peak memory (getText() over the whole file), vs master:

  samples/bugs/PullRequest457.pdf        147 MB -> 88 MB  (-40%)
  samples/DocumentWithLotsOfObjects.pdf   99 MB -> 62 MB  (-38%)

Documents whose peak occurs during text extraction rather than parsing (e.g. Issue356.pdf, Issue391.pdf) are unchanged. Extracted text is identical in all cases.
