### PR TITLE
Ignore a "Q" that has no matching "q"

### DIFF
--- a/src/Smalot/PdfParser/PDFObject.php
+++ b/src/Smalot/PdfParser/PDFObject.php
@@ -827,8 +827,14 @@ class PDFObject
 
                         // Restore previous selected font and graphics matrix
                     case 'Q':
-                        list($current_font, $current_font_size) = array_pop($clipped_font);
-                        $current_position_cm = array_pop($clipped_position_cm);
+                        // A malformed content stream can restore a graphics state it never saved,
+                        // leaving nothing on these stacks to pop.
+                        if ([] !== $clipped_font) {
+                            list($current_font, $current_font_size) = array_pop($clipped_font);
+                        }
+                        if ([] !== $clipped_position_cm) {
+                            $current_position_cm = array_pop($clipped_position_cm);
+                        }
                         break;
 
                         // End marked content sequence

--- a/tests/PHPUnit/Unit/PDFObjectTest.php
+++ b/tests/PHPUnit/Unit/PDFObjectTest.php
@@ -29,6 +29,22 @@ class PDFObjectTest extends TestCase
         static::assertSame(' ', (new PDFObject($document, null, null))->getText(new Page($document)));
     }
 
+    /**
+     * A stream may concatenate save-state operators without whitespace ("qq"),
+     * which lexes as a single unknown token instead of two "q" operators. The
+     * matching "Q"s then restore a state that was never pushed, and the rest of
+     * the stream must still be read.
+     */
+    public function testGetTextWithUnmatchedGraphicsStateRestore(): void
+    {
+        $document = new Document();
+        $document->init();
+
+        $content = "qq\nBT /F1 12 Tf 10 10 Td (Hello) Tj ET\nQ\nQ\nBT 10 -20 Td (World) Tj ET";
+
+        static::assertSame("Hello\nWorld ", (new PDFObject($document, null, $content, new Config()))->getText());
+    }
+
     public function testTextArrayObjects(): void
     {
         $document = new Document();


### PR DESCRIPTION
# Ignore a `Q` that has no matching `q`

Small, well-scoped bug fix, with a test.

## Problem

`PDFObject::getTextArray()` pushes the current font and graphics matrix onto `$clipped_font` / `$clipped_position_cm` on `q`, and pops them on `Q`:

```php
case 'Q':
    list($current_font, $current_font_size) = array_pop($clipped_font);
    $current_position_cm = array_pop($clipped_position_cm);
    break;
```

Neither pop is guarded. When a stream restores a graphics state that was never pushed, both stacks are already empty, so `array_pop()` returns `null` and:

- `$current_position_cm` is `null`, and the next text-showing operator reads offsets off it → `Warning: Trying to access array offset on null` (PDFObject.php:909 and :910);
- `$current_font` is `null` and reaches `getTJUsingFontFallback()` → `TypeError: Argument #1 ($font) must be of type Font, null given`.

## How a real file gets there

Not by authoring a stray `Q`. This came from a product catalog (20 pages, PDF-1.7) that arrived as an email attachment and hit our mail importer in production, producing **276 warnings** in one parse.

Counting operators in the raw file gives 2111 `q` and 2111 `Q` — balanced. The imbalance is created at the lexer: one page content stream (92,247 bytes) begins

```
qqqqqqqqqqqqqqqqqqqqq
0 0 841.8900 594.7640 re
W n
```

— 21 save-state operators concatenated with no separators. That same stream holds **355 properly separated `q` and 376 properly separated `Q`**, and 355 + 21 = 376, so the file's intent is balanced; only the encoding of those 21 saves is broken.

Per 7.2.2 a keyword token runs until white-space or a delimiter, so `qqqq…q` is a single unknown keyword rather than 21 operators. PdfParser is right not to treat it as `q` — but then nothing is pushed while the 21 matching `Q`s still pop. Instrumenting the `Q` case on that file reports exactly 21 underflows.

Introduced by #634, which replaced the single stored state with a stack; first released in v2.8.0.

## Fix

Skip each pop when its stack is empty, keeping the current font and matrix — which is how a viewer treats the same stream. No attempt is made to lex the run as 21 `q` operators: per spec it is not 21 operators.

## Test

`PDFObjectTest::testGetTextWithUnmatchedGraphicsStateRestore` reproduces the real shape, no PDF fixture needed:

```php
$content = "qq\nBT /F1 12 Tf 10 10 Td (Hello) Tj ET\nQ\nQ\nBT 10 -20 Td (World) Tj ET";

static::assertSame("Hello\nWorld ", (new PDFObject($document, null, $content, new Config()))->getText());
```

On `master` this errors with 2 warnings; with the fix it passes. The properly separated form (`q\nq\n…`) behaves identically before and after — the trigger is the concatenation, not the operator count.

## Scope of the impact

On the file above the text still comes out: 54,219 characters, byte-identical with and without this patch (sha1 `1cad49de23f860ada2b84fe9fed847836676a4ba`). The cost there is 276 logged errors, not lost content. Losing the remainder of the stream requires no `Tf` to follow the `Q`, so the font stays `null` and the `TypeError` fires — real, but not what this file hits.

## Checks

Run against `master` on PHP 8.4.19:

- **PHPUnit** — 194 tests, 1185 assertions, all green (193 before this PR's test).
- **PHP-CS-Fixer** — `Found 0 of 82 files that can be fixed`.
- **PHPStan** — the 4 pre-existing findings are identical with and without this change; it adds none. (Run with PHPStan 2.x rather than the pinned `^1`, since `dev-tools` could not be installed in my environment.)

The change is PHP 7.1-compatible, in line with `composer.json`.