### PR TITLE
Avoid quadratic placeholder replacement in PDFObject::formatContent()

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -320,12 +320,18 @@ class PDFObject
                 // Replace the string with a unique placeholder
                 $id = uniqid('STRING_', true);
                 $pdfstrings[$id] = $text[0];
-                $content = preg_replace(
-                    '/'.preg_quote($text[0], '/').'/',
-                    '@@@'.$id.'@@@',
-                    $content,
-                    1
-                );
+                // Replace the first literal occurrence without compiling a regex
+                // per string operand (preg_quote + preg_replace is quadratic for
+                // kerned TJ arrays with many operands).
+                $stringPos = strpos($content, $text[0]);
+                if (false !== $stringPos) {
+                    $content = substr_replace(
+                        $content,
+                        '@@@'.$id.'@@@',
+                        $stringPos,
+                        \strlen($text[0])
+                    );
+                }
 
                 // Reset to search for the next string
                 $attempt = '(';
@@ -381,24 +387,32 @@ class PDFObject
 
         // Restore the original content of the dictionary << >> commands
         $dictstore = array_reverse($dictstore, true);
-        foreach ($dictstore as $id => $dict) {
-            $content = str_replace('###'.$id.'###', $dict, $content);
+        if ([] !== $dictstore) {
+            $dictMap = [];
+            foreach ($dictstore as $id => $dict) {
+                $dictMap['###'.$id.'###'] = $dict;
+            }
+            $content = strtr($content, $dictMap);
         }
 
-        // Restore the original string content
+        // Restore the original string content in a single pass (strtr) instead
+        // of one full-content str_replace() per placeholder, which is quadratic
+        // for kerned TJ arrays with many string operands.
         $pdfstrings = array_reverse($pdfstrings, true);
+        $stringMap = [];
         foreach ($pdfstrings as $id => $text) {
             // Strings may contain escaped newlines, or literal newlines
             // and we should clean these up before replacing the string
             // back into the content stream; this ensures no strings are
             // split between two lines (every command must be on one line)
-            $text = str_replace(
+            $stringMap['@@@'.$id.'@@@'] = str_replace(
                 ["\\\r\n", "\\\r", "\\\n", "\r", "\n"],
                 ['', '', '', '\r', '\n'],
                 $text
             );
-
-            $content = str_replace('@@@'.$id.'@@@', $text, $content);
+        }
+        if ([] !== $stringMap) {
+            $content = strtr($content, $stringMap);
         }
 
         // Restore the original content of any inline images


### PR DESCRIPTION
# Type of pull request

* [ ] Bug fix (involves code and configuration changes)
* [ ] New feature (involves code and configuration changes)
* [ ] Documentation update
* [X] Performance

# About

This is a follow-up to the performance issue I opened in #712.

As described there, parsing gets slow on PDFs whose text is encoded as bracket-notation TJ arrays like [(Xxxx)1.7(a)1.2(tt )-10.1(\374)...], because every string operand becomes a placeholder in PDFObject::formatContent() and is then replaced back with its own str_replace() over the whole content stream. With many small operands this becomes quadratic and dominates the parsing time.

Instead of shortening the placeholder (which I first suggested, but which could collide with real stream content), I kept the uniqid() placeholders and only changed how they are handled:

First, the placeholders are now restored in a single strtr() pass instead of one str_replace() per placeholder. strtr() does all replacements in one traversal, so the cost no longer grows with the number of operands.

Second, the initial extraction now uses strpos() + substr_replace() instead of preg_quote() + preg_replace(), which avoids compiling a regex for every operand.

In my measurements this brings the affected PDFs down from about 8.3 seconds to about 2.1 seconds (roughly 3.5-4x), while documents that were already fast stay the same. The extracted text from getTextArray() is byte-identical before and after on all my sample files.

Thank you for your time!

# Checklist for code / configuration changes

See [CONTRIBUTING.md](./../CONTRIBUTING.md) for all essential information about contributing.
