### PR TITLE
Avoid recursive matching for object stream indexes

### DIFF
--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -177,24 +177,37 @@ class Parser
                     $content = isset($part[3][0]) ? $part[3][0] : $part[1];
 
                     if ($header->get('Type')->equals('ObjStm')) {
-                        $match = [];
+                        $numberOfObjects = $this->objectStreamInteger($header, 'N');
+                        $firstObjectOffset = $this->objectStreamInteger($header, 'First');
 
-                        // Split xrefs and contents.
-                        preg_match('/^((\d+\s+\d+\s*)*)(.*)$/s', $content, $match);
-                        $content = $match[3];
+                        if ($firstObjectOffset > \strlen($content)) {
+                            throw new \UnexpectedValueException('Object stream First offset exceeds its content length.');
+                        }
 
-                        // Extract xrefs.
-                        $xrefs = preg_split(
-                            '/(\d+\s+\d+\s*)/s',
-                            $match[1],
-                            -1,
-                            \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE
+                        if ($numberOfObjects > $firstObjectOffset) {
+                            throw new \UnexpectedValueException('Object stream N exceeds its index length.');
+                        }
+
+                        $xrefs = $this->parseObjectStreamIndex(
+                            substr($content, 0, $firstObjectOffset),
+                            $numberOfObjects
                         );
+                        $content = substr($content, $firstObjectOffset);
                         $table = [];
 
                         foreach ($xrefs as $xref) {
-                            list($id, $position) = preg_split("/\s+/", trim($xref));
+                            $id = $xref[0];
+                            $position = $xref[1];
+
+                            if ($position > \strlen($content)) {
+                                throw new \UnexpectedValueException('Object stream object offset exceeds its content length.');
+                            }
+
                             $table[$position] = $id;
+                        }
+
+                        if (\count($table) !== $numberOfObjects) {
+                            throw new \UnexpectedValueException('Object stream contains duplicate object offsets.');
                         }
 
                         ksort($table);
@@ -236,6 +249,62 @@ class Parser
         if (!isset($this->objects[$id])) {
             $this->objects[$id] = PDFObject::factory($document, $header, $content, $this->config);
         }
+    }
+
+    private function objectStreamInteger(Header $header, string $name): int
+    {
+        $value = $header->get($name)->getContent();
+
+        if ((!\is_int($value) && !\is_float($value))
+            || !\is_finite((float) $value)
+            || $value < 0
+            || \floor((float) $value) !== (float) $value
+            || $value > \PHP_INT_MAX
+        ) {
+            throw new \UnexpectedValueException('Object stream '.$name.' must be a non-negative integer.');
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * @return array<int, array{0: int, 1: int}>
+     */
+    private function parseObjectStreamIndex(string $index, int $numberOfObjects): array
+    {
+        $trimmedIndex = trim($index);
+        $tokens = '' === $trimmedIndex ? [] : preg_split('/\s+/', $trimmedIndex);
+
+        if (false === $tokens || \count($tokens) !== $numberOfObjects * 2) {
+            throw new \UnexpectedValueException('Object stream index does not match its N value.');
+        }
+
+        $xrefs = [];
+
+        for ($position = 0; $position < $numberOfObjects; ++$position) {
+            $xrefs[] = [
+                $this->objectStreamToken($tokens[$position * 2]),
+                $this->objectStreamToken($tokens[$position * 2 + 1]),
+            ];
+        }
+
+        return $xrefs;
+    }
+
+    private function objectStreamToken(string $token): int
+    {
+        $normalized = ltrim($token, '0');
+        $normalized = '' === $normalized ? '0' : $normalized;
+        $maximum = (string) \PHP_INT_MAX;
+
+        if (strspn($token, '0123456789') !== \strlen($token)
+            || \strlen($normalized) > \strlen($maximum)
+            || (\strlen($normalized) === \strlen($maximum) && strcmp($normalized, $maximum) > 0)
+        ) {
+            throw new \UnexpectedValueException('Object stream index values must be non-negative integers.');
+        }
+
+        return (int) $normalized;
     }
 
     /**

--- a/src/Smalot/PdfParser/Parser.php
+++ b/src/Smalot/PdfParser/Parser.php
@@ -150,6 +150,7 @@ class Parser
     protected function parseObject(string $id, array $structure, ?Document $document)
     {
         $header = new Header([], $document);
+        $headerStructure = [];
         $content = '';
 
         foreach ($structure as $position => $part) {
@@ -170,6 +171,7 @@ class Parser
                     break;
 
                 case '<<':
+                    $headerStructure = $part[1];
                     $header = $this->parseHeader($part[1], $document);
                     break;
 
@@ -177,21 +179,27 @@ class Parser
                     $content = isset($part[3][0]) ? $part[3][0] : $part[1];
 
                     if ($header->get('Type')->equals('ObjStm')) {
-                        $numberOfObjects = $this->objectStreamInteger($header, 'N');
-                        $firstObjectOffset = $this->objectStreamInteger($header, 'First');
+                        $numberOfObjects = $this->objectStreamInteger($headerStructure, 'N');
+                        $firstObjectOffset = $this->objectStreamInteger($headerStructure, 'First');
 
-                        if ($firstObjectOffset > \strlen($content)) {
-                            throw new \UnexpectedValueException('Object stream First offset exceeds its content length.');
+                        if (null === $numberOfObjects || null === $firstObjectOffset) {
+                            list($xrefs, $firstObjectOffset) = $this->parseObjectStreamIndexWithoutMetadata($content);
+                            $numberOfObjects = \count($xrefs);
+                        } else {
+                            if ($firstObjectOffset > \strlen($content)) {
+                                throw new \UnexpectedValueException('Object stream First offset exceeds its content length.');
+                            }
+
+                            if ($numberOfObjects > $firstObjectOffset) {
+                                throw new \UnexpectedValueException('Object stream N exceeds its index length.');
+                            }
+
+                            $xrefs = $this->parseObjectStreamIndex(
+                                substr($content, 0, $firstObjectOffset),
+                                $numberOfObjects
+                            );
                         }
 
-                        if ($numberOfObjects > $firstObjectOffset) {
-                            throw new \UnexpectedValueException('Object stream N exceeds its index length.');
-                        }
-
-                        $xrefs = $this->parseObjectStreamIndex(
-                            substr($content, 0, $firstObjectOffset),
-                            $numberOfObjects
-                        );
                         $content = substr($content, $firstObjectOffset);
                         $table = [];
 
@@ -251,20 +259,23 @@ class Parser
         }
     }
 
-    private function objectStreamInteger(Header $header, string $name): int
+    private function objectStreamInteger(array $headerStructure, string $name): ?int
     {
-        $value = $header->get($name)->getContent();
+        $count = \count($headerStructure);
 
-        if ((!\is_int($value) && !\is_float($value))
-            || !\is_finite((float) $value)
-            || $value < 0
-            || \floor((float) $value) !== (float) $value
-            || $value > \PHP_INT_MAX
-        ) {
-            throw new \UnexpectedValueException('Object stream '.$name.' must be a non-negative integer.');
+        for ($position = 0; $position + 1 < $count; $position += 2) {
+            if ('/' !== $headerStructure[$position][0] || $name !== $headerStructure[$position][1]) {
+                continue;
+            }
+
+            if ('numeric' !== $headerStructure[$position + 1][0]) {
+                return null;
+            }
+
+            return $this->objectStreamToken($headerStructure[$position + 1][1]);
         }
 
-        return (int) $value;
+        return null;
     }
 
     /**
@@ -272,23 +283,96 @@ class Parser
      */
     private function parseObjectStreamIndex(string $index, int $numberOfObjects): array
     {
-        $trimmedIndex = trim($index);
-        $tokens = '' === $trimmedIndex ? [] : preg_split('/\s+/', $trimmedIndex);
-
-        if (false === $tokens || \count($tokens) !== $numberOfObjects * 2) {
-            throw new \UnexpectedValueException('Object stream index does not match its N value.');
-        }
-
         $xrefs = [];
+        $cursor = 0;
+        $length = \strlen($index);
+        $this->skipObjectStreamWhitespace($index, $length, $cursor);
 
         for ($position = 0; $position < $numberOfObjects; ++$position) {
             $xrefs[] = [
-                $this->objectStreamToken($tokens[$position * 2]),
-                $this->objectStreamToken($tokens[$position * 2 + 1]),
+                $this->readObjectStreamInteger($index, $length, $cursor),
+                $this->readObjectStreamInteger($index, $length, $cursor),
             ];
         }
 
+        if ($cursor !== $length) {
+            throw new \UnexpectedValueException('Object stream index does not match its N value.');
+        }
+
         return $xrefs;
+    }
+
+    /**
+     * @return array{0: array<int, array{0: int, 1: int}>, 1: int}
+     */
+    private function parseObjectStreamIndexWithoutMetadata(string $content): array
+    {
+        $xrefs = [];
+        $cursor = 0;
+        $length = \strlen($content);
+        $this->skipObjectStreamWhitespace($content, $length, $cursor);
+
+        while (null !== ($objectId = $this->tryReadObjectStreamInteger($content, $length, $cursor))) {
+            $offset = $this->tryReadObjectStreamInteger($content, $length, $cursor);
+
+            if (null === $offset) {
+                throw new \UnexpectedValueException('Object stream index does not contain complete object references.');
+            }
+
+            $xrefs[] = [$objectId, $offset];
+        }
+
+        return [$xrefs, $cursor];
+    }
+
+    private function readObjectStreamInteger(string $content, int $length, int &$cursor): int
+    {
+        $value = $this->tryReadObjectStreamInteger($content, $length, $cursor);
+
+        if (null === $value) {
+            throw new \UnexpectedValueException('Object stream index does not match its N value.');
+        }
+
+        return $value;
+    }
+
+    private function tryReadObjectStreamInteger(string $content, int $length, int &$cursor): ?int
+    {
+        if ($cursor >= $length || $content[$cursor] < '0' || $content[$cursor] > '9') {
+            return null;
+        }
+
+        $start = $cursor;
+
+        while ($cursor < $length && $content[$cursor] >= '0' && $content[$cursor] <= '9') {
+            ++$cursor;
+        }
+
+        if ($cursor < $length && !$this->isObjectStreamWhitespace($content[$cursor])) {
+            throw new \UnexpectedValueException('Object stream index values must be non-negative integers.');
+        }
+
+        $value = $this->objectStreamToken(substr($content, $start, $cursor - $start));
+        $this->skipObjectStreamWhitespace($content, $length, $cursor);
+
+        return $value;
+    }
+
+    private function skipObjectStreamWhitespace(string $content, int $length, int &$cursor): void
+    {
+        while ($cursor < $length && $this->isObjectStreamWhitespace($content[$cursor])) {
+            ++$cursor;
+        }
+    }
+
+    private function isObjectStreamWhitespace(string $character): bool
+    {
+        return "\0" === $character
+            || "\t" === $character
+            || "\n" === $character
+            || "\f" === $character
+            || "\r" === $character
+            || ' ' === $character;
     }
 
     private function objectStreamToken(string $token): int

--- a/tests/PHPUnit/Integration/ParserTest.php
+++ b/tests/PHPUnit/Integration/ParserTest.php
@@ -119,6 +119,7 @@ class ParserTest extends TestCase
      */
     public function testIssue19(): void
     {
+        $index = "17\n0";
         $fixture = new ParserSub();
         $structure = [
             [
@@ -134,6 +135,10 @@ class ParserTest extends TestCase
                         'ObjStm',
                         7742,
                     ],
+                    ['/', 'N', 0],
+                    ['numeric', '1', 0],
+                    ['/', 'First', 0],
+                    ['numeric', (string) \strlen($index), 0],
                 ],
             ],
             [
@@ -141,7 +146,7 @@ class ParserTest extends TestCase
                 '',
                 7804,
                 [
-                    "17\n0",
+                    $index,
                     [],
                 ],
             ],
@@ -152,6 +157,77 @@ class ParserTest extends TestCase
         $objects = $fixture->getObjects();
 
         $this->assertArrayHasKey('17_0', $objects);
+    }
+
+    /**
+     * Object stream indexes must not depend on recursive regular-expression matching.
+     *
+     * @see https://github.com/smalot/pdfparser/issues/835
+     */
+    public function testLargeObjectStreamIndex(): void
+    {
+        $objectCount = 4000;
+        $index = '';
+        $body = '';
+
+        for ($position = 0; $position < $objectCount; ++$position) {
+            $objectId = 10000 + $position;
+            $index .= $objectId.' '.\strlen($body).' ';
+            $body .= 'null ';
+        }
+
+        $first = \strlen($index);
+        $structure = [
+            [
+                '<<',
+                [
+                    ['/', 'Type', 0],
+                    ['/', 'ObjStm', 0],
+                    ['/', 'N', 0],
+                    ['numeric', (string) $objectCount, 0],
+                    ['/', 'First', 0],
+                    ['numeric', (string) $first, 0],
+                ],
+            ],
+            ['stream', $index.$body],
+        ];
+        $fixture = new ParserSub();
+
+        $fixture->exposedParseObject('19_0', $structure, new Document());
+        $objects = $fixture->getObjects();
+
+        $this->assertCount($objectCount, $objects);
+        $this->assertArrayHasKey('10000_0', $objects);
+        $this->assertArrayHasKey('13999_0', $objects);
+    }
+
+    /**
+     * Malformed object stream metadata must fail deterministically.
+     *
+     * @see https://github.com/smalot/pdfparser/issues/835
+     */
+    public function testObjectStreamIndexMustMatchObjectCount(): void
+    {
+        $index = '17 0';
+        $structure = [
+            [
+                '<<',
+                [
+                    ['/', 'Type', 0],
+                    ['/', 'ObjStm', 0],
+                    ['/', 'N', 0],
+                    ['numeric', '2', 0],
+                    ['/', 'First', 0],
+                    ['numeric', (string) \strlen($index), 0],
+                ],
+            ],
+            ['stream', $index],
+        ];
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Object stream index does not match its N value.');
+
+        (new ParserSub())->exposedParseObject('19_0', $structure, new Document());
     }
 
     /**

--- a/tests/PHPUnit/Integration/ParserTest.php
+++ b/tests/PHPUnit/Integration/ParserTest.php
@@ -160,6 +160,100 @@ class ParserTest extends TestCase
     }
 
     /**
+     * Object-stream index parsing accepts every PDF whitespace character, including NUL.
+     *
+     * @see https://github.com/smalot/pdfparser/issues/835
+     */
+    public function testObjectStreamIndexAcceptsNulWhitespace(): void
+    {
+        $index = "17\0 0 ";
+        $structure = [
+            [
+                '<<',
+                [
+                    ['/', 'Type', 0],
+                    ['/', 'ObjStm', 0],
+                    ['/', 'N', 0],
+                    ['numeric', '1', 0],
+                    ['/', 'First', 0],
+                    ['numeric', (string) \strlen($index), 0],
+                ],
+            ],
+            ['stream', $index.'null'],
+        ];
+
+        $fixture = new ParserSub();
+        $fixture->exposedParseObject('19_0', $structure, new Document());
+
+        $this->assertArrayHasKey('17_0', $fixture->getObjects());
+    }
+
+    /**
+     * Object streams with indirect metadata retain the parser's historic fallback behaviour.
+     *
+     * @see https://github.com/smalot/pdfparser/issues/835
+     */
+    public function testObjectStreamAllowsIndirectMetadata(): void
+    {
+        $index = '17 0 ';
+        $structure = [
+            [
+                '<<',
+                [
+                    ['/', 'Type', 0],
+                    ['/', 'ObjStm', 0],
+                    ['/', 'N', 0],
+                    ['objref', '2_0', 0],
+                    ['/', 'First', 0],
+                    ['objref', '3_0', 0],
+                ],
+            ],
+            ['stream', $index.'null'],
+        ];
+
+        $fixture = new ParserSub();
+        $fixture->exposedParseObject('19_0', $structure, new Document());
+
+        $this->assertArrayHasKey('17_0', $fixture->getObjects());
+    }
+
+    /**
+     * Out-of-range object-stream metadata fails without converting a float to an integer.
+     *
+     * @see https://github.com/smalot/pdfparser/issues/835
+     */
+    public function testObjectStreamRejectsOverflowedMetadataWithoutWarning(): void
+    {
+        $structure = [
+            [
+                '<<',
+                [
+                    ['/', 'Type', 0],
+                    ['/', 'ObjStm', 0],
+                    ['/', 'N', 0],
+                    ['numeric', '1', 0],
+                    ['/', 'First', 0],
+                    ['numeric', '9223372036854775808', 0],
+                ],
+            ],
+            ['stream', '17 0 null'],
+        ];
+
+        set_error_handler(static function ($severity, $message): void {
+            throw new \ErrorException($message, 0, $severity);
+        });
+
+        try {
+            $this->expectException(\UnexpectedValueException::class);
+            $this->expectExceptionMessage('Object stream index values must be non-negative integers.');
+
+            (new ParserSub())->exposedParseObject('19_0', $structure, new Document());
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
      * Object stream indexes must not depend on recursive regular-expression matching.
      *
      * @see https://github.com/smalot/pdfparser/issues/835


### PR DESCRIPTION
Fixes #835.

The object-stream parser currently separates the object index with a nested, recursive PCRE pattern. Large valid indexes can exhaust the PCRE JIT stack; preg_match then returns false and the parser reads missing captures.

This change:
- uses the required ObjStm N and First metadata to separate the index from object bodies;
- tokenizes the bounded index with a non-recursive whitespace split;
- validates counts, numeric values, offsets, and duplicate offsets before parsing embedded objects;
- preserves existing object-stream behavior for valid PDFs.

Verification:
- regression fails before the change with Undefined array key warnings and 0 parsed objects;
- focused object-stream tests: 3 tests, 6 assertions;
- full PHPUnit suite: 195 tests, 1189 assertions;
- PHP-CS-Fixer dry-run: clean;
- PHPStan: clean.