### PR TITLE
Replaces #825 - Fix float-to-int cast warning in Font::uchr on PHP 8.1+ fix

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,21 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false" displayDetailsOnTestsThatTriggerWarnings="true">
-  <php>
-    <ini name="error_reporting" value="-1"/>
-    <ini name="zend.enable_gc" value="0"/>
-    <ini name="error_reporting" value="-1"/>
-    <ini name="intl.error_level" value="0"/>
-    <ini name="display_errors" value="On"/>
-  </php>
-  <testsuites>
-    <testsuite name="all">
-      <directory>tests/PHPUnit</directory>
-    </testsuite>
-  </testsuites>
-  <source>
-    <include>
-      <directory>src</directory>
-    </include>
-  </source>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    backupGlobals="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    failOnWarning="true">
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="zend.enable_gc" value="0"/>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="display_errors" value="On"/>
+        <ini name="memory_limit" value="1G"/>
+    </php>
+    <testsuites>
+        <testsuite name="all">
+            <directory>tests/PHPUnit</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Smalot/PdfParser/Font.php
+++ b/src/Smalot/PdfParser/Font.php
@@ -142,6 +142,15 @@ class Font extends PDFObject
         // note:
         // $code was typed as int before, but changed in https://github.com/smalot/pdfparser/pull/623
         // because in some cases uchr was called with a float instead of an integer.
+        //
+        // A float that is out of integer range (e.g. resulting from a hexdec()
+        // overflow) cannot be cast to int without raising a "not representable
+        // as int" warning on PHP 8.1+, and such a value can never be a valid
+        // Unicode code point, so we treat it as a missing character.
+        if (\is_float($code) && (!\is_finite($code) || $code < \PHP_INT_MIN || $code > \PHP_INT_MAX)) {
+            return self::MISSING;
+        }
+
         $code = (int) $code;
 
         if (!isset(self::$uchrCache[$code])) {

--- a/tests/PHPUnit/Unit/FontTest.php
+++ b/tests/PHPUnit/Unit/FontTest.php
@@ -68,4 +68,36 @@ class FontTest extends TestCase
         // compare result with expected value
         self::assertEquals('3cc2ab083e', bin2hex($result));
     }
+
+    /**
+     * A CMap could contain oversized hex values. hexdec() then returns a float
+     * larger than PHP_INT_MAX which cannot be cast to int. On PHP 8.5 this
+     * cast raises a "not representable as int" warning.
+     *
+     * Since these values can not represent valid Unicode code points anyway,
+     * it's safe to return Font::MISSING for them. This test checks that this
+     * is the case.
+     *
+     * The test relies on PhpUnit's failOnWarning="true" in phpunit.xml:
+     * a warning would error.
+     *
+     * @see https://github.com/smalot/pdfparser/pull/623
+     * @see https://github.com/smalot/pdfparser/pull/825
+     */
+    public function testUchrWithOutOfRangeFloat(): void
+    {
+        // a regular code point is still decoded
+        $this->assertEquals('A', Font::uchr(0x41));
+
+        // a float that fits into an integer is still cast and decoded; this is
+        // the reason uchr() accepts floats in the first place
+        $this->assertEquals('A', Font::uchr(65.0));
+
+        // floats that do not fit into an integer can never be a valid code
+        // point; the value below is produced by hexdec() of an oversized hex
+        // string taken from samples/bugs/Issue621.pdf
+        $this->assertEquals(Font::MISSING, Font::uchr(1.50646556872121E+28));
+        $this->assertEquals(Font::MISSING, Font::uchr(\INF));
+        $this->assertEquals(Font::MISSING, Font::uchr(\NAN));
+    }
 }


### PR DESCRIPTION
Replaces https://github.com/smalot/pdfparser/pull/825 by @splitbrain because I had no permission to push my commits into `cosmocode:fix/uchr-float-cast-warning`.

---

**Symptom (#825):** `Font::uchr()` raised "The float ... is not representable as an int" warnings on PHP 8.5 while parsing `samples/bugs/Issue621.pdf`. On older PHP versions the cast silently produced a wrapped-around integer, which ended up as a NUL byte or a literal `&#-123;` string in the translation table.

**Root cause:** The floats come from the `<srcCode1> <srcCode2> <dstString>` form of `bfrange` in ToUnicode CMaps. `dstString` may hold several UTF-16BE code units (e.g. `<00310030002F00310031>` = `10/11`, or Katakana unit names in Issue621.pdf), but `loadTranslateTable()` passed the whole string to `hexdec()` and treated it as a single code point. Every such entry decoded to garbage; strings of more than 16 hex digits additionally overflowed to a float.

**Changes**

* `Font::loadTranslateTable()`: `dstString` of the offset form is split into code units like the `bfchar` and array forms already do; only the last one is incremented per source code (ISO 32000-1:2008, 9.10.3).
* `Font::uchr()` (from #825): floats outside the integer range, `INF` and `NAN` return `Font::MISSING` instead of being cast. The upper bound is compared as float (`>= PHP_INT_MAX + 1`), because `> PHP_INT_MAX` misses exactly 2^63 (`hexdec('8000000000000000')`).
* Tests:
  * `testUchrWithOutOfRangeFloat` (from #825), extended by boundary and negative cases
  * new `loadTranslateTable()` tests for multi-code-unit `bfrange` entries, synthetic and from `samples/bugs/Issue621.pdf`
* `phpunit.xml`: `memory_limit=1G`. The suite peaks at ~600 MB and fails with PHP's default 128M