### PR TITLE
Fix `spl_object_hash` deprecation on PHP 8.6

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -1210,6 +1210,6 @@ class PDFObject
      */
     protected function getUniqueId(): string
     {
-        return spl_object_hash($this);
+        return \PHP_VERSION_ID < 70200 ? \spl_object_hash($this) : (string) \spl_object_id($this);
     }
 }


### PR DESCRIPTION
# Type of pull request

* [x] Bug fix (involves code and configuration changes)
* [ ] New feature (involves code and configuration changes)
* [ ] Documentation update
* [ ] Something else

# About

When testing with PHP 8.6.0beta2, I get the following deprecation warning:

    Function spl_object_hash() is deprecated since 8.6, consider using spl_object_id() instead

Let’s switch to the suggested function where supported.

https://www.php.net/manual/en/function.spl-object-hash.php
https://www.php.net/manual/en/function.spl-object-id.php

# Checklist for code / configuration changes

See [CONTRIBUTING.md](./../CONTRIBUTING.md) for all essential information about contributing.
