### PR TITLE
Add opt-in content spooling to lower retained memory

### DIFF
--- a/doc/CustomConfig.md
+++ b/doc/CustomConfig.md
@@ -26,6 +26,7 @@ The `Config` class has the following options:
 | `setPdfWhitespaces`      | String  | `\0\t\n\f\r `   |                                                                                                                                                      |
 | `setPdfWhitespacesRegex` | String  | `[\0\t\n\f\r ]` |                                                                                                                                                      |
 | `setRetainImageContent`  | Boolean | `true`          | If parsing fails due to memory exhaustion, you can set the value to `false`. This will reduce memory usage, although it will no longer retain image content. |
+| `setContentSpooling`     | Boolean | `false`         | If parsing large documents fails due to memory exhaustion, set this to `true` to spool decoded stream content to a temporary file instead of keeping it in memory. Lowers peak memory usage at the cost of some extra disk I/O. |
 
 
 ## option setDecodeMemoryLimit + setRetainImageContent (manage memory usage)
@@ -40,6 +41,26 @@ $config->setRetainImageContent(false);
 $config->setDecodeMemoryLimit(1000000);
 $parser = new \Smalot\PdfParser\Parser([], $config);
 ```
+
+## option setContentSpooling (manage memory usage)
+
+When parsing large documents, the bulk of the memory a parsed document keeps
+alive is the decoded content of its stream objects. Enabling content spooling
+writes that content to a single temporary file as objects are parsed and reads
+it back on demand, so the full set of decoded streams no longer has to reside in
+memory at once. This noticeably lowers peak memory usage for large files in
+exchange for a small amount of disk I/O. The extracted text and document details
+are identical with the option on or off.
+
+```php
+$config = new \Smalot\PdfParser\Config();
+// Spool decoded stream content to a temporary file instead of memory
+$config->setContentSpooling(true);
+$parser = new \Smalot\PdfParser\Parser([], $config);
+```
+
+The temporary file is created in the system temp directory and removed
+automatically once the parsed document is no longer referenced.
 
 ## option setHorizontalOffset
 

--- a/src/Smalot/PdfParser/Config.php
+++ b/src/Smalot/PdfParser/Config.php
@@ -89,6 +89,15 @@ class Config
      */
     private $ignoreEncryption = false;
 
+    /**
+     * Whether decoded object stream content is spooled to a temporary file
+     * instead of being kept in memory. Trades disk I/O for a lower peak memory
+     * footprint when parsing large documents.
+     *
+     * @var bool
+     */
+    private $contentSpooling = false;
+
     public function getFontSpaceLimit()
     {
         return $this->fontSpaceLimit;
@@ -171,5 +180,15 @@ class Config
     public function setIgnoreEncryption(bool $ignoreEncryption): void
     {
         $this->ignoreEncryption = $ignoreEncryption;
+    }
+
+    public function getContentSpooling(): bool
+    {
+        return $this->contentSpooling;
+    }
+
+    public function setContentSpooling(bool $contentSpooling): void
+    {
+        $this->contentSpooling = $contentSpooling;
     }
 }

--- a/src/Smalot/PdfParser/ContentSpool.php
+++ b/src/Smalot/PdfParser/ContentSpool.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * @file
+ *          This file is part of the PdfParser library.
+ *
+ * @author  Andreas Gohr <gohr@cosmocode.de>
+ *
+ * @date    2026-06-18
+ *
+ * @license LGPLv3
+ *
+ * @url     <https://github.com/smalot/pdfparser>
+ *
+ *  PdfParser is a pdf library written in PHP, extraction oriented.
+ *  Copyright (C) 2017 - Sébastien MALOT <sebastien@malot.fr>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.
+ *  If not, see <http://www.pdfparser.org/sites/default/LICENSE.txt>.
+ */
+
+namespace Smalot\PdfParser;
+
+/**
+ * Temporary on-disk store for decoded stream content.
+ *
+ * When content spooling is enabled (see Config::setContentSpooling()), the
+ * decoded content of each parsed object is appended to a single temporary file
+ * instead of being held in memory, and read back on demand. This trades a small
+ * amount of disk I/O for a markedly lower peak memory footprint, since the full
+ * set of decoded streams - usually the largest thing a parsed Document keeps
+ * alive - no longer has to reside in RAM all at once.
+ *
+ * The backing temporary file is created lazily on first use and removed
+ * automatically once the spool (and the Document owning it) is destroyed.
+ *
+ * @internal
+ */
+class ContentSpool
+{
+    /**
+     * @var resource|null
+     */
+    private $handle;
+
+    /**
+     * Current size of the spool file, i.e. the offset at which the next chunk
+     * of content will be written.
+     *
+     * @var int
+     */
+    private $size = 0;
+
+    /**
+     * Append a chunk of content to the spool.
+     *
+     * @return array{0: int, 1: int}|null [offset, length] locating the stored
+     *                                     content, or null if it could not be
+     *                                     stored (the caller should then keep
+     *                                     the content in memory)
+     */
+    public function store(string $content): ?array
+    {
+        $length = \strlen($content);
+        if (0 === $length) {
+            return null;
+        }
+
+        $handle = $this->handle();
+        if (null === $handle) {
+            return null;
+        }
+
+        $offset = $this->size;
+        if (0 === fseek($handle, $offset) && fwrite($handle, $content) === $length) {
+            $this->size += $length;
+
+            return [$offset, $length];
+        }
+
+        return null;
+    }
+
+    /**
+     * Read back content previously stored via store().
+     *
+     * @param int $offset offset returned by store()
+     * @param int $length length returned by store()
+     */
+    public function fetch(int $offset, int $length): string
+    {
+        if (!\is_resource($this->handle) || $length <= 0) {
+            return '';
+        }
+
+        // Seeking before reading also flushes any pending write buffer, which
+        // is required when reading data that was just written to the handle.
+        if (0 !== fseek($this->handle, $offset)) {
+            return '';
+        }
+
+        $content = '';
+        $remaining = $length;
+        while ($remaining > 0 && !feof($this->handle)) {
+            $chunk = fread($this->handle, $remaining);
+            if (false === $chunk || '' === $chunk) {
+                break;
+            }
+            $content .= $chunk;
+            $remaining -= \strlen($chunk);
+        }
+
+        return $content;
+    }
+
+    /**
+     * Lazily open the backing temporary file.
+     *
+     * @return resource|null
+     */
+    private function handle()
+    {
+        if (null === $this->handle) {
+            // tmpfile() opens a binary-safe read-write handle and removes the
+            // underlying file automatically when the handle is closed.
+            $handle = tmpfile();
+            $this->handle = false !== $handle ? $handle : null;
+        }
+
+        return $this->handle;
+    }
+
+    /**
+     * Ensure the backing file is closed and removed when the spool is destroyed.
+     */
+    public function __destruct()
+    {
+        if (\is_resource($this->handle)) {
+            fclose($this->handle);
+        }
+    }
+}

--- a/src/Smalot/PdfParser/Document.php
+++ b/src/Smalot/PdfParser/Document.php
@@ -74,9 +74,27 @@ class Document
      */
     protected $details;
 
+    /**
+     * Optional on-disk store for decoded object stream content, shared by all
+     * objects of this document. Only set when content spooling is enabled.
+     *
+     * @var ContentSpool|null
+     */
+    protected $contentSpool;
+
     public function __construct()
     {
         $this->trailer = new Header([], $this);
+    }
+
+    public function getContentSpool(): ?ContentSpool
+    {
+        return $this->contentSpool;
+    }
+
+    public function setContentSpool(?ContentSpool $contentSpool): void
+    {
+        $this->contentSpool = $contentSpool;
     }
 
     public function init()

--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -65,9 +65,18 @@ class PDFObject
     protected $header;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $content;
+
+    /**
+     * Location of this object's content within the document's ContentSpool,
+     * as [offset, length], when the content has been spooled to disk instead
+     * of being kept in $content. Null when the content lives in memory.
+     *
+     * @var array{0: int, 1: int}|null
+     */
+    protected $contentRef;
 
     /**
      * @var Config|null
@@ -130,7 +139,43 @@ class PDFObject
 
     public function getContent(): ?string
     {
+        // Content has been spooled to disk; read it back on demand.
+        if (null !== $this->contentRef) {
+            $spool = $this->document->getContentSpool();
+
+            return null !== $spool
+                ? $spool->fetch($this->contentRef[0], $this->contentRef[1])
+                : null;
+        }
+
         return $this->content;
+    }
+
+    /**
+     * Move this object's in-memory content to the document's ContentSpool, if
+     * one is configured, freeing the in-memory copy. The content is transparently
+     * read back from disk by getContent() when needed.
+     *
+     * @internal
+     */
+    public function spoolContent(): void
+    {
+        if (null !== $this->contentRef
+            || null === $this->content
+            || '' === $this->content) {
+            return;
+        }
+
+        $spool = $this->document->getContentSpool();
+        if (null === $spool) {
+            return;
+        }
+
+        $ref = $spool->store($this->content);
+        if (null !== $ref) {
+            $this->contentRef = $ref;
+            $this->content = null;
+        }
     }
 
     /**
@@ -686,7 +731,7 @@ class PDFObject
         $marked_stack = [];
         $last_written_position = false;
 
-        $sections = $this->getSectionsText($this->content);
+        $sections = $this->getSectionsText($this->getContent());
         $current_font = $this->getDefaultFont($page);
         $current_font_size = 1;
         $current_text_leading = 0;

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -114,6 +114,13 @@ class Parser
         $document = new Document();
         $this->objects = [];
 
+        // When content spooling is enabled, give the document an on-disk store
+        // so each object's decoded content can be moved out of memory as soon
+        // as the object is built (see parseObject()).
+        if ($this->config->getContentSpooling()) {
+            $document->setContentSpool(new ContentSpool());
+        }
+
         foreach ($data as $id => $structure) {
             $this->parseObject($id, $structure, $document);
             unset($data[$id]);
@@ -234,7 +241,12 @@ class Parser
         }
 
         if (!isset($this->objects[$id])) {
-            $this->objects[$id] = PDFObject::factory($document, $header, $content, $this->config);
+            $object = PDFObject::factory($document, $header, $content, $this->config);
+            // Free the just-decoded content from memory by moving it to the
+            // document's on-disk spool (no-op unless content spooling is on).
+            // The local $content copy is released when this method returns.
+            $object->spoolContent();
+            $this->objects[$id] = $object;
         }
     }
 

--- a/src/Smalot/PdfParser/XObject/Form.php
+++ b/src/Smalot/PdfParser/XObject/Form.php
@@ -44,7 +44,7 @@ class Form extends Page
     public function getText(?Page $page = null): string
     {
         $header = new Header([], $this->document);
-        $contents = new PDFObject($this->document, $header, $this->content, $this->config);
+        $contents = new PDFObject($this->document, $header, $this->getContent(), $this->config);
 
         return $contents->getText($this);
     }

--- a/tests/PHPUnit/Integration/ConfigTest.php
+++ b/tests/PHPUnit/Integration/ConfigTest.php
@@ -37,6 +37,7 @@ namespace PHPUnitTests\Integration;
 
 use PHPUnitTests\TestCase;
 use Smalot\PdfParser\Config;
+use Smalot\PdfParser\ContentSpool;
 
 class ConfigTest extends TestCase
 {
@@ -54,5 +55,30 @@ class ConfigTest extends TestCase
         $reference = '11 ADET DERGİ İÇİN 3 KALEM HİZMET ALIMI İHALE EDİLECEKTİR ';
         $firstLine = explode("\n", $text)[0];
         $this->assertEquals($reference, $firstLine);
+    }
+
+    /**
+     * Spooling decoded stream content to a temporary file must not change the
+     * extracted text or document details - it only lowers peak memory usage.
+     */
+    public function testContentSpoolingProducesIdenticalOutput()
+    {
+        $filename = $this->rootDir.'/samples/bugs/Issue356.pdf';
+
+        $inMemoryConfig = new Config();
+        $inMemoryConfig->setContentSpooling(false);
+        $inMemory = $this->getParserInstance($inMemoryConfig)->parseFile($filename);
+
+        $spoolingConfig = new Config();
+        $spoolingConfig->setContentSpooling(true);
+        $spooled = $this->getParserInstance($spoolingConfig)->parseFile($filename);
+
+        // The spooling document must actually use an on-disk spool ...
+        $this->assertNull($inMemory->getContentSpool());
+        $this->assertInstanceOf(ContentSpool::class, $spooled->getContentSpool());
+
+        // ... while producing exactly the same results.
+        $this->assertSame($inMemory->getText(), $spooled->getText());
+        $this->assertSame($inMemory->getDetails(), $spooled->getDetails());
     }
 }

--- a/tests/PHPUnit/Unit/ConfigTest.php
+++ b/tests/PHPUnit/Unit/ConfigTest.php
@@ -75,4 +75,15 @@ class ConfigTest extends TestCase
         $this->fixture->setRetainImageContent(false);
         $this->assertFalse($this->fixture->getRetainImageContent());
     }
+
+    /**
+     * Tests setter and getter for content spooling.
+     */
+    public function testContentSpoolingSetterGetter(): void
+    {
+        $this->assertFalse($this->fixture->getContentSpooling());
+
+        $this->fixture->setContentSpooling(true);
+        $this->assertTrue($this->fixture->getContentSpooling());
+    }
 }

--- a/tests/PHPUnit/Unit/ContentSpoolTest.php
+++ b/tests/PHPUnit/Unit/ContentSpoolTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitTests\Unit;
+
+use PHPUnitTests\TestCase;
+use Smalot\PdfParser\ContentSpool;
+
+class ContentSpoolTest extends TestCase
+{
+    public function testStoreAndFetchRoundTrip(): void
+    {
+        $spool = new ContentSpool();
+
+        $a = 'first chunk of content';
+        $b = "second chunk\nwith a newline";
+
+        $refA = $spool->store($a);
+        $refB = $spool->store($b);
+
+        $this->assertIsArray($refA);
+        $this->assertIsArray($refB);
+
+        // Chunks are appended, so the second starts right after the first
+        $this->assertSame([0, \strlen($a)], $refA);
+        $this->assertSame([\strlen($a), \strlen($b)], $refB);
+
+        // Fetching does not depend on order and can be repeated
+        $this->assertSame($b, $spool->fetch($refB[0], $refB[1]));
+        $this->assertSame($a, $spool->fetch($refA[0], $refA[1]));
+        $this->assertSame($a, $spool->fetch($refA[0], $refA[1]));
+    }
+
+    public function testStoringEmptyContentReturnsNull(): void
+    {
+        $spool = new ContentSpool();
+
+        $this->assertNull($spool->store(''));
+    }
+
+    public function testFetchIsBinarySafe(): void
+    {
+        $spool = new ContentSpool();
+
+        $binary = random_bytes(2048)."\x00\x1f\x80\xff";
+        $ref = $spool->store($binary);
+
+        $this->assertIsArray($ref);
+        $this->assertSame($binary, $spool->fetch($ref[0], $ref[1]));
+    }
+}


### PR DESCRIPTION
Part 3 of #824 

Add Config::setContentSpooling(): when enabled, each parsed object's decoded stream content is written to a single temporary file (ContentSpool) and read back on demand via PDFObject::getContent(), instead of being held in memory for the document's lifetime. The temp file is removed automatically once the document is destroyed.

This lowers the memory retained after parsing and during text extraction; extracted text and document details are byte-for-byte identical with the option on or off (verified across the sample suite).

Measured memory retained after parsing (getText output identical), vs master:

  samples/bugs/PullRequest457.pdf        71 MB -> 30 MB  (-58%)
  samples/DocumentWithLotsOfObjects.pdf  55 MB -> 32 MB  (-41%)
  samples/bugs/Issue356.pdf              25 MB ->  2 MB  (-93%)
  samples/bugs/Issue391.pdf               5 MB ->  2 MB  (-62%)

Note: on documents whose peak occurs while the raw object graph is being built, spooling alone does not lower the peak - it pairs with incremental object construction (#827), which removes that earlier peak.
